### PR TITLE
Add a Vagrantfile to run the new-image smoketest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# vi: set ft=ruby :
+
+# In the future, this might do something more interesting
+# like contain code to sync git from the local dir into
+# the system and do builds/installs there.  But for
+# now at least this exists as a starting point, and
+# once `ostree admin unlock` exists in the next version,
+# things will be a bit simpler.
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "centos/atomic-host"
+    config.vm.hostname = "centosah-dev"
+    config.vm.synced_folder ".", "/srv/vagrant", disabled: true
+
+    config.vm.provision "ansible" do |ansible|
+      ansible.playbook = "tests/new-image-smoketest/main.yaml"
+    end
+end


### PR DESCRIPTION
We should make it convenient for people to test this
locally, similar to what openshift-ansible has.

This is just a stub file to run the new-image-smoketest - it currently
fails, looks like because we're missing a template file.