### PR TITLE
Add check for rpm-ostree status json deployment output

### DIFF
--- a/roles/redhat_subscription/tasks/main.yaml
+++ b/roles/redhat_subscription/tasks/main.yaml
@@ -33,12 +33,12 @@
   - name: Set version and commit if deployment 0 is booted
     set_fact:
       booted_commit: "{{ json['deployments'][0]['checksum'] }}"
-    when: json['deployments'][0]['booted']
+    when: json['deployments'][0] is defined and json['deployments'][0]['booted']
 
   - name: Set version and commit if deployment 1 is booted
     set_fact:
       booted_commit: "{{ json['deployments'][1]['checksum'] }}"
-    when: json['deployments'][1]['booted']
+    when: json['deployments'][1] is defined and json['deployments'][1]['booted']
 
   - name: Get refspec from origin file
     command: grep refspec /ostree/deploy/rhel-atomic-host/deploy/{{ booted_commit }}.0.origin


### PR DESCRIPTION
The redhat subscription role will save and restore the refspec for the
currently booted commit (because it gets overwritten by subscription
manager). Added a check to verify that the deployment exists so set_fact
will no longer fail.