### PR TITLE
roles: fix /etc roles to just insert IP address

### DIFF
--- a/roles/etc_modify/tasks/main.yml
+++ b/roles/etc_modify/tasks/main.yml
@@ -5,7 +5,7 @@
   lineinfile:
     dest: /etc/hosts
     insertafter: EOF
-    line: "{{ ansible_default_ipv4 }} {{ ansible_fqdn }}"
+    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }}"
     state: present
 
 - name: Copy EPEL repo into /etc/yum.repos.d

--- a/roles/etc_verify_changes/tasks/main.yml
+++ b/roles/etc_verify_changes/tasks/main.yml
@@ -2,7 +2,7 @@
 # vim: set ft=ansible:
 #
 - name: Verify changes to /etc/hosts
-  command: grep "{{ ansible_default_ipv4 }} {{ ansible_fqdn }}" /etc/hosts
+  command: grep "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }}" /etc/hosts
 
 - name: Verify EPEL repo is present in /etc/yum.repos.d
   stat:


### PR DESCRIPTION
The `etc_modify` and `etc_verify_changes` roles were using the
`ansible_default_ipv4` variable to make modifications (and
verifications) to `/etc/hosts`.

This variable is actually a dictionary, so a huge string was being
inserted into `/etc/hosts` instead of a more sensical IP address.

This changes the two roles to use the correct IP address rather than
an embarrasingly long Python `dict`.