### PR TITLE
Revert "Move away from deprecated docker module (#56)"

### DIFF
--- a/roles/docker_build_tag_push/tasks/main.yaml
+++ b/roles/docker_build_tag_push/tasks/main.yaml
@@ -68,8 +68,8 @@
     command: docker build -t {{ ansible_docker0.ipv4.address}}:5000/dbforweb:latest /root/db
 
   - name: verify tag
-    docker_container:
-      name: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
+    docker:
+      image: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
       state: present
 
   - name: push db to private registry
@@ -94,8 +94,8 @@
     command: docker build -t {{ ansible_docker0.ipv4.address }}:5000/webwithdb:latest /root/web
 
   - name: verify tag
-    docker_container:
-      name: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
+    docker:
+      image: '{{ ansible_docker0.ipv4.address }}:5000/dbforweb'
       state: present
 
   - name: push web to private registry

--- a/roles/docker_private_registry/tasks/main.yaml
+++ b/roles/docker_private_registry/tasks/main.yaml
@@ -35,11 +35,11 @@
 #    pause: seconds=30
 
   - name: create private registry
-    docker_container:
+    docker:
       name: registry
       image: registry:2
-      state: started
-      restart: yes
+      pull: missing
+      state: reloaded
       ports: 
         - 5000:5000
       restart_policy: always

--- a/roles/kubernetes_setup/tasks/main.yaml
+++ b/roles/kubernetes_setup/tasks/main.yaml
@@ -10,9 +10,8 @@
 #      - kubernetes-scheduler
 
   - name: pull kubernetes api-server, controller-mgr, scheduler 
-    docker_image:
-      name: {{ item }}
-      repository: registry.access.redhat.com/rhel7/
+    docker:
+      image: registry.access.redhat.com/rhel7/{{ item }}
       state: present
     with_items:
       - kubernetes-apiserver


### PR DESCRIPTION
This reverts commit c9877e3b8f8ae902a0830fbcb4e5239dc6fb9752.
The tests are pinned to Ansible version 2.1 so the changes to
the new docker module do not work.