### PR TITLE
selinux_verify: add check for getfattr

### DIFF
--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
 # vim: set ft=ansible:
 #
+- name: Check if getfattr installed
+  stat:
+    path: /usr/bin/getfattr
+  register: getfattr
+
+- name: Fail if getfattr not installed
+  fail:
+    msg: "The getfattr utility is not installed"
+  when: getfattr.stat.exists == False
+
 - name: Verify that the SELinux context is correct on ostree/rpm-ostree
   command: getfattr -n security.selinux {{ item }} --absolute-names --only-values
   register: selinux_context


### PR DESCRIPTION
We've run into situations where the `getfattr` utility is not
installed on the host and the failure message from this role is not
explicit in that case.  So I added a check for the utility ahead of
trying to use it.

I'm not going to bother trying to check SELinux information using
different methods, since this utility should be commonly installed on
AH and if it isn't, that is a problem to flag.