### PR TITLE
add RPM db tests

### DIFF
--- a/roles/rpm_ostree_upgrade/tasks/main.yml
+++ b/roles/rpm_ostree_upgrade/tasks/main.yml
@@ -1,5 +1,15 @@
 ---
 # vim: set ft=ansible:
 #
-- name: rpm-ostree upgrade
+- name: Check for available upgrade
+  command: rpm-ostree upgrade --check
+  register: upgrade_check
+  ignore_errors: true
+
+- name: Fail when upgrade not available
+  fail:
+    msg: "No upgrade available"
+  when: upgrade_check.rc == 77 and "No upgrade available" in upgrade_check.stdout
+
+- name: Perform the upgrade
   command: rpm-ostree upgrade

--- a/roles/rpmdb_verify/tasks/main.yml
+++ b/roles/rpmdb_verify/tasks/main.yml
@@ -8,4 +8,4 @@
 - name: Fail if the RPM database is broken
   fail:
     msg: "The RPM database is not usuable"
-  when: rpmdb.stdout <= 0 or rpmdb.rc != 0
+  when: "{{ rpmdb.stdout | int }} <= 0 or rpmdb.rc != 0"

--- a/roles/rpmdb_verify/tasks/main.yml
+++ b/roles/rpmdb_verify/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# vim: set ft=ansible:
+#
+- name: Verify that the RPM database is intact
+  shell: rpm -qa | wc -l
+  register: rpmdb
+
+- name: Fail if the RPM database is broken
+  fail:
+    msg: "The RPM database is not usuable"
+  when: rpmdb.stdout <= 0 or rpmdb.rc != 0

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -52,6 +52,11 @@
       tags:
         - tmp_check_perms
 
+    # Check that the RPM database is functional
+    - role: rpmdb_verify
+      tags:
+        - rpmdb_verify
+
     # Add users, make changes to /etc, and add things to /var before the
     # the system is upgraded
     - { role: user_add, ua_uid: "{{ g_uid1 }}", tags: ['user_add'] }
@@ -99,6 +104,11 @@
     - role: tmp_check_perms
       tags:
         - tmp_check_perms
+
+    # Check that the RPM database is functional
+    - role: rpmdb_verify
+      tags:
+        - rpmdb_verify
 
     # Verify that the new users, /etc changes, and /var additions are still
     # present after the upgrade
@@ -148,6 +158,11 @@
     - role: tmp_check_perms
       tags:
         - tmp_check_perms
+
+    # Check that the RPM database is functional
+    - role: rpmdb_verify
+      tags:
+        - rpmdb_verify
 
     # Verify changes still exist in original tree
     - role: etc_verify_changes


### PR DESCRIPTION
This introduces a simple test of the RPM database to the sanity suite,
among other things.  Other changes:
  - the `Vagrantfile` now has Fedora 24 support
  - the playbook executed by the Vagrant box can be configured by an
    environment variable
  - the `rpm-ostree upgrade` role has been improved to check for an
    available update first