### PR TITLE
Use fully qualified container name for cockpit

### DIFF
--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Set cockpit container name for Fedora/CentOS
   set_fact:
-    cockpit_cname: "cockpit/ws"
+    cockpit_cname: "docker.io/cockpit/ws"
   when: ('CentOS' in ansible_distribution) or ansible_distribution == "Fedora"
 
 - name: Install cockpit container


### PR DESCRIPTION
There is an upstream issue #674 filed in the atomic CLI project for
the pull that occurs during atomic install. The pull does not
resolve the fully qualified name for the container and throws an
error. We should be using fully qualified container names so we
know we are pulling the right image from the right registry anyhow.