### PR TITLE
docker_build_httpd:  add makecache.sh script

### DIFF
--- a/roles/docker_build_httpd/files/centos_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/centos_httpd_Dockerfile
@@ -7,9 +7,9 @@ LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
 ENV container docker
 
 ADD makecache.sh /
-RUN /makecache.sh
 
-RUN yum -y install httpd && \
+RUN /makecache.sh && \
+    yum -y install httpd && \
     yum clean all
 
 RUN echo "SUCCESS centos_httpd" > /var/www/html/index.html

--- a/roles/docker_build_httpd/files/centos_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/centos_httpd_Dockerfile
@@ -1,10 +1,13 @@
 FROM centos
 MAINTAINER Micah Abbott <micah@redhat.com>
 
-LABEL Version=1.1
+LABEL Version=1.2
 LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
 
 ENV container docker
+
+ADD makecache.sh /
+RUN /makecache.sh
 
 RUN yum -y install httpd && \
     yum clean all

--- a/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
@@ -1,10 +1,13 @@
 FROM fedora
 MAINTAINER Micah Abbott <micah@redhat.com>
 
-LABEL Version=1.1
+LABEL Version=1.2
 LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
 
 ENV container docker
+
+ADD makecache.sh /
+RUN /makecache.sh
 
 RUN dnf -y install httpd && \
     dnf clean all

--- a/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
@@ -7,9 +7,9 @@ LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
 ENV container docker
 
 ADD makecache.sh /
-RUN /makecache.sh
 
-RUN dnf -y install httpd && \
+RUN /makecache.sh && \
+    dnf -y install httpd && \
     dnf clean all
 
 RUN echo "SUCCESS fedora24_httpd" > /var/www/html/index.html

--- a/roles/docker_build_httpd/files/makecache.sh
+++ b/roles/docker_build_httpd/files/makecache.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xeou pipefail
+retries=5
+while [ $retries -gt 0 ]; do
+	if yum makecache; then
+		break
+	fi
+	retries=$((retries - 1))
+done
+

--- a/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
@@ -7,9 +7,9 @@ LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
 ENV container docker
 
 ADD makecache.sh /
-RUN /makecache.sh
 
-RUN yum install --disablerepo=\* \
+RUN /makecache.sh && \
+    yum install --disablerepo=\* \
                 --enablerepo=rhel-7-server-rpms \
                 -y httpd && \
     yum clean all

--- a/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
@@ -1,10 +1,13 @@
 FROM registry.access.redhat.com/rhel7
 MAINTAINER Micah Abbott <micah@redhat.com>
 
-LABEL Version=1.2
+LABEL Version=1.3
 LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
 
 ENV container docker
+
+ADD makecache.sh /
+RUN /makecache.sh
 
 RUN yum install --disablerepo=\* \
                 --enablerepo=rhel-7-server-rpms \


### PR DESCRIPTION
We have seen failures in the tests that appear to be related to
network issues (either in our OpenStack infra or in the Fedora infra)
when trying to install `httpd` while building the Docker image.

To combat this, we just steal the [env_make_cache()](https://github.com/jlebon/redhat-ci/blob/master/testrunner#L267)
routine from @jlebon and stick it in a dumb script.  Then we `ADD` to
the Docker image and `RUN` it before trying to install any packages.

This does add some extra instructions and time while building the
Docker image, but should help us avoid these network related failures.