### PR TITLE
roles: update SELinux contexts for F25

### DIFF
--- a/roles/var_add_files/tasks/main.yml
+++ b/roles/var_add_files/tasks/main.yml
@@ -1,6 +1,17 @@
 ---
 # vim: set ft=ansible:
 #
+- name: Set fedora25 to be False by default
+  set_fact:
+    fedora25: False
+
+- name: Set fedora25 to be True for F25
+  set_fact:
+    fedora25: True
+  when:
+    - ansible_distribution == "Fedora"
+    - ansible_distribution_version == "25"
+
 - name: Fail if vaf_filename is not defined
   fail:
     msg: "vaf_filename is undefined"
@@ -11,12 +22,21 @@
     msg: "vaf_dirname is undefined"
   when: vaf_dirname is undefined
 
-- name: Make directory in /var
+- name: Make directory in /var with svirt_sandbox_file_t
   file:
     path: "/var/{{ vaf_dirname }}"
     state: directory
     mode: 0755
     setype: svirt_sandbox_file_t
+  when: not fedora25
+
+- name: Make directory in /var with container_file_t
+  file:
+    path: "/var/{{ vaf_dirname }}"
+    state: directory
+    mode: 0755
+    setype: container_file_t
+  when: fedora25
 
 - name: Add file in new directory
   shell: "echo $(sha256sum /etc/passwd) > {{ vaf_filename | quote }}"

--- a/roles/var_add_files/tasks/main.yml
+++ b/roles/var_add_files/tasks/main.yml
@@ -1,16 +1,19 @@
 ---
 # vim: set ft=ansible:
 #
-- name: Set fedora25 to be False by default
+- name: Set use_container_file_t to be False by default
   set_fact:
-    fedora25: False
+    use_container_file_t: False
 
-- name: Set fedora25 to be True for F25
+- name: Check for presence of container_file_t type
+  command: seinfo --type=container_file_t
+  register: seinfo
+  ignore_errors: True
+
+- name: Set use_container_file_t to True when present
   set_fact:
-    fedora25: True
-  when:
-    - ansible_distribution == "Fedora"
-    - ansible_distribution_version == "25"
+    use_container_file_t: True
+  when: seinfo.rc == 0
 
 - name: Fail if vaf_filename is not defined
   fail:
@@ -28,7 +31,7 @@
     state: directory
     mode: 0755
     setype: svirt_sandbox_file_t
-  when: not fedora25
+  when: not use_container_file_t
 
 - name: Make directory in /var with container_file_t
   file:
@@ -36,7 +39,7 @@
     state: directory
     mode: 0755
     setype: container_file_t
-  when: fedora25
+  when: use_container_file_t
 
 - name: Add file in new directory
   shell: "echo $(sha256sum /etc/passwd) > {{ vaf_filename | quote }}"

--- a/roles/var_add_files/tasks/main.yml
+++ b/roles/var_add_files/tasks/main.yml
@@ -1,19 +1,14 @@
 ---
 # vim: set ft=ansible:
 #
-- name: Set use_container_file_t to be False by default
-  set_fact:
-    use_container_file_t: False
-
 - name: Check for presence of container_file_t type
   command: seinfo --type=container_file_t
   register: seinfo
   ignore_errors: True
 
-- name: Set use_container_file_t to True when present
+- name: Set SELinux type to be used
   set_fact:
-    use_container_file_t: True
-  when: seinfo.rc == 0
+    selinux_type: '{{ "container_file_t" if seinfo.rc == 0 else "svirt_sandbox_file_t" }}'
 
 - name: Fail if vaf_filename is not defined
   fail:
@@ -25,21 +20,12 @@
     msg: "vaf_dirname is undefined"
   when: vaf_dirname is undefined
 
-- name: Make directory in /var with svirt_sandbox_file_t
+- name: Make directory in /var_
   file:
     path: "/var/{{ vaf_dirname }}"
     state: directory
     mode: 0755
