### PR TITLE
docker_build_httpd: copy makecache.sh script

### DIFF
--- a/roles/docker_build_httpd/tasks/main.yml
+++ b/roles/docker_build_httpd/tasks/main.yml
@@ -27,6 +27,14 @@
     group: root
     mode: 0644
 
+- name: Copy makecache.sh to temp directory
+  copy:
+    src: makecache.sh
+    dest: "{{ build_dir }}"
+    owner: root
+    group: root
+    mode: 0744
+
 - name: Build httpd image
   command: "docker build -t {{ g_httpd_name }} -f {{ build_dir }}/{{ g_httpd_name }}_Dockerfile {{ build_dir }}"
 


### PR DESCRIPTION
While the inclusion of the `makecache.sh` script is nice, it would
help if we actually copied it over to the host under test.

I used a separate `copy` statement to give the script executable
permissions, which the Dockerfile does not require.