### PR TITLE
tests: tag individual plays in sanity test

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -30,6 +30,9 @@
   hosts: all
   become: yes
 
+  tags:
+    - pre_upgrade
+
   vars_files:
     - vars.yml
 
@@ -156,6 +159,9 @@
   hosts: all
   become: yes
 
+  tags:
+    - post_upgrade
+
   vars_files:
     - vars.yml
 
@@ -271,6 +277,9 @@
 - name: Improved Sanity Test - Post-Rollback
   hosts: all
   become: yes
+
+  tags:
+    - post_rollback
 
   vars_files:
     - vars.yml


### PR DESCRIPTION
This adds tags on the higher order plays contained in the
`improved-sanity-test` playbook.  This allows us even more flexibility
in running specific tests when necessary.