-    setype: svirt_sandbox_file_t
-  when: not use_container_file_t
-
-- name: Make directory in /var with container_file_t
-  file:
-    path: "/var/{{ vaf_dirname }}"
-    state: directory
-    mode: 0755
-    setype: container_file_t
-  when: use_container_file_t
+    setype: "{{ selinux_type }}"
 
 - name: Add file in new directory
   shell: "echo $(sha256sum /etc/passwd) > {{ vaf_filename | quote }}"

--- a/roles/var_add_files/tasks/main.yml
+++ b/roles/var_add_files/tasks/main.yml
@@ -20,7 +20,7 @@
     msg: "vaf_dirname is undefined"
   when: vaf_dirname is undefined
 
-- name: Make directory in /var_
+- name: Make directory in /var
   file:
     path: "/var/{{ vaf_dirname }}"
     state: directory

--- a/roles/var_files_present/tasks/main.yml
+++ b/roles/var_files_present/tasks/main.yml
@@ -1,16 +1,19 @@
 ---
 # vim: set ft=ansible:
 #
-- name: Set fedora25 to be False by default
+- name: Set use_container_file_t to be False by default
   set_fact:
-    fedora25: False
+    use_container_file_t: False
 
-- name: Set fedora25 to be True for F25
+- name: Check for presence of container_file_t type
+  command: seinfo --type=container_file_t
+  register: seinfo
+  ignore_errors: True
+
+- name: Set use_container_file_t to True when present
   set_fact:
-    fedora25: True
-  when:
-    - ansible_distribution == "Fedora"
-    - ansible_distribution_version == "25"
+    use_container_file_t: True
+  when: seinfo.rc == 0
 
 - name: Fail if vfp_filename is not defined
   fail:
@@ -44,11 +47,11 @@
 
 - name: Check for svirt_sandbox_file_t context on directory
   shell: "stat /var/{{ vfp_dirname | quote }} | grep svirt_sandbox_file_t"
-  when: not fedora25
+  when: not use_container_file_t
 
 - name: Check for container_file_t context on directory
   shell: "stat /var/{{ vfp_dirname | quote }} | grep container_file_t"
-  when: fedora25
+  when: use_container_file_t
 
 - name: Check that file added to the directory is present
   stat:
@@ -71,9 +74,13 @@
   when: added_file.stat.mode != "0644"
 
 - name: Check for svirt_sandbox_file_t context on added file
-  shell: "stat /var/{{ vfp_dirname | quote }}/{{ vfp_filename | quote}} | grep svirt_sandbox_file_t"
-  when: not fedora25
+  command: "stat -c '%C' /var/{{ vfp_dirname }}/{{ vfp_filename }}"
+  register: stat
+  failed_when: "'svirt_sandbox_file_t' not in stat.stdout"
+  when: not use_container_file_t
 
 - name: Check for container_file_t context on added file
-  shell: "stat /var/{{ vfp_dirname | quote }}/{{ vfp_filename | quote}} | grep container_file_t"
-  when: fedora25
+  command: "stat -c '%C' /var/{{ vfp_dirname }}/{{ vfp_filename }}"
+  register: stat
+  failed_when: "'container_file_t' not in stat.stdout"
+  when: use_container_file_t

--- a/roles/var_files_present/tasks/main.yml
+++ b/roles/var_files_present/tasks/main.yml
@@ -1,19 +1,14 @@
 ---
 # vim: set ft=ansible:
 #
-- name: Set use_container_file_t to be False by default
-  set_fact:
-    use_container_file_t: False
-
 - name: Check for presence of container_file_t type
   command: seinfo --type=container_file_t
   register: seinfo
   ignore_errors: True
 
-- name: Set use_container_file_t to True when present
+- name: Set SELinux type to be used
   set_fact:
-    use_container_file_t: True
-  when: seinfo.rc == 0
+    selinux_type: '{{ "container_file_t" if seinfo.rc == 0 else "svirt_sandbox_file_t" }}'
 
 - name: Fail if vfp_filename is not defined
   fail:
