### PR TITLE
Utilize ignore errors when saving failure

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -74,7 +74,8 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
 
     def v2_runner_on_failed(self,result, ignore_errors=False):
         '''Save last failure'''
-        self.failed_task = result
+        if ignore_errors is False:
+            self.failed_task = result
 
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
         if 'exception' in result._result:


### PR DESCRIPTION
The code was capturing all failures including ones that are purposely
ignored in the playbook. I changed it so it would respect ignore
errors and only save the actual failure.