### PR TITLE
Add support for testing new tree via rebase

### DIFF
--- a/tests/new-tree-smoketest/README.md
+++ b/tests/new-tree-smoketest/README.md
@@ -1,6 +1,7 @@
 This playbook performs a simple test of the upgrade and rollback mechanisms
-that are present in an Atomic Host.  This playbook should run on the Atomic
-Host variants of CentOS, Fedora, and Red Hat Enterprise Linux.
+that are present in an Atomic Host.  This playbook also supports testing
+a new tree that was delivered via `rpm-ostree rebase`.  This playbook should
+run on the Atomic Host variants of CentOS, Fedora, and Red Hat Enterprise Linux.
 
 ### Prerequisites
   - Configure necessary variables
@@ -15,11 +16,34 @@ Host variants of CentOS, Fedora, and Red Hat Enterprise Linux.
 
 ### Running the Playbook
 
-To run the test, simply invoke as any other Ansible playbook:
+Before running the playbook, decide if you are testing the
+`rpm-ostree upgrade` path or `rpm-ostree rebase` path.
+
+When testing the `upgrade` path, you will need to exclude the `rpm_ostree_rebase`
+tag, like so:
 
 ```
-$ ansible-playbook -i inventory main.yaml
+$ ansible-playbook -i inventory main.yaml --skip-tags rpm_ostree_rebase
 ```
+
+When testing the `rebase` path, you will need to exclude the `rpm_ostree_upgrade`
+tag and possibly the `subscription_manager` tag.  Additionally, you will need to
+provide values to certain variables either individually via the command line or
+via a YAML file on the command line.
+
+```
+$ ansible-playbook -i inventory main.yaml --skip-tags subscription_manager,rpm_ostree_upgrade -e "@rebase_vars.yaml"
+```
+
+Example YAML variable file:
+
+```yaml
+---
+ostree_remote_name: "new-atomic"
+ostree_remote_url: "https://dl.fedoraproject.org/pub/fedora/linux/atomic/24/"
+ostree_refspec: "new-atomic:fedora-atomic/f24/x86_64/docker-host"
+```
+
 
 *NOTE*: You are responsible for providing a host to run the test against and the
 inventory file for that host.

--- a/tests/new-tree-smoketest/main.yaml
+++ b/tests/new-tree-smoketest/main.yaml
@@ -2,10 +2,24 @@
 # vim: set ft=ansible:
 #
 # A playbook that performs a simple smoke test of Atomic Host upgrading to
-# a new ostree.
+# a new ostree or rebasing to a new ostree.
 #
-# This basically just does an upgrade, reboot, rollback, and reboot on an
+# This basically just does an upgrade/rebase, reboot, rollback, and reboot on an
 # Atomic Host.
+#
+# In order to support the ability to test the 'rebase' scenario, certain tags
+# had to be added to some tasks, so that we could exclude some tasks.
+#
+# For example, in the case of the 'rebase' option, it is unlikely that we want
+# to subscribe using 'subscription-manager' or run the 'rpm-ostree upgrade'
+# command.  One would run this test using:
+#
+# '--skip-tags subscription_manager,rpm_ostree_upgrade'
+#
+# ...when testing the 'rebase' option.
+#
+# Additionally, when testing the 'upgrade' option, the test should be run
+# with '--skip-tags rpm_ostree_rebase'
 #
 # If the 'jenkins' tag is not skipped, it also performs some data gathering
 # operations which will generate output files on the host that can be
@@ -32,12 +46,31 @@
     - upgraded_rpms: "upgraded_rpm_list.txt"
 
   tasks:
+    # The first two tasks do some early checking of variables that can be
+    # required when testing a new ostree that is landed via 'rebase'
+    - name: Fail if ostree_remote_name or ostree_remote_url is undefined
+      fail:
+        msg: "ostree_remote_name or ostree_remote_url is undefined"
+      when: ostree_remote_name is undefined or ostree_remote_url is undefined
+      tags:
+        - ostree_remote
+        - rpm_ostree_rebase
+
+    - name: Fail if ostree_refspec is undefined
+      fail:
+        msg: "ostree_refspec is undefined"
+      when: ostree_refspec is undefined
+      tags:
+        - rpm_ostree_rebase
+
     - name: Check if system is an Atomic Host
       include: ../../common/atomic.yaml
 
     - name: Register using subscription-manager
       include: ../../rhel/subscribe.yaml
       when: ansible_distribution == "RedHat"
+      tags:
+        - subscription_manager
 
     - name: Setup data directory
       include: ../../common/data_dir.yaml
@@ -59,10 +92,25 @@
       tags:
         - jenkins
 
+    - name: Add ostree remote for rebase
+      command: "ostree remote add {{ ostree_remote_name }} {{ ostree_remote_url }} --no-gpg-verify"
+      tags:
+        - ostree_remote
+        - rpm_ostree_rebase
+
+    - name: Rebase to new refspec
+      shell: "rpm-ostree rebase {{ ostree_refspec }} | tee rpm_ostree_upgrade"
+      args:
+        chdir: "{{ datadir }}"
+      tags:
+        - rpm_ostree_rebase
+
     - name: Upgrade to latest tree
       shell: rpm-ostree upgrade | tee rpm_ostree_upgrade
       args:
         chdir: "{{ datadir }}"
+      tags:
+        - rpm_ostree_upgrade
 
     - name: Run downgrade check script
       command: "{{ datadir }}/check_downgrade.py {{ datadir }}/rpm_ostree_upgrade"
@@ -103,3 +151,5 @@
     - name: Remove all registrations using subscription-manager
       include: ../../rhel/unsubscribe.yaml
       when: ansible_distribution == "RedHat"
+      tags:
+        - subscription_manager


### PR DESCRIPTION
This change introduces the ability to perform the smoketest on a tree
that was delivered via `rpm-ostree rebase`.  In doing so, a number of
tags were introduced for some tasks in order to limit which delivery
mechanism can be used.

For example, when testing a new tree delivered via `rpm-ostree upgrade`,
the test should not run the `rpm-ostree rebase` command (and associated
tasks).  This is accomplished through the use of `--skip-tags
rpm_ostree_rebase` when running the playbook.  A similar exclusion
strategy is used when testing a new tree delivered via `rpm-ostree
rebase`.

This does increase the complexity when running the playbook, but also
increases flexibility.

It would probably be worthwhile to investigate how to simplify this test
by divorcing the choice of delivery (`upgrade` vs. `rebase`) from the
test itself.