### PR TITLE
docs: tidy up information regarding Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Atomic Host Tests
-This repo will contain a number of Ansible playbooks that can be used to run
+This repo contains a number of Ansible playbooks that can be used to run
 tests against an Atomic Host.
 
 The intent is to have a collection of tests that can be used to test the
@@ -9,6 +9,27 @@ Currently, these tests fall into the category of single host, integration tests.
 
 **NOTE**:  This repo only provides playbooks/tests and does not currently
 provide any way for provisioning test resources/infrastructure.
+
+### Supported Test Suites
+The following test suites are available and supported.  Any other playbooks
+found in the repo are currently unmaintained and may not work correctly.
+
+- [ostree admin unlock](tests/admin-unlock/main.yml)
+  - Verifies the ability to install packages using `ostree admin unlock`
+- [Docker Swarm](tests/docker-swarm/main.yml)
+  - Covers the basic functionality of the `docker swarm` commands
+- [Docker/Docker Latest](tests/docker/main.yml)
+  - Validates basic `docker` operations using either `docker` or `docker-latest`
+- [Improved Sanity Test](tests/improved-sanity-test/main.yml)
+  - A test suite aimed at providing smoketest-like coverage of an entire
+    Atomic Host
+- [Kubernetes ](tests/k8-cluster/main.yml)
+  - Validates standing up a single-node Kubernetes cluster and deploying a
+    simple web+DB application
+- [Package Layering](tests/pkg-layering)
+  - Validates the package layering functionality of `rpm-ostree`
+- [System Containers](tests/system-containers/main.yml)
+  - Verifies the basic usage of system containers on Atomic Host
 
 ### Why Ansible?
 The reasons for choosing Ansible playbooks are mainly 1) ease of use, 2)
@@ -38,26 +59,41 @@ Additionally, certain variables are required to be configured for each test and
 the required variables can vary between tests.  There are sensible defaults
 provided, but it is up to the user to configure them as they see fit.
 