@@ -45,13 +40,10 @@
     msg: "/var/{{ vfp_dirname }} does not have the correct permissions"
   when: var_dir.stat.mode != "0755"
 
-- name: Check for svirt_sandbox_file_t context on directory
-  shell: "stat /var/{{ vfp_dirname | quote }} | grep svirt_sandbox_file_t"
-  when: not use_container_file_t
-
-- name: Check for container_file_t context on directory
-  shell: "stat /var/{{ vfp_dirname | quote }} | grep container_file_t"
-  when: use_container_file_t
+- name: Check for correct SELinux type
+  command: "stat -c '%C' /var/{{ vfp_dirname }}"
+  register: dir_stat
+  failed_when: "selinux_type not in dir_stat.stdout"
 
 - name: Check that file added to the directory is present
   stat:
@@ -73,14 +65,7 @@
     msg: "The permissions on the added file are incorrect"
   when: added_file.stat.mode != "0644"
 
-- name: Check for svirt_sandbox_file_t context on added file
+- name: Check for correct SELinux type
   command: "stat -c '%C' /var/{{ vfp_dirname }}/{{ vfp_filename }}"
-  register: stat
-  failed_when: "'svirt_sandbox_file_t' not in stat.stdout"
-  when: not use_container_file_t
-
-- name: Check for container_file_t context on added file
-  command: "stat -c '%C' /var/{{ vfp_dirname }}/{{ vfp_filename }}"
-  register: stat
-  failed_when: "'container_file_t' not in stat.stdout"
-  when: use_container_file_t
+  register: file_stat
+  failed_when: "selinux_type not in file_stat.stdout"

--- a/roles/var_files_present/tasks/main.yml
+++ b/roles/var_files_present/tasks/main.yml
@@ -1,6 +1,17 @@
 ---
 # vim: set ft=ansible:
 #
+- name: Set fedora25 to be False by default
+  set_fact:
+    fedora25: False
+
+- name: Set fedora25 to be True for F25
+  set_fact:
+    fedora25: True
+  when:
+    - ansible_distribution == "Fedora"
+    - ansible_distribution_version == "25"
+
 - name: Fail if vfp_filename is not defined
   fail:
     msg: "vfp_filename is undefined"
@@ -31,8 +42,13 @@
     msg: "/var/{{ vfp_dirname }} does not have the correct permissions"
   when: var_dir.stat.mode != "0755"
 
-- name: Check if the SELinux context on the directory is correct
+- name: Check for svirt_sandbox_file_t context on directory
   shell: "stat /var/{{ vfp_dirname | quote }} | grep svirt_sandbox_file_t"
+  when: not fedora25
+
+- name: Check for container_file_t context on directory
+  shell: "stat /var/{{ vfp_dirname | quote }} | grep container_file_t"
+  when: fedora25
 
 - name: Check that file added to the directory is present
   stat:
@@ -54,5 +70,10 @@
     msg: "The permissions on the added file are incorrect"
   when: added_file.stat.mode != "0644"
 
-- name: Check if the SELinux context on the added file is correct
+- name: Check for svirt_sandbox_file_t context on added file
   shell: "stat /var/{{ vfp_dirname | quote }}/{{ vfp_filename | quote}} | grep svirt_sandbox_file_t"
+  when: not fedora25
+
+- name: Check for container_file_t context on added file
+  shell: "stat /var/{{ vfp_dirname | quote }}/{{ vfp_filename | quote}} | grep container_file_t"
+  when: fedora25


### PR DESCRIPTION
Turns out the SELinux policy on F25 has `svirt_sandbox_file_t` is an
alias to `container_file_t`

```
$ seinfo -x --type=svirt_sandbox_file_t
   TypeName container_file_t
   Aliases
      svirt_sandbox_file_t
      svirt_lxc_file_t
```

This was causing some of the SELinux checks to fail on F25, so now they are
conditional on F25.