### PR TITLE
improved-sanity-test: Add tests for docker operations

### DIFF
--- a/roles/docker_build_httpd/files/centos_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/centos_httpd_Dockerfile
@@ -1,0 +1,16 @@
+FROM centos
+MAINTAINER Micah Abbott <micah@redhat.com>
+
+LABEL Version=1.1
+LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
+
+ENV container docker
+
+RUN yum -y install httpd && \
+    yum clean all
+
+RUN echo "SUCCESS centos_httpd" > /var/www/html/index.html
+EXPOSE 80
+
+ENTRYPOINT [ "/usr/sbin/httpd" ]
+CMD [ "-D", "FOREGROUND" ]

--- a/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
@@ -1,0 +1,16 @@
+FROM fedora
+MAINTAINER Micah Abbott <micah@redhat.com>
+
+LABEL Version=1.1
+LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
+
+ENV container docker
+
+RUN dnf -y install httpd && \
+    dnf clean all
+
+RUN echo "SUCCESS fedora24_httpd" > /var/www/html/index.html
+EXPOSE 80
+
+ENTRYPOINT [ "/usr/sbin/httpd" ]
+CMD [ "-D", "FOREGROUND" ]

--- a/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.access.redhat.com/rhel7
+MAINTAINER Micah Abbott <micah@redhat.com>
+
+LABEL Version=1.2
+LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
+
+ENV container docker
+
+RUN yum install --disablerepo=\* \
+				--enablerepo=rhel-7-server-rpms \
+				-y httpd && \
+    yum clean all
+
+RUN echo "SUCCESS rhel7_httpd" > /var/www/html/index.html
+
+EXPOSE 80
+
+ENTRYPOINT [ "/usr/sbin/httpd" ]
+CMD [ "-D", "FOREGROUND" ]

--- a/roles/docker_build_httpd/tasks/main.yml
+++ b/roles/docker_build_httpd/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+# vim: set ft=ansible:
+#
+- name: Fail if g_osname not set
+  fail:
+    msg: "The g_osname variable is not defined"
+  when: g_osname is not defined
+
+- name: Create temp directory for building
+  command: mktemp -d
+  register: m
+
+- name: Set build_dir fact
+  set_fact:
+    build_dir: "{{ m.stdout }}"
+
+- name: Copy Dockerfile to temp directory
+  copy:
+    src: "{{ g_osname }}_httpd_Dockerfile"
+    dest: "{{ build_dir }}"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Build httpd image
+  command: "docker build -t {{ g_osname }}_httpd -f {{ build_dir }}/{{ g_osname }}_httpd_Dockerfile {{ build_dir }}"
+
+- name: Get docker images after build
+  command: docker images
+  register: build_images
+
+- name: Fail if httpd image not present
+  fail:
+    msg: "The {{ g_osname }}_httpd image is not present"
+  when: "'{{ g_osname }}_httpd' not in build_images.stdout"

--- a/roles/docker_pull_base_image/tasks/main.yml
+++ b/roles/docker_pull_base_image/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# vim: set ft=ansible:
+#
+- name: Fail if g_osname is not set
+  fail:
+    msg: "The g_osname variable is not defined"
+  when: g_osname is not defined
+
+- name: Pull base image
+  command: "docker pull {{ g_osname }}"
+
+- name: List Docker images
+  command: docker images
+  register: docker_images
+
+- name: Fail if base image is missing
+  fail:
+    msg: "The base image named {{ g_osname }} is missing"
+  when: "'{{ g_osname }}' not in docker_images.stdout"

--- a/roles/docker_remove_all/tasks/main.yml
+++ b/roles/docker_remove_all/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# vim: set ft=ansible:
+#
+- name: Remove all containers
+  shell: docker rm -f $(docker ps -aq)
+  ignore_errors: true
+
+- name: Check for containers
+  command: docker ps -aq
+  register: docker_ps
+
+- name: Fail if any containers persist
+  fail:
+    msg: "All containers were not removed successfully"
+  when: "{{ docker_ps.stdout|length }} != 0"
+
+- name: Remove all images
+  shell: docker rmi -f $(docker images -aq)
+  ignore_errors: true
+
+- name: Check for images
+  command: docker images -aq
+  register: docker_images
+
+- name: Fail if any images persist
+  fail:
+    msg: "All images were not removed successfully"
+  when: "{{ docker_images.stdout|length }} != 0"

