### PR TITLE
reboot: provide ability to check for started services after reboot

### DIFF
--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -39,3 +39,11 @@
     wait_for host={{ real_ansible_host }}
     port=22 state=started delay=30 timeout=120
   become: false
+
+# provide an empty iterator when a list is not provided
+# http://docs.ansible.com/ansible/playbooks_conditionals.html#loops-and-conditionals
+- name: check services have started
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items: "{{ services|default([]) }}"

--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -46,4 +46,4 @@
   service:
     name: "{{ item }}"
     state: started
-  with_items: "{{ services|default([]) }}"
+  with_items: "{{ wait_for_services|default([]) }}"

--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -2,5 +2,3 @@
 # provide an empty iterator when a list is not provided
 # http://docs.ansible.com/ansible/playbooks_conditionals.html#loops-and-conditionals
 - include: ../../../common/ans_reboot.yaml
-  vars:
-    services: "{{ wait_for_services|default([]) }}"

--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -1,2 +1,6 @@
 ---
+# provide an empty iterator when a list is not provided
+# http://docs.ansible.com/ansible/playbooks_conditionals.html#loops-and-conditionals
 - include: ../../../common/ans_reboot.yaml
+  vars:
+    services: "{{ wait_for_services|default([]) }}"

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -187,6 +187,8 @@
         - rpm_ostree_upgrade
 
     - role: reboot
+      wait_for_services:
+        - docker
       tags:
         - reboot
 
@@ -331,6 +333,8 @@
         - rpm_ostree_rollback
 
     - role: reboot
+      wait_for_services:
+        - docker
       tags:
         - reboot
 


### PR DESCRIPTION
Occasionally, we have seen instances where the `docker` daemon was not
starting quickly enough after a reboot, causing subsequent tasks to
fail.  This change attempts to mitigate that by introducing the ability to specify a list of
services to check when rebooting the host.

It's slightly messy because we have a `reboot` role and the
`ans_reboot.yaml` file that can be included.  So I went the
conservative route and made sure there were defaults specified for
both cases.

I've only changed the use of the `reboot` role in the
`improved-sanity-tests`.  Other places in that suite or in other tests
that reboot the host have not been changed.