### PR TITLE
add a test for rhbz 1421867

### DIFF
--- a/roles/atomic_host_status_verify/tasks/main.yml
+++ b/roles/atomic_host_status_verify/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # vim: set ft=ansible:
 #
+- name: Optionally stop the rpm-ostree daemon
+  service:
+    name: rpm-ostreed
+    state: stopped
+  when:
+    - stop_daemon is defined
+    - stop_daemon
+
 - name: Run atomic host status
   command: atomic host status
   register: ahs

--- a/roles/redhat_unsubscribe/tasks/main.yml
+++ b/roles/redhat_unsubscribe/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+# vim: set ft=ansible:
+#
+# NOTE: This role should only be used on RHEL systems
+#
+# We get the neccessary info to insert the 'unconfigured-state' field into the origin
+# file only when we need to.  Otherwise, we just use the sub-man command to remove
+# all the subscriptions.
+#
+- block:
+  - name: Get the current commit to find the correct origin file to manipulate later...
+    command: rpm-ostree status --json
+    register: rpm_output
+
+  - name: Convert deployment information into jinja2 json
+    set_fact:
+      json: "{{ rpm_output.stdout|from_json }}"
+
+  - name: Set version and commit if deployment 0 is booted
+    set_fact:
+      booted_commit: "{{ json['deployments'][0]['checksum'] }}"
+    when: json['deployments'][0] is defined and json['deployments'][0]['booted']
+
+  - name: Set version and commit if deployment 1 is booted
+    set_fact:
+      booted_commit: "{{ json['deployments'][1]['checksum'] }}"
+    when: json['deployments'][1] is defined and json['deployments'][1]['booted']
+  when:
+    - unconfigured_state is defined
+    - unconfigured_state
+
+- name: Remove all subscriptions
+  command: subscription-manager remove --all
+
+- name: Insert 'unconfigured-state' field
+  lineinfile:
+    dest: /ostree/deploy/rhel-atomic-host/deploy/{{ booted_commit }}.0.origin
+    line: 'unconfigured-state=This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.'
+    insertafter: EOF
+  when:
+    - unconfigured_state is defined
+    - unconfigured_state

--- a/roles/redhat_unsubscribe/tasks/main.yml
+++ b/roles/redhat_unsubscribe/tasks/main.yml
@@ -29,8 +29,16 @@
     - unconfigured_state is defined
     - unconfigured_state
 
-- name: Remove all subscriptions
+# we've seen the remove command return 70 even though it was successful
+- name: Remove all subscriptions locally
   command: subscription-manager remove --all
+  register: subman_remove
+  failed_when:
+    - subman_remove.rc != 0
+    - subman_remove.rc != 70
+
+- name: Unregister from remote service
+  command: subscription-manager unregister
 
 - name: Insert 'unconfigured-state' field
   lineinfile:

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -220,6 +220,7 @@
         - redhat_unsubscribe
 
     - role: atomic_host_status_verify
+      stop_daemon: true
       tags:
         - atomic_host_status_verify
 

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -44,6 +44,10 @@
       tags:
         - atomic_host_check
 
+    - role: atomic_host_status_verify
+      tags:
+        - atomic_host_status_verify
+
     - role: selinux_verify
       tags:
         - selinux_verify
@@ -123,10 +127,6 @@
     - role: osname_set_fact
       tags:
         - osname_set_fact
-
-    - role: atomic_host_status_verify
-      tags:
-        - atomic_host_status_verify
 
     - role: atomic_pull_verify
       tags:
@@ -209,6 +209,24 @@
     - role: atomic_host_check
       tags:
         - atomic_host_check
+
+    # we remove any subscriptions after the upgrade to verify that
+    # 'rpm-ostree status' with the 'unconfigured-state' field present.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1421867
+    - role: redhat_unsubscribe
+      unconfigured_state: true
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe
+
+    - role: atomic_host_status_verify
+      tags:
+        - atomic_host_status_verify
+
+    - role: redhat_subscription
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_subscribe
 
     - role: selinux_verify
       tags:
@@ -297,11 +315,6 @@
     - role: docker_rmi_httpd_image
       tags:
         - docker_rmi_httpd_image
-
-    # Re-run atomic tests
-    - role: atomic_host_status_verify
-      tags:
-        - atomic_host_status_verify
 
     - role: docker_remove_all
       tags:
@@ -403,3 +416,9 @@
 
     # Verify the most recent changes to /var are present
     - { role: var_files_present, vfp_filename: "{{ g_file2 }}", vfp_dirname: "{{ g_dir2 }}", tags: ['var_files_present'] }
+
+    # cleanup our subscriptions because we are nice people
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe


### PR DESCRIPTION
Our internal testing found that trying to use `rpm-ostree status` on a
RHELAH host that was not registered via `subscription-manager` would
fail. See [RHBZ
1421867](https://bugzilla.redhat.com/show_bug.cgi?id=1421867)

To test for this, I've re-arranged when we use `rpm-ostree status` and
added a role that removes any subscriptions from a host and drops an
`unconfigured-state` field into the origin file (optionally).