-**NOTE** The playbooks originally added to the repo were tested using Ansible
-1.9.4, but we are beginning to adopt Ansible version 2 (or newer) for future
-tests.  See [Issue #28](https://github.com/projectatomic/atomic-host-tests/issues/28)
-for discussion.
+**NOTE**:  Playbooks are developed and tested using Ansible 2.1.  Ansible 2.2
+should also work, but it is not guaranteed.  Please do not use any version of
+Ansible earlier than 2.1.
 
-### Directory Layout
+### Vagrant
 
-**WARNING** The directory structure described below is in place for some of
-the first tests that were added to this repo.  However, newer tests have
-begun to adopt the OpenShift Ansible guidelines as described in
-[Issue #25](https://github.com/projectatomic/atomic-host-tests/issues/25).
-We will have to refactor the original tests to use these new guidelines in
-the future.
+You can see how the playbooks would run by using the supplied
+Vagrantfile which defines multiple boxes to test with. The Vagrantfile
+requires a 'vagrant-reload' plugin available from the following GitHub repo:
 
-The directory structure attempts to break out functionality into separate
-sub-directories where appropriate.  For example, the `common` directory has
-a set tasks that could be run anywhere and the `rhel` directory contains
-tasks would only be run on RHEL Atomic Host.
+https://github.com/aidanns/vagrant-reload
 
-The tests use `include:` to bring in tasks to the playbook rather than using
-roles.  This was done in hopes that re-use of tasks could be achieved rather
-than copying the same tasks into a role structure for each playbook.
+With the plugin installed, you should be able to choose a CentOS AH box, a
+Fedora 24/25 AH box, or a CentOS AH Continuous (CAHC) box.
 
+```
+$ vagrant up centos
+
+or
+
+$ vagrant up {fedora24|fedora25}
+
+or
+
+$ vagrant up cahc
+```
+
+By default, the Vagrantfile will run the `tests/improved-sanity-tests/main.yml`
+playbook after Vagrant completes the provisioning of the box.  The playbook
+which is run can be changed by setting the environment variable `PLAYBOOK_FILE`
+to point to a playbook in the repo.
+
+```
+$ PLAYBOOK_FILE=tests/docker-swarm/main.yml vagrant up cahc
+```
+
+**NOTE**: By default, the Vagrant boxes will provision HEAD-1 of the flavor of
+Atomic Host you want to bring up.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 # https://github.com/aidanns/vagrant-reload
 
 # This Vagrantfile defines multiple boxes that are tooled to test/run the
-# sanity playbook in 'tests/cach-sanity-test/main.yml'.
+# sanity playbook in 'tests/improved-sanity-test/main.yml'.
 #
 # Each box boots into the OS, deploys HEAD^ of a particular tree, then runs
 # the playbook (which currently includes upgrading to HEAD of the same tree).

--- a/tests/admin-unlock/README.md
+++ b/tests/admin-unlock/README.md
@@ -69,30 +69,3 @@ $ ansible-playbook -i inventory tests/admin-unlock/main.yml
 inventory file for that host.
 
 *NOTE*: This playbook must be run as a whole.  Do not run individual plays.
-
-#### Vagrant
-
-Alternatively, you can see how the playbook would run by using the supplied
-Vagrantfile which defines multiple boxes to test with. The Vagrantfile
-requires a 'vagrant-reload' plugin - see the Vagrantfile for additional
-information.
-
-With the plugin installed, you should be able to choose a CentOS AH box, a
-Fedora 24/25 AH box, or a CAHC box.
-
-```
-$ vagrant up centos
-
-or
-
-$ vagrant up fedora24
-
-or
-
-$ vagrant up fedora25
-
-or
-
-$ vagrant up cahc
-```
-

--- a/tests/docker-swarm/README.md
+++ b/tests/docker-swarm/README.md
@@ -33,26 +33,3 @@ $ ansible-playbook -i inventory tests/docker-swarm/main.yml
 
 *NOTE*: You are responsible for providing a host to run the test against and the
 inventory file for that host.
-
-#### Vagrant
-
-Alternatively, you can see how the playbook would run by using the supplied
-Vagrantfile which defines multiple boxes to test with. The Vagrantfile
-requires a 'vagrant-reload' plugin - see the Vagrantfile for additional
-information.
-
-With the plugin installed, you should be able to choose a CentOS AH box, a
-Fedora 23 AH box, or a CAHC box.
-
-```
-$ vagrant up centos
-
-or
-
-$ vagrant up fedora24
-
-or
-
-$ vagrant up cahc
-```
-

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -41,23 +41,3 @@ out-of-box release of docker, set g_docker_latest to false in [tests/docker/vars
 
 *NOTE*: You are responsible for providing a host to run the test against and the
 inventory file for that host.
-
-#### Vagrant
-
-Alternatively, you can see how the playbook would run by using the supplied
-Vagrantfile which defines multiple boxes to test with. The Vagrantfile
-requires a 'vagrant-reload' plugin - see the Vagrantfile for additional
-information.
-
-With the plugin installed, you should be able to choose a CentOS AH box,
-a CAHC box.
-
-```
-$ vagrant up centos
-```
-
-or
-
-```
-$ vagrant up cahc
-```

--- a/tests/improved-sanity-test/README.md
+++ b/tests/improved-sanity-test/README.md
@@ -37,25 +37,3 @@ $ ansible-playbook -i inventory tests/improved-sanity-test/main.yml
 
 *NOTE*: You are responsible for providing a host to run the test against and the
 inventory file for that host.
-
-#### Vagrant
-
-Alternatively, you can see how the playbook would run by using the supplied
-Vagrantfile which defines multiple boxes to test with. The Vagrantfile
-requires a 'vagrant-reload' plugin - see the Vagrantfile for additional
-information.
-
-With the plugin installed, you should be able to choose a CentOS AH box, a
-Fedora 24/25 AH box, or a CAHC box.
-
-```
-$ vagrant up centos
-
-or
-
-$ vagrant up {fedora24|fedora25}
-
-or
-
-$ vagrant up cahc
-```

--- a/tests/pkg-layering/README.md
+++ b/tests/pkg-layering/README.md
@@ -43,26 +43,3 @@ $ ansible-playbook -i inventory tests/pkg-layering/main.yml
 
 *NOTE*: You are responsible for providing a host to run the test against and the
 inventory file for that host.
-
-#### Vagrant
-
-Alternatively, you can see how the playbook would run by using the supplied
-Vagrantfile which defines multiple boxes to test with. The Vagrantfile
-requires a 'vagrant-reload' plugin - see the Vagrantfile for additional
-information.
-
-With the plugin installed, you should be able to choose a CentOS AH box, a
-Fedora 23 AH box, or a CAHC box.
-
-```
-$ vagrant up centos
-
-or
-
-$ vagrant up fedora23
-
-or
-
-$ vagrant up cahc
-```
-

--- a/tests/system-containers/README.md
+++ b/tests/system-containers/README.md
@@ -57,26 +57,3 @@ $ ansible-playbook -i inventory tests/system-containers/main.yml
 
 *NOTE*: You are responsible for providing a host to run the test against and the
 inventory file for that host.
-
-#### Vagrant
-
-Alternatively, you can see how the playbook would run by using the supplied
-Vagrantfile which defines multiple boxes to test with. The Vagrantfile
-requires a 'vagrant-reload' plugin - see the Vagrantfile for additional
-information.
-
-With the plugin installed, you should be able to choose a CentOS AH box, a
-Fedora 23 AH box, or a CAHC box.
-
-```
-$ vagrant up centos
-
-or
-
-$ vagrant up fedora23
-
-or
-
-$ vagrant up cahc
-```
-


### PR DESCRIPTION
I happened to notice that the READMEs that we include for each of the
test suites mention running `vagrant up` to execute the playbook.
This wasn't entirely correct, since the individual tests suites don't
have a Vagrantfile in their directory.

So I removed that section from the READMEs and cleaned up the top
README to explain how to run different playbooks using the included
Vagrantfile.

Additionally, I tried to clean up the top-level README to be more
useful and correct.