### PR TITLE
docker_run_httpd: retry connection to httpd container

### DIFF
--- a/roles/docker_run_httpd/tasks/main.yml
+++ b/roles/docker_run_httpd/tasks/main.yml
@@ -25,6 +25,10 @@
 
 - name: Test connectivity to container
   command: curl http://localhost:80
+  register: curl
+  until: curl.rc == 0
+  retries: 6
+  delay: 5
 
 - name: Stop httpd container
   command: "docker stop {{ g_osname }}_httpd"


### PR DESCRIPTION
The internal CI job occasionally fails because the connectivity test
to the httpd container is unsuccessful. There does not seem to be a
good reason for this, so we'll just retry a few times.