### PR TITLE
expand SELinux tests

### DIFF
--- a/roles/selinux_boolean/tasks/main.yml
+++ b/roles/selinux_boolean/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# vim: set ft=ansible
+#
+- name: Fail if 'g_seboolean' is not defined
+  fail:
+    msg: "The variable 'g_seboolean' is undefined"
+  when: g_seboolean is undefined
+
+- name: Modify an SELinux Boolean
+  seboolean:
+    name: "{{ g_seboolean }}"
+    persistent: yes
+    state: yes

--- a/roles/selinux_boolean_verify/tasks/main.yml
+++ b/roles/selinux_boolean_verify/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# vim: set ft=ansible
+#
+- name: Fail if 'g_seboolean' is undefined
+  fail:
+    msg: "The variable 'g_seboolean' is undefined"
+  when: g_seboolean is undefined
+
+- name: Verify that the SELinux Boolean is correct
+  command: "getsebool {{ g_seboolean }}"
+  register: seboolean
+  failed_when: "'off' in seboolean.stdout"

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
 # vim: set ft=ansible:
 #
+- name: Fail if required variables are not defined
+  fail:
+    msg: "The required variables are not defined.  Check roles/selinux_verify/vars/main.yml"
+  when: etc_files is undefined or
+        mountpoints is undefined or
+        services is undefined
+
 - name: Check if getfattr installed
   stat:
     path: /usr/bin/getfattr
@@ -11,19 +18,92 @@
     msg: "The getfattr utility is not installed"
   when: getfattr.stat.exists == False
 
-- name: Verify that the SELinux context is correct on ostree/rpm-ostree
-  command: getfattr -n security.selinux {{ item }} --absolute-names --only-values
-  register: selinux_context
-  failed_when: "'install_exec_t' not in selinux_context.stdout"
-  with_items:
-    - /usr/bin/ostree
-    - /usr/bin/rpm-ostree
-    - /usr/libexec/rpm-ostreed
+  # I'm both proud and embarrassed about what I've done here.  This is peak
+  # "Ansible abuse".  Please don't do this.
+  #
+  # I discovered a handy iterator 'with_subelements' that lets you iterate over
+  # a hash/dict and then iterates on a list found in a key of the dict. See the
+  # following bit of docs:
+  #
+  # http://docs.ansible.com/ansible/playbooks_loops.html#looping-over-subelements
+  #
+  # This allowed me to use a simple data structure (really just a variable) in
+  # 'roles/selinux_verify/vars/main.yml' to track files/procs/labels for different
+  # services.
+  #
+  # After getting the results for each 'service', I had to figure a way to compare
+  # the labels in the data structure to what was found in the output of the command.
+  #
+  # I happened to notice that each item in the 'results' variable contained a key
+  # named 'item' that is the original data structure which was used for the original
+  # 'command' invocation.  This allowed me to pull out the 'file_label' value from
+  # the original data structure and compare it to what was in stdout.
+  #
+  # http://docs.ansible.com/ansible/playbooks_loops.html#using-register-with-a-loop
+  #
+  # This type of abuse is continued for the inspection of SELinux process labels and
+  # /etc/ file labels
+  #
+- name: Retrieve the SELinux file labels
+  command: getfattr -n security.selinux {{ item.1 }} --absolute-names --only-values
+  register: selinux_file_labels
+  with_subelements:
+    - "{{ services }}"
+    - files
+
+- name: Verify SELinux file labels are correct
+  fail:
+    msg: "The file {{ item.item.1 }} did not have the correct SELinux file label"
+  when: item.item.0.file_label not in item.stdout
+  with_items: "{{ selinux_file_labels.results }}"
 
 - name: Run 'rpm-ostree status' to start daemon
   command: rpm-ostree status
 
-- name: Verify SELinux label is correct on rpm-ostreed process
-  shell: ps --no-headers -o label -q $(systemctl show -p MainPID rpm-ostreed | sed -e s,MainPID=,,) 
-  register: selinux_label
-  failed_when: "'install_t' not in selinux_label.stdout"
+- name: Retrieve SELinux process labels
+  shell: ps --no-headers -o label -q $(systemctl show -p MainPID {{ item.1|quote }} | sed -e s,MainPID=,,)
+  register: selinux_proc_labels
+  with_subelements:
+    - "{{ services }}"
+    - procs
+
+- name: Verify SELinux process labels are correct
+  fail:
+    msg: "The process {{ item.item.1 }} did not have the correct SELinux process label"
+  when: item.item.0.proc_label not in item.stdout
+  with_items: "{{ selinux_proc_labels.results }}"
+
+- name: Look for files/dirs with 'default_t' label
+  command: find {{ item }} -context '*:default_t:*'
+  register: find_default_t
+  with_items: "{{ mountpoints }}"
+
+- name: Fail if a file/dir is found with 'default_t' label
+  fail:
+    msg: "The file {{ item.item }} had an SELinux label of 'default_t'"
+  when: "{{ item.stdout | length }} != 0"
+  with_items: "{{ find_default_t.results }}"
+
+- name: Look for files/dir with 'file_t' label
+  command: find {{ item }} -context '*:file_t:*'
+  register: find_file_t
+  with_items: "{{ mountpoints }}"
+
+- name: Fail if a file is found with the 'file_t' label
+  fail:
+    msg: "The file {{ item.item }} had an SELinux label of 'file_t'"
+  when: "{{ item.stdout | length }} != 0"
+  with_items: "{{ find_file_t.results }}"
+
+- name: Retrieve the SELinux file labels for key /etc files
+  command: getfattr -n security.selinux {{ item.1 }} --absolute-names --only-values
+  register: etc_file_labels
+  with_subelements:
+    - "{{ etc_files }}"
+    - files
+
+- name: Verify key /etc SELinux file labels are correct
+  fail:
+    msg: "The file {{ item.item.1 }} did not have the correct SELinux file label"
+  when: item.item.0.label not in item.stdout
+  with_items: "{{ etc_file_labels.results }}"

