### PR TITLE
atomic_installation_verify: use :latest tag

### DIFF
--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -14,12 +14,12 @@
 #
 - name: Set cockpit container name for RHELAH
   set_fact:
-    cockpit_cname: "registry.access.redhat.com/rhel7/cockpit-ws"
+    cockpit_cname: "registry.access.redhat.com/rhel7/cockpit-ws:latest"
   when: ansible_distribution == "RedHat"
 
 - name: Set cockpit container name for Fedora/CentOS
   set_fact:
-    cockpit_cname: "docker.io/cockpit/ws"
+    cockpit_cname: "docker.io/cockpit/ws:latest"
   when: ('CentOS' in ansible_distribution) or ansible_distribution == "Fedora"
 
 - name: Install cockpit container


### PR DESCRIPTION
In projectatomic/skopeo#227, the `atomic install` command is failing
because there is no explicit tag specified.

This change makes the test use the `:latest` tag explicitly on the
cockpit images.

(We may want to revert this once the upstream issue is fixed)