### PR TITLE
roles: check for presence of running httpd container

### DIFF
--- a/roles/docker_build_httpd/tasks/main.yml
+++ b/roles/docker_build_httpd/tasks/main.yml
@@ -6,6 +6,11 @@
     msg: "The g_osname variable is not defined"
   when: g_osname is not defined
 
+- name: Fail if g_httpd_name not set
+  fail:
+    msg: "The g_httpd_name variable is not defined"
+  when: g_httpd_name is not defined
+
 - name: Create temp directory for building
   command: mktemp -d
   register: m
@@ -16,14 +21,14 @@
 
 - name: Copy Dockerfile to temp directory
   copy:
-    src: "{{ g_osname }}_httpd_Dockerfile"
+    src: "{{ g_httpd_name }}_Dockerfile"
     dest: "{{ build_dir }}"
     owner: root
     group: root
     mode: 0644
 
 - name: Build httpd image
-  command: "docker build -t {{ g_osname }}_httpd -f {{ build_dir }}/{{ g_osname }}_httpd_Dockerfile {{ build_dir }}"
+  command: "docker build -t {{ g_httpd_name }} -f {{ build_dir }}/{{ g_httpd_name }}_Dockerfile {{ build_dir }}"
 
 - name: Get docker images after build
   command: docker images
@@ -31,5 +36,5 @@
 
 - name: Fail if httpd image not present
   fail:
-    msg: "The {{ g_osname }}_httpd image is not present"
-  when: "'{{ g_osname }}_httpd' not in build_images.stdout"
+    msg: "The {{ g_httpd_name }} image is not present"
+  when: "'{{ g_httpd_name }}' not in build_images.stdout"

--- a/roles/docker_rm_httpd_container/tasks/main.yml
+++ b/roles/docker_rm_httpd_container/tasks/main.yml
@@ -6,17 +6,22 @@
     msg: "The g_osname variable is not defined"
   when: g_osname is not defined
 
+- name: Fail if g_httpd_name not set
+  fail:
+    msg: "The g_httpd_name variable is not defined"
+  when: g_httpd_name is not defined
+
 - name: Get list of all containers
   command: docker ps -a
   register: ps_before
 
 - name: Fail if httpd container is not present
   fail:
-    msg: "The {{ g_osname }}_httpd container is not present"
-  when: "'{{ g_osname}}_httpd' not in ps_before.stdout"
+    msg: "The {{ g_httpd_name }} container is not present"
+  when: "'{{ g_httpd_name }}' not in ps_before.stdout"
 
 - name: Remove the httpd container
-  command: "docker rm {{ g_osname }}_httpd"
+  command: "docker rm {{ g_httpd_name }}"
 
 - name: Get list of all containers again
   command: docker ps -a
@@ -24,5 +29,5 @@
 
 - name: Fail if httpd container is present
   fail:
-    msg: "The {{ g_osname }}_httpd container is still present"
-  when: "'{{ g_osname }}_httpd' in ps_after.stdout"
+    msg: "The {{ g_httpd_name }} container is still present"
+  when: "'{{ g_httpd_name }}' in ps_after.stdout"

--- a/roles/docker_rmi_httpd_image/tasks/main.yml
+++ b/roles/docker_rmi_httpd_image/tasks/main.yml
@@ -6,17 +6,22 @@
     msg: "The g_osname variable is not defined"
   when: g_osname is not defined
 
+- name: Fail if g_httpd_name is not set
+  fail:
+    msg: "The g_httpd_name variable is not defined"
+  when: g_httpd_name is not defined
+
 - name: Get all the docker images
   command: docker images
   register: images_before
 
 - name: Fail if the httpd image is not present
   fail:
-    msg: "The {{ g_osname }}_httpd container is not present"
-  when: "'{{ g_osname}}_httpd' not in images_before.stdout"
+    msg: "The {{ g_httpd_name }} container is not present"
+  when: "'{{ g_httpd_name }}' not in images_before.stdout"
 
 - name: Remove the httpd container
-  command: "docker rmi {{ g_osname }}_httpd"
+  command: "docker rmi {{ g_httpd_name }}"
 
 - name: Get the docker images against
   command: docker images
@@ -24,5 +29,5 @@
 
 - name: Fail if the httpd image is present
   fail:
