### PR TITLE
users: verify password hashing algorithm

### DIFF
--- a/roles/user_add/tasks/main.yml
+++ b/roles/user_add/tasks/main.yml
@@ -6,6 +6,22 @@
     msg: "ua_uid variable is not defined"
   when: ua_uid is undefined
 
+- name: Check enabled password algorithm
+  shell: authconfig --test | grep hash
+  register: algo
+
+- name: Fail if password algorithm is not SHA-512
+  fail:
+    msg: "Password algorithm is not SHA-512"
+  when: "'sha512' not in algo.stdout"
+
 - name: Add user
   command: "useradd atomic-user-{{ ua_uid }} -u {{ ua_uid }}"
 
+  # because UUIDs could be passwords
+- name: Generate some random string
+  command: uuidgen -r
+  register: uuid
+
+- name: Set the password for the user
+  shell: "echo {{ uuid.stdout | quote }} | passwd atomic-user-{{ ua_uid | quote }} --stdin"

--- a/roles/user_verify_present/tasks/main.yml
+++ b/roles/user_verify_present/tasks/main.yml
@@ -10,4 +10,4 @@
   command: "grep atomic-user-{{ uvp_uid }}:x:{{ uvp_uid }}:{{ uvp_uid }}::/home/atomic-user-{{ uvp_uid }}:/bin/bash /etc/passwd"
 
 - name: Verify password is a SHA-512 hash
-  command: "grep '^atomic-user-{{ uvp_uid }}:$6.*' /etc/shadow"
+  command: "grep '^atomic-user-{{ uvp_uid }}:$6$.*' /etc/shadow"

--- a/roles/user_verify_present/tasks/main.yml
+++ b/roles/user_verify_present/tasks/main.yml
@@ -8,3 +8,6 @@
 
 - name: Verify users in /etc/passwd
   command: "grep atomic-user-{{ uvp_uid }}:x:{{ uvp_uid }}:{{ uvp_uid }}::/home/atomic-user-{{ uvp_uid }}:/bin/bash /etc/passwd"
+
+- name: Verify password is a SHA-512 hash
+  command: "grep '^atomic-user-{{ uvp_uid }}:$6.*' /etc/shadow"


### PR DESCRIPTION
CentOS, Fedora, and RHEL Atomic Host all conveniently use SHA-512 to
hash their passwords.

These changes verify that the hashing algorithm is correctly
configured to SHA-512 and also verifies that hashed passwords are
correctly stored in `/etc/shadow`

The password is randomly generated via `uuidgen`, then fed into
`passwd`.  The hash is confirmed by searching for the user and the
leading `$6` on the password hash in `/etc/shadow`.

See `man crypt` for details about the hashing algorithms.