--- a/roles/docker_rm_httpd_container/tasks/main.yml
+++ b/roles/docker_rm_httpd_container/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# vim: set ft=ansible:
+#
+- name: Fail if g_osname not set
+  fail:
+    msg: "The g_osname variable is not defined"
+  when: g_osname is not defined
+
+- name: Get list of all containers
+  command: docker ps -a
+  register: ps_before
+
+- name: Fail if httpd container is not present
+  fail:
+    msg: "The {{ g_osname }}_httpd container is not present"
+  when: "'{{ g_osname}}_httpd' not in ps_before.stdout"
+
+- name: Remove the httpd container
+  command: "docker rm {{ g_osname }}_httpd"
+
+- name: Get list of all containers again
+  command: docker ps -a
+  register: ps_after
+
+- name: Fail if httpd container is present
+  fail:
+    msg: "The {{ g_osname }}_httpd container is still present"
+  when: "'{{ g_osname }}_httpd' in ps_after.stdout"

--- a/roles/docker_rmi_httpd_image/tasks/main.yml
+++ b/roles/docker_rmi_httpd_image/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# vim: set ft=ansible:
+#
+- name: Fail if g_osname not set
+  fail:
+    msg: "The g_osname variable is not defined"
+  when: g_osname is not defined
+
+- name: Get all the docker images
+  command: docker images
+  register: images_before
+
+- name: Fail if the httpd image is not present
+  fail:
+    msg: "The {{ g_osname }}_httpd container is not present"
+  when: "'{{ g_osname}}_httpd' not in images_before.stdout"
+
+- name: Remove the httpd container
+  command: "docker rmi {{ g_osname }}_httpd"
+
+- name: Get the docker images against
+  command: docker images
+  register: images_after
+
+- name: Fail if the httpd image is present
+  fail:
+    msg: "The {{ g_osname }}_httpd image was not removed"
+  when: "'{{ g_osname }}_httpd' in images_after.stdout"

--- a/roles/docker_run_httpd/tasks/main.yml
+++ b/roles/docker_run_httpd/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# vim: set ft=ansible:
+#
+- name: Fail if g_osname is not set
+  fail:
+    msg: "The g_osname variable is not defined"
+  when: g_osname is not defined
+
+- name: Get list of Docker images
+  command: docker images
+  register: images
+
+- name: Fail if httpd image is missing
+  fail:
+    msg: "httpd image is not present"
+  when: "'{{ g_osname }}_httpd' not in images.stdout"
+
+- name: Run httpd container
+  command: "docker run -d -p 80:80 --name {{ g_osname }}_httpd {{ g_osname }}_httpd"
+
+- name: Verify port 80 is open
+  wait_for:
+    port: 80
+    timeout: 30
+
+- name: Test connectivity to container
+  command: curl http://localhost:80
+
+- name: Stop httpd container
+  command: "docker stop {{ g_osname }}_httpd"
+
+- name: Get a list of running containers
+  command: docker ps
+  register: ps
+
+- name: Fail if httpd container is still running
+  fail:
+    msg: "The {{ g_osname }}_httpd container is still running"
+  when: "'{{ g_osname }}_httpd' in ps.stdout"

--- a/roles/osname_set_fact/tasks/main.yml
+++ b/roles/osname_set_fact/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# vim: set ft=ansible:
+#
+- name: Set g_osname fact for CentOS
+  set_fact:
+    g_osname: "centos"
+  when: "'CentOS' in ansible_distribution"
+
+- name: Set g_osname fact for Fedora
+  set_fact:
+    g_osname: "{{ ansible_distribution|lower }}"
+  when: "ansible_distribution == 'Fedora'"
+
+- name: Set g_osname fact for RHEL
+  set_fact:
+    g_osname: "rhel7"
+  when: "ansible_distribution == 'RedHat'"