-    msg: "The {{ g_osname }}_httpd image was not removed"
-  when: "'{{ g_osname }}_httpd' in images_after.stdout"
+    msg: "The {{ g_httpd_name }} image was not removed"
+  when: "'{{ g_httpd_name }}' in images_after.stdout"

--- a/roles/docker_run_httpd/tasks/main.yml
+++ b/roles/docker_run_httpd/tasks/main.yml
@@ -6,6 +6,11 @@
     msg: "The g_osname variable is not defined"
   when: g_osname is not defined
 
+- name: Fail if g_httpd_name is not set
+  fail:
+    msg: "The g_httpd_name variable is not set"
+  when: g_httpd_name is not defined
+
 - name: Get list of Docker images
   command: docker images
   register: images
@@ -13,10 +18,19 @@
 - name: Fail if httpd image is missing
   fail:
     msg: "httpd image is not present"
-  when: "'{{ g_osname }}_httpd' not in images.stdout"
+  when: "'{{ g_httpd_name }}' not in images.stdout"
 
 - name: Run httpd container
-  command: "docker run -d -p 80:80 --name {{ g_osname }}_httpd {{ g_osname }}_httpd"
+  command: "docker run -d -p 80:80 --name {{ g_httpd_name }} {{ g_httpd_name }}"
+
+- name: Get running containers
+  command: "docker ps"
+  register: ps_run
+
+- name: Check for httpd container
+  fail:
+    msg: "The {{ g_httpd_name }} container is not running"
+  when: "'{{ g_httpd_name }}' not in ps_run.stdout"
 
 - name: Verify port 80 is open
   wait_for:
@@ -31,13 +45,13 @@
   delay: 5
 
 - name: Stop httpd container
-  command: "docker stop {{ g_osname }}_httpd"
+  command: "docker stop {{ g_httpd_name }}"
 
 - name: Get a list of running containers
   command: docker ps
-  register: ps
+  register: ps_stop
 
 - name: Fail if httpd container is still running
   fail:
-    msg: "The {{ g_osname }}_httpd container is still running"
-  when: "'{{ g_osname }}_httpd' in ps.stdout"
+    msg: "The {{ g_httpd_name }} container is still running"
+  when: "'{{ g_httpd_name }}' in ps_stop.stdout"

--- a/roles/osname_set_fact/tasks/main.yml
+++ b/roles/osname_set_fact/tasks/main.yml
@@ -15,3 +15,7 @@
   set_fact:
     g_osname: "rhel7"
   when: "ansible_distribution == 'RedHat'"
+
+- name: Set g_httpd_name fact
+  set_fact:
+    g_httpd_name: "{{ g_osname }}_httpd"

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -122,9 +122,9 @@
       tags:
         - docker_build_httpd
 
-    - { role: atomic_run_verify, container: "{{ g_osname }}_httpd", tags: ['atomic_run_verify'] }
+    - { role: atomic_run_verify, container: "{{ g_httpd_name }}", tags: ['atomic_run_verify'] }
 
-    - { role: atomic_stop_verify, container: "{{ g_osname }}_httpd", tags: ['atomic_stop_verify'] }
+    - { role: atomic_stop_verify, container: "{{ g_httpd_name }}", tags: ['atomic_stop_verify'] }
 
     - role: docker_rm_httpd_container
       tags:
@@ -210,9 +210,9 @@
       tags:
         - osname_set_fact
 
-    - { role: atomic_run_verify, container: "{{ g_osname }}_httpd", tags: ['atomic_run_verify'] }
+    - { role: atomic_run_verify, container: "{{ g_httpd_name }}", tags: ['atomic_run_verify'] }
 
-    - { role: atomic_stop_verify, container: "{{ g_osname }}_httpd", tags: ['atomic_stop_verify'] }
+    - { role: atomic_stop_verify, container: "{{ g_httpd_name }}", tags: ['atomic_stop_verify'] }
 
     - role: docker_rm_httpd_container
       tags:


### PR DESCRIPTION
While debugging a recent failure on the internal autobrew stream, it
wasn't immediately obvious from the Ansible output that the httpd
container was not running.  I added a check after starting the
container to see if the container was in the output of `docker ps`.

Additionally, I opted to make use of a global variable in the httpd
image/container roles.  We previously took the `g_osname` variable and
concatenated some text onto it to make the values used in various
`docker` operations.