### PR TITLE
Change reboot task to just wait for host to come up

### DIFF
--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -8,7 +8,10 @@
 #       To mitigate this, we prefix a sleep command before the shutdown so
 # ansible has time to move on. For more info on this issue, see:
 # https://github.com/ansible/ansible/issues/10616
-
+#
+# The Ansible docs now recommend this combination of tasks to handle reboots
+# https://support.ansible.com/hc/en-us/articles/201958037-Reboot-a-server-and-wait-for-it-to-come-back
+#
 - name: restart hosts
   shell: sleep 3 && shutdown -r now
   async: 1
@@ -20,5 +23,5 @@
 # anyway.
 
 - name: wait for hosts to come back up
-  local_action: wait_for host={{ inventory_hostname }} port=22 state=started delay=30 timeout=120
+  local_action: wait_for host={{ inventory_hostname }} port=22 state=started delay=15 timeout=120
   sudo: false

--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -19,10 +19,6 @@
 # that they don't use sudo, which may require a password, and is not necessary
 # anyway.
 
-- name: wait for hosts to come down
-  local_action: wait_for host={{ inventory_hostname }} port=22 state=stopped
-  sudo: false
-
 - name: wait for hosts to come back up
-  local_action: wait_for host={{ inventory_hostname }} port=22 state=started
+  local_action: wait_for host={{ inventory_hostname }} port=22 state=started delay=30 timeout=120
   sudo: false


### PR DESCRIPTION
I kept running into trouble with the reboot task when testing with local
VMs.  Sometimes the VM wouldn't be identified as having come down, other
times the VM wouldn't be identified as having come up.

After some experimenting, I settled on just waiting for the host to come
up after a short delay.