### PR TITLE
Move away from deprecated docker module

### DIFF
--- a/roles/docker_build_tag_push/tasks/main.yaml
+++ b/roles/docker_build_tag_push/tasks/main.yaml
@@ -68,8 +68,8 @@
     command: docker build -t {{ ansible_docker0.ipv4.address}}:5000/dbforweb:latest /root/db
 
   - name: verify tag
-    docker:
-      image: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
+    docker_container:
+      name: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
       state: present
 
   - name: push db to private registry
@@ -94,8 +94,8 @@
     command: docker build -t {{ ansible_docker0.ipv4.address }}:5000/webwithdb:latest /root/web
 
   - name: verify tag
-    docker:
-      image: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
+    docker_container:
+      name: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
       state: present
 
   - name: push web to private registry

--- a/roles/docker_private_registry/tasks/main.yaml
+++ b/roles/docker_private_registry/tasks/main.yaml
@@ -35,11 +35,11 @@
 #    pause: seconds=30
 
   - name: create private registry
-    docker:
+    docker_container:
       name: registry
       image: registry:2
-      pull: missing
-      state: reloaded
+      state: started
+      restart: yes
       ports: 
         - 5000:5000
       restart_policy: always

--- a/roles/kubernetes_setup/tasks/main.yaml
+++ b/roles/kubernetes_setup/tasks/main.yaml
@@ -10,8 +10,9 @@
 #      - kubernetes-scheduler
 
   - name: pull kubernetes api-server, controller-mgr, scheduler 
-    docker:
-      image: registry.access.redhat.com/rhel7/{{ item }}
+    docker_image:
+      name: {{ item }}
+      repository: registry.access.redhat.com/rhel7/
       state: present
     with_items:
       - kubernetes-apiserver


### PR DESCRIPTION
The docker module is now considered deprecated. This change moves to
using the newer docker_container (2.1.0) and docker_image (1.5)
modules.

See: http://docs.ansible.com/ansible/docker_module.html#deprecated

Part of #28