--- a/roles/selinux_verify/vars/main.yml
+++ b/roles/selinux_verify/vars/main.yml
@@ -1,0 +1,75 @@
+---
+etc_files:
+  - name: net_conf
+    files:
+      - '/etc/hosts'
+      - '/etc/hosts.allow'
+      - '/etc/hosts.deny'
+    label: 'system_u:object_r:net_conf_t:s0'
+
+  - name: passwd
+    files:
+      - '/etc/group'
+      - '/etc/group-'
+      - '/etc/passwd'
+      - '/etc/passwd-'
+    label: 'system_u:object_r:passwd_file_t:s0'
+
+  - name: shadow
+    files:
+      - '/etc/gshadow'
+      - '/etc/gshadow-'
+      - '/etc/shadow'
+      - '/etc/shadow-'
+    label: 'system_u:object_r:shadow_t:s0'
+
+mountpoints:
+  - '/boot'
+  - '/sysroot'
+  - '/usr'
+  - '/var'
+
+services:
+  - name: docker
+    # This is the intersection of the three sets of files provided by the
+    # docker and docker-common packages per distro.  I used:
+    #
+    # $ rpm -qf docker docker-common | grep -E 'bin|libexec'
+    #
+    # ...to generate the lists.
+    files:
+      - '/usr/bin/docker'
+      - '/usr/bin/dockerd-current'
+      - '/usr/bin/docker-storage-setup'
+      - '/usr/libexec/docker/docker-proxy-current'
+      - '/usr/libexec/docker/docker-runc-current'
+    file_label: 'system_u:object_r:container_runtime_exec_t:s0'
+    procs:
+      - 'docker'
+    proc_label: 'system_u:system_r:container_runtime_t:s0'
+
+  - name: NetworkManager
+    files:
+      - '/usr/sbin/NetworkManager'
+    file_label: 'system_u:object_r:NetworkManager_exec_t:s0'
+    procs:
+      - 'NetworkManager'
+    proc_label: 'system_u:system_r:NetworkManager_t:s0'
+
+  - name: rpm-ostree
+    files:
+      - '/usr/bin/ostree'
+      - '/usr/bin/rpm-ostree'
+      - '/usr/libexec/rpm-ostreed'
+    file_label: 'system_u:object_r:install_exec_t:s0'
+    procs:
+      - 'rpm-ostreed'
+    proc_label: 'system_u:system_r:install_t:s0'
+
+  - name: sshd
+    files:
+      - '/usr/sbin/sshd'
+    file_label: 'system_u:object_r:sshd_exec_t:s0'
+    procs:
+      - 'sshd'
+    proc_label: 'system_u:system_r:sshd_t:s0-s0'

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -56,6 +56,10 @@
       tags:
         - semanage_add_verify
 
+    - role: selinux_boolean
+      tags:
+        - selinux_boolean
+
     # Subscribe if the system is RHEL
     - role: redhat_subscription
       when: ansible_distribution == 'RedHat'
@@ -236,6 +240,10 @@
     - role: semanage_add_verify
       tags:
         - semanage_add_verify
+
+    - role: selinux_boolean_verify
+      tags:
+        - selinux_boolean_verify
 
     - role: docker_pull_run_remove
       tags:

--- a/tests/improved-sanity-test/vars.yml
+++ b/tests/improved-sanity-test/vars.yml
@@ -8,3 +8,4 @@ g_dir2: 'qe2'
 g_hostname: 'myhostname'
 g_rpm_name: "fpaste"
 g_pkg: "wget"
+g_seboolean: "virt_use_nfs"


### PR DESCRIPTION
This commit expands the scope of our SELinux checks to include the
validation of the SELinux labels on multiple key processes and files.

It also checks that any files on the filesystem do not have the
default labels `default_t` or `file_t`.

Finally, it includes a simple test to validate that changes made
to an SELinux boolean will persist through the upgrade/reboot cycle.
This particular test covers [RHBZ#1381588](https://bugzilla.redhat.com/show_bug.cgi?id=1381588)