### PR TITLE
Add SELinux checks for ostree/rpm-ostree

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,8 +32,14 @@ CAHC
 $centos = <<CENTOS
 #!/bin/bash
 set -xeuo pipefail
+current=$(ostree rev-parse centos-atomic-host/7/x86_64/standard)
+sed -i 's|true|false|' /etc/ostree/remotes.d/centos-atomic-host.conf
 sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-host:centos-atomic-host/7/x86_64/standard
-sudo rpm-ostree deploy $(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
+sed -i 's|false|true|' /etc/ostree/remotes.d/centos-atomic-host.conf
+minusone=$(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
+if $current != $minusone; then
+    sudo rpm-ostree deploy $minusone
+fi
 CENTOS
 
 $fedora23 = <<FEDORA23

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,14 +32,8 @@ CAHC
 $centos = <<CENTOS
 #!/bin/bash
 set -xeuo pipefail
-current=$(ostree rev-parse centos-atomic-host/7/x86_64/standard)
-sed -i 's|true|false|' /etc/ostree/remotes.d/centos-atomic-host.conf
 sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-host:centos-atomic-host/7/x86_64/standard
-sed -i 's|false|true|' /etc/ostree/remotes.d/centos-atomic-host.conf
-minusone=$(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
-if $current != $minusone; then
-    sudo rpm-ostree deploy $minusone
-fi
+sudo rpm-ostree deploy $(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
 CENTOS
 
 $fedora23 = <<FEDORA23

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -10,7 +10,6 @@
     - /usr/bin/rpm-ostree
     - /usr/libexec/rpm-ostreed
 
-
 - name: Run 'rpm-ostree status' to start daemon
   command: rpm-ostree status
 

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# vim: set ft=ansible:
+#
+- name: Verify that the SELinux context is correct on ostree/rpm-ostree
+  shell: ls -Z {{ item }} | awk '{print $4}'
+  register: selinux_context
+  failed_when: "'install_exec_t' not in selinux_context.stdout"
+  with_items:
+    - /usr/bin/ostree
+    - /usr/bin/rpm-ostree
+    - /usr/libexec/rpm-ostreed
+  when: ansible_distribution != "Fedora"
+
+
+- name: Verify that the SELinux context is correct ostree/rpm-ostree (Fedora)
+  shell: ls -Z {{ item }} | awk '{print $1}'
+  register: selinux_context_f
+  failed_when: "'install_exec_t' not in selinux_context_f.stdout"
+  with_items:
+    - /usr/bin/ostree
+    - /usr/bin/rpm-ostree
+    - /usr/libexec/rpm-ostreed
+  when: ansible_distribution == "Fedora"
+
+- name: Run 'rpm-ostree status' to start daemon
+  command: rpm-ostree status
+
+- name: Verify SELinux label is correct on rpm-ostreed process
+  shell: ps --no-headers -o label -q $(pidof rpm-ostreed)
+  register: selinux_label
+  failed_when: "'install_t' not in selinux_label.stdout"

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -2,25 +2,14 @@
 # vim: set ft=ansible:
 #
 - name: Verify that the SELinux context is correct on ostree/rpm-ostree
-  shell: ls -Z {{ item }} | awk '{print $4}'
+  command: getfattr -n security.selinux {{ item }} --absolute-names --only-values
   register: selinux_context
   failed_when: "'install_exec_t' not in selinux_context.stdout"
   with_items:
     - /usr/bin/ostree
     - /usr/bin/rpm-ostree
     - /usr/libexec/rpm-ostreed
-  when: ansible_distribution != "Fedora"
 
-
-- name: Verify that the SELinux context is correct ostree/rpm-ostree (Fedora)
-  shell: ls -Z {{ item }} | awk '{print $1}'
-  register: selinux_context_f
-  failed_when: "'install_exec_t' not in selinux_context_f.stdout"
-  with_items:
-    - /usr/bin/ostree
-    - /usr/bin/rpm-ostree
-    - /usr/libexec/rpm-ostreed
-  when: ansible_distribution == "Fedora"
 
 - name: Run 'rpm-ostree status' to start daemon
   command: rpm-ostree status

--- a/tests/improved-sanity-test/info.txt
+++ b/tests/improved-sanity-test/info.txt
@@ -5,6 +5,7 @@ Test Coverage:
 * Modifications to /etc and verifying 3 way merge during upgrades/rollbacks
 * Verification of /tmp file permissions
 * Verification of basic rpm usage
+* Verification of SELinux context/labels for ostree/rpm-ostree
 * Basic docker operations (pull, build, run, rm, rmi)
 * Basic atomic operations (host status, pull, install, uninstall, run, stop, scan)
 * Pull and run cockpit container

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -41,6 +41,10 @@
       tags:
         - atomic_host_check
 
+    - role: selinux_verify
+      tags:
+        - selinux_verify
+
     # Subscribe if the system is RHEL
     - role: redhat_subscription
       when: ansible_distribution == 'RedHat'
@@ -163,6 +167,10 @@
       tags:
         - atomic_host_check
 
+    - role: selinux_verify
+      tags:
+        - selinux_verify
+
     # Check that /tmp is properly setup
     - role: tmp_check_perms
       tags:
@@ -274,6 +282,10 @@
     - role: atomic_host_check
       tags:
         - atomic_host_check
+
+    - role: selinux_verify
+      tags:
+        - selinux_verify
 
     # Check that /tmp is properly setup
     - role: tmp_check_perms


### PR DESCRIPTION
This change introduces a role that does some basic checks of the
SELinux contexts on the `ostree`, `rpm-ostree`, and `rpm-ostreed`
binaries.  It also checks the SELinux labeling of the `rpm-ostreed`
process.