### PR TITLE
Handle None case for ignore_errors

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -74,7 +74,7 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
 
     def v2_runner_on_failed(self,result, ignore_errors=False):
         '''Save last failure'''
-        if ignore_errors is False:
+        if ignore_errors is not True:
             self.failed_task = result
 
         delegated_vars = result._result.get('_ansible_delegated_vars', None)


### PR DESCRIPTION
ignore_errors is set to None when it is passed into v2_runner_on_failed
which will not capture any failures except when the calling function
does not pass an ignore_errors parameter.  I swapped it to capture the
failure in all cases except when ignore_errors is explicitly set to
true.