### PR TITLE
roles: use ansible_hostname instead of ansible_fqdn

### DIFF
--- a/roles/etc_modify/tasks/main.yml
+++ b/roles/etc_modify/tasks/main.yml
@@ -5,7 +5,7 @@
   lineinfile:
     dest: /etc/hosts
     insertafter: EOF
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }}"
+    line: "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}"
     state: present
 
 - name: Copy EPEL repo into /etc/yum.repos.d

--- a/roles/etc_verify_changes/tasks/main.yml
+++ b/roles/etc_verify_changes/tasks/main.yml
@@ -2,7 +2,7 @@
 # vim: set ft=ansible:
 #
 - name: Verify changes to /etc/hosts
-  command: grep "{{ ansible_default_ipv4.address }} {{ ansible_hostname}}" /etc/hosts
+  command: grep "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}" /etc/hosts
 
 - name: Verify EPEL repo is present in /etc/yum.repos.d
   stat:

--- a/roles/etc_verify_changes/tasks/main.yml
+++ b/roles/etc_verify_changes/tasks/main.yml
@@ -2,7 +2,7 @@
 # vim: set ft=ansible:
 #
 - name: Verify changes to /etc/hosts
-  command: grep "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }}" /etc/hosts
+  command: grep "{{ ansible_default_ipv4.address }} {{ ansible_hostname}}" /etc/hosts
 
 - name: Verify EPEL repo is present in /etc/yum.repos.d
   stat:


### PR DESCRIPTION
While using the `improved_sanity_test` playboook in our OpenStack
environment (when driven by Jenkins), we were seeing failures when trying to
verify changes made to `/etc/hosts`.  (We did not see the same
failures when running the playbook by hand.)

The root cause was the value of `ansible_fqdn` was changing after the
host was rebooted.  I don't fully understand why this was changing
after a reboot, but in order to work around this, we can just use
`ansible_hostname` in its stead.