### PR TITLE
atomic_scan_verify: use upstream scanner

### DIFF
--- a/roles/atomic_scan_verify/tasks/main.yml
+++ b/roles/atomic_scan_verify/tasks/main.yml
@@ -49,7 +49,7 @@
   when: "'Files associated' not in atomic_output.stdout"
 
 - name: Get scanner result directory
-  shell: echo "{{ atomic_output.stdout | quote }}" | awk '/Files associated/{print $8}' | sed "s/\.[\']*//"
+  shell: echo {{ atomic_output.stdout | quote }} | awk '/^Files associated/{print $8}' | sed "s/\.[\']*//"
   register: dir
 
 - name: Verify scanner result directory exists

--- a/roles/atomic_scan_verify/tasks/main.yml
+++ b/roles/atomic_scan_verify/tasks/main.yml
@@ -34,8 +34,10 @@
     msg="Atomic install was unsuccessful"
   when: "'Installation complete' not in result.stdout"
 
+  # Use 'docker pull' for now; maybe switch to 'atomic pull' once all the
+  # streams have support for v1 schema manifests
 - name: Pull scanner target
-  command: atomic pull {{ scanner_target }}
+  command: docker pull {{ scanner_target }}
 
 - name: Run atomic scan
   command: atomic --debug scan --scanner {{ scanner_type }} {{ scanner_target }}

--- a/roles/atomic_scan_verify/tasks/main.yml
+++ b/roles/atomic_scan_verify/tasks/main.yml
@@ -9,9 +9,24 @@
 #   - atomic install
 #   - atomic scan
 #
+- name: Set scanner image (RHEL)
+  set_fact:
+    scanner_image: "registry.access.redhat.com/rhel7/openscap"
+    scanner_type: "openscap"
+  when: ansible_distribution == "RedHat"
+
+- name: Set scanner image
+  set_fact:
+    scanner_image: "docker.io/fedora/atomic_scan_openscap"
+    scanner_type: "atomic_scan_openscap"
+  when: ansible_distribution != "RedHat"
+
+- name: Set scanner target
+  set_fact:
+    scanner_target: "registry.access.redhat.com/rhel7"
 
 - name: Install openscap
-  command: atomic install registry.access.redhat.com/rhel7/openscap
+  command: atomic install {{ scanner_image }}
   register: result
 
 - name: Check installation of openscap
@@ -19,8 +34,11 @@
     msg="Atomic install was unsuccessful"
   when: "'Installation complete' not in result.stdout"
 
+- name: Pull scanner target
+  command: atomic pull {{ scanner_target }}
+
 - name: Run atomic scan
-  shell: python -c "import pty; pty.spawn(['atomic', 'scan', '--scanner', 'openscap', 'registry.access.redhat.com/rhel7/openscap'])"
+  command: atomic --debug scan --scanner {{ scanner_type }} {{ scanner_target }}
   register: atomic_output
 
 - name: Catch atomic scan failures


### PR DESCRIPTION
We were seeing failures on certain streams when trying to install the
`openscap` scanner from `registry.access.redhat.com`.  The version of
`skopeo` being used in these cases did not support v1 schema manifests
and that is the only version available on that registry.

Using the scanner from upstream alleviates this problem and gives us
further coverage in this space.

Oddly, only RHEL-based images are supported by the `openscap` scanner,
so the behavior has been changed to scan the RHEL7 image regardless if
the scanner used is upstream or downstream.

Finally, `atomic scan` no longer requires a TTY, so we can change
how that command is invoked.