### PR TITLE
roles: add role to pull/run/remove "popular" images

### DIFF
--- a/roles/docker_pull_run_remove/tasks/main.yml
+++ b/roles/docker_pull_run_remove/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# vim: set ft=ansible:
+#
+# popular_images is defined in roles/docker_pull_run_remove/vars/main.yml
+#
+- name: Pull the popular images from Docker Hub
+  command: "docker pull docker.io/{{ item }}"
+  with_items: "{{ popular_images }}"
+
+- name: Run the popular images
+  command: "docker run --rm docker.io/{{ item }} echo 'hello'"
+  with_items: "{{ popular_images }}"
+
+- name: Remove the popular images
+  command: "docker rmi docker.io/{{ item }}"
+  with_items: "{{ popular_images }}"

--- a/roles/docker_pull_run_remove/vars/main.yml
+++ b/roles/docker_pull_run_remove/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# vim: set ft=ansible:
+#
+popular_images:
+  - alpine
+  - busybox
+  - centos
+  - debian
+  - fedora
+  - ubuntu

--- a/roles/docker_pull_run_remove/vars/main.yml
+++ b/roles/docker_pull_run_remove/vars/main.yml
@@ -4,7 +4,4 @@
 popular_images:
   - alpine
   - busybox
-  - centos
-  - debian
-  - fedora
   - ubuntu

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -58,6 +58,10 @@
       tags:
         - redhat_subscription
 
+    - role: docker_pull_run_remove
+      tags:
+        - docker_pull_run_remove
+
     # Install package using package layering
     - role: rpm_ostree_install
       packages: "{{ g_pkg }}"
@@ -215,6 +219,10 @@
     - role: semanage_add_verify
       tags:
         - semanage_add_verify
+
+    - role: docker_pull_run_remove
+      tags:
+        - docker_pull_run_remove
 
     # Check layered package is still installed
     - role: rpm_ostree_install_verify

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -58,10 +58,6 @@
       tags:
         - redhat_subscription
 
-    - role: docker_pull_run_remove
-      tags:
-        - docker_pull_run_remove
-
     # Install package using package layering
     - role: rpm_ostree_install
       packages: "{{ g_pkg }}"


### PR DESCRIPTION
This is a really simple role that just checks we can pull, run, and
remove some of the more popular images on the Docker Hub.

Useful?  Meh.  Kind of just a checkbox because my $dayjob boss asked
me to include it.  :)