### PR TITLE
roles: remove ansible_host reboot case

### DIFF
--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -22,19 +22,6 @@
 # that they don't use sudo, which may require a password, and is not necessary
 # anyway.
 
-# During playbook testing, I found that sometimes the 'ansible_host' variable
-# is sometimes undefined, leading to errors waiting for the host to return.
-# We can opt to use the 'inventory_hostname' in this case and avoid those
-# (admittedly) rare error cases.
-- name: wait for hosts to come back up (ansible_host)
-  local_action: wait_for host={{ ansible_host }}
-                port=22
-                state=started
-                delay=15
-                timeout=120
-  become: false
-  when: ansible_host is defined
-
 - name: wait for hosts to come back up (inventory_hostname)
   local_action: wait_for host={{ inventory_hostname }}
                 port=22
@@ -42,4 +29,3 @@
                 delay=15
                 timeout=120
   become: false
-  when: ansible_host is undefined


### PR DESCRIPTION
During recent testing of incoming changes, some of us have noticed
inconsistency when using the `ansible_host` variable during the
'reboot' role.  Instead, the `inventory_hostname` variable has given
us more more reliability.

This somewhat flies in the face of the comment originally made in
PR #33, but live and learn.