### PR TITLE
repo: add .redhat-ci.yml

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -1,0 +1,15 @@
+cluster:
+  hosts:
+    - name: testnode
+      distro: centos/7/atomic/alpha
+      ostree:
+        branch: centos-atomic-host/7/x86_64/devel/smoketested
+  container:
+    image: fedora:25
+
+packages:
+  - ansible
+
+tests:
+  - ansible-playbook -vi testnode, common/ans_ah_head-1_deploy.yml
+  - ansible-playbook -vi testnode, tests/improved-sanity-tests/main.yml

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -12,4 +12,4 @@ packages:
 
 tests:
   - ansible-playbook -vi testnode, common/ans_ah_head-1_deploy.yml
-  - ansible-playbook -vi testnode, tests/improved-sanity-tests/main.yml
+  - ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml

--- a/common/ans_ah_head-1_deploy.yml
+++ b/common/ans_ah_head-1_deploy.yml
@@ -1,0 +1,32 @@
+---
+- hosts: '{{ hosts | default("all") }}'
+  gather_facts: false
+  become: yes
+
+  tasks:
+    - name: Get rpm-ostree JSON status
+      command: rpm-ostree status --json
+      register: rpm_output
+
+    - name: Convert JSON to Jinja2
+      set_fact:
+        json: "{{ rpm_output.stdout|from_json }}"
+
+    - name: Get checksum of HEAD-1
+      command: ostree rev-parse {{ json['deployments'][0]['checksum'] }}^
+      register: head_minus_one
+
+    - name: Deploy HEAD-1
+      command: rpm-ostree deploy {{ head_minus_one.stdout }}
+      register: output
+      until: output.rc == 0
+      retries: 3
+      delay: 5
+      failed_when: "output.rc != 0"
+
+    - include: ans_reboot.yaml
+
+    - name: wait for docker service to start
+      service:
+        name: docker
+        state: started

--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -39,7 +39,3 @@
     wait_for host={{ real_ansible_host }}
     port=22 state=started delay=30 timeout=120
   become: false
-
-- name: give host some time to settle
-  local_action: pause seconds=30
-  become: false

--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -39,3 +39,7 @@
     wait_for host={{ real_ansible_host }}
     port=22 state=started delay=30 timeout=120
   become: false
+
+- name: give host some time to settle
+  local_action: pause seconds=15
+  become: false

--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -41,5 +41,5 @@
   become: false
 
 - name: give host some time to settle
-  local_action: pause seconds=15
+  local_action: pause seconds=30
   become: false


### PR DESCRIPTION
Now that we have a known working tree with the CAHC smoketested branch,
we can spin this around and use it to automatically test new additions
to the improved sanity tests.

Of course, if we're adding new tests that catch bugs that are already
present in the latest smoketested branch, the PR tester will fail. Thus,
this is not meant to be used with a merge bot, but rather a general
indication of how sane a PR is.