--- a/tests/improved-sanity-test/info.txt
+++ b/tests/improved-sanity-test/info.txt
@@ -5,4 +5,5 @@ Test Coverage:
 * Modifications to /etc and verifying 3 way merge during upgrades/rollbacks
 * Verification of /tmp file permissions
 * Verification of basic rpm usage
+* Basic docker operations (pull, build, run, rm, rmi)
 * Pull and run cockpit container

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -34,8 +34,8 @@
     - vars.yml
 
   roles:
-    # This playbook requires Ansible 2.0+ and an Atomic Host
-    - { role: ansible_version_check, avc_major: "2", avc_minor: "0", tags: ['ansible_version_check'] }
+    # This playbook requires Ansible 2.1 and an Atomic Host
+    - { role: ansible_version_check, avc_major: "2", avc_minor: "1", tags: ['ansible_version_check'] }
 
     - role: atomic_host_check
       tags:
@@ -75,6 +75,32 @@
 
     - { role: var_files_present, vfp_filename: "{{ g_file1 }}", vfp_dirname: "{{ g_dir1 }}", tags: ['var_files_present'] }
 
+    # Pull down docker base images, build a layered, image, run it, then
+    # remove the container.  But we keep the image around to run later.
+    - role: osname_set_fact
+      tags:
+        - osname_set_fact
+
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+
+    - role: docker_pull_base_image
+      tags:
+        - docker_pull_base_image
+
+    - role: docker_build_httpd
+      tags:
+        - docker_build_httpd
+
+    - role: docker_run_httpd
+      tags:
+        - docker_run_httpd
+
+    - role: docker_rm_httpd_container
+      tags:
+        - docker_rm_httpd_container
+
     # Download and run cockpit container and verify it is running
     - role: cockpit_run_verify
       tags:
@@ -98,7 +124,7 @@
     - vars.yml
 
   roles:
-    # This playbook requires Ansible 2.0+ and an Atomic Host
+    # This playbook requires Ansible 2.1 and an Atomic Host
     - { role: ansible_version_check, avc_major: "2", avc_minor: "0", tags: ['ansible_version_check'] }
 
     - role: atomic_host_check
@@ -134,6 +160,23 @@
 
     - { role: var_files_present, vfp_filename: "{{ g_file2 }}", vfp_dirname: "{{ g_dir2 }}", tags: ['var_files_present'] }
 
+    # Run the previously created docker layered image, then remove the container and the image.
+    - role: osname_set_fact
+      tags:
+        - osname_set_fact
+
+    - role: docker_run_httpd
+      tags:
+        - docker_run_httpd
+
+    - role: docker_rm_httpd_container
+      tags:
+        - docker_rm_httpd_container
+
+    - role: docker_rmi_httpd_image
+      tags:
+        - docker_rmi_httpd_image
+
     # Run cockpit container
     - role: cockpit_run_verify
       tags:
@@ -157,8 +200,8 @@
     - vars.yml
 
   roles:
-    # This playbook requires Ansible 2.0+ and an Atomic Host
-    - { role: ansible_version_check, avc_major: "2", avc_minor: "0", tags: ['ansible_version_check'] }
+    # This playbook requires Ansible 2.1 and an Atomic Host
+    - { role: ansible_version_check, avc_major: "2", avc_minor: "1", tags: ['ansible_version_check'] }
 
     - role: atomic_host_check
       tags:


### PR DESCRIPTION
This brings in some simple docker tests to the sanity suite.  There
are tests performed pre and post upgrade of the system.

Before the upgrade happens, a base image is pulled to be used as part
of the build process of a layered image.  The layered image is built,
run, and then the resulting container is removed.

After the upgrade, the layered image that was built is ran again, the
resulting container removed, and then the layered image is removed.

As part of this change, I also pinned the playbook to Ansible 2.1 as
it seems pretty stable and has been working well thusfar.