### PR TITLE
Vagrantfile: adjust logic for CentOS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,8 +32,14 @@ CAHC
 $centos = <<CENTOS
 #!/bin/bash
 set -xeuo pipefail
+current=$(ostree rev-parse centos-atomic-host/7/x86_64/standard)
+sed -i 's|true|false|' /etc/ostree/remotes.d/centos-atomic-host.conf
 sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-host:centos-atomic-host/7/x86_64/standard
-sudo rpm-ostree deploy $(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
+sed -i 's|false|true|' /etc/ostree/remotes.d/centos-atomic-host.conf
+minusone=$(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
+if $current != $minusone; then
+    sudo rpm-ostree deploy $minusone
+fi
 CENTOS
 
 $fedora23 = <<FEDORA23

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ sed -i 's|true|false|' /etc/ostree/remotes.d/centos-atomic-host.conf
 sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-host:centos-atomic-host/7/x86_64/standard
 sed -i 's|false|true|' /etc/ostree/remotes.d/centos-atomic-host.conf
 minusone=$(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
-if [ "$current" != "$minusone"] ; then
+if [ "$current" != "$minusone" ] ; then
     sudo rpm-ostree deploy $minusone
 fi
 CENTOS

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ sed -i 's|true|false|' /etc/ostree/remotes.d/centos-atomic-host.conf
 sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-host:centos-atomic-host/7/x86_64/standard
 sed -i 's|false|true|' /etc/ostree/remotes.d/centos-atomic-host.conf
 minusone=$(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
-if $current != $minusone; then
+if [ "$current" != "$minusone"] ; then
     sudo rpm-ostree deploy $minusone
 fi
 CENTOS


### PR DESCRIPTION
When trying to deploy HEAD^ for CentOS, I encountered an error because
the version of C7AH in the current Vagrant box is equivalent to HEAD^.

I adjusted the logic around the deploy to skip out if the version of
the Vagrant box happened to be HEAD^ from the remote.

Additionally, I had to use some `sed` edits to disable GPG
verification because of ostreedev/ostree#518