### PR TITLE
Fix handling of systems (CAHC) with no builtin kube

### DIFF
--- a/common/atomic.yaml
+++ b/common/atomic.yaml
@@ -24,3 +24,13 @@
   fail:
     msg: "The system is not an Atomic Host"
   when: not is_atomic
+
+- name: Determine we have builtin kube
+  command: rpm -q kubelet
+  changed_when: false
+  failed_when: false
+  register: rpmq_kubelet
+
+- name: Set the builtin kube fact
+  set_fact:
+    have_builtin_kube: rpmq_kubelet.rc == 0

--- a/common/atomic.yaml
+++ b/common/atomic.yaml
@@ -23,14 +23,5 @@
 - name: Fail if system is not an Atomic Host
   fail:
     msg: "The system is not an Atomic Host"
-  when: not is_atomic
+    when: not is_atomic
 
-- name: Determine we have builtin kube
-  command: rpm -q kubelet
-  changed_when: false
-  failed_when: false
-  register: rpmq_kubelet
-
-- name: Set the builtin kube fact
-  set_fact:
-    have_builtin_kube: rpmq_kubelet.rc == 0

--- a/roles/semanage_add_verify/tasks/main.yml
+++ b/roles/semanage_add_verify/tasks/main.yml
@@ -8,13 +8,16 @@
   set_fact:
     selinux_type: '{{ "container_file_t" if seinfo.rc == 0 else "svirt_sandbox_file_t" }}'
     dir_match: '/var/lib/kubelet(/.*)?'
+  when: have_builtin_kube
 
 - name: Set fcontext for /var/lib/kubernetes
   command: semanage fcontext -a -t {{ selinux_type }} {{ dir_match }}
+  when: have_builtin_kube
 
 - name: Verify fcontext is set
   shell: semanage fcontext --list | grep '{{ dir_match }}'
   register: output
+  when: have_builtin_kube
 
 - name: Fail selinux type is not in semanage output
   fail:

--- a/roles/semanage_add_verify/tasks/main.yml
+++ b/roles/semanage_add_verify/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Determine we have builtin kube
+  command: rpm -q kubelet
+  changed_when: false
+  failed_when: false
+  register: rpmq_kubelet
+
+- name: Set the builtin kube fact
+  set_fact:
+    have_builtin_kube: rpmq_kubelet.rc == 0
+
 - name: Check for presence of container_file_t type
   command: seinfo --type=container_file_t
   register: seinfo
@@ -22,4 +32,4 @@
 - name: Fail selinux type is not in semanage output
   fail:
     msg: "Could not find {{ selinux_type }} in output"
-  when: "selinux_type not in output.stdout"
+  when: "{{ selinux_type }} not in output.stdout and output is defined"


### PR DESCRIPTION
The previous change to test semanage for /var/lib/kubelet fails if the host
doesn't have kubelet installed, as is the case for CAHC.

Add a global `have_builtin_kube` fact that we can use elsewhere too.