### PR TITLE
Skip the SELinux tests temporarily

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -12,4 +12,4 @@ packages:
 
 tests:
   - ansible-playbook -vi testnode, common/ans_ah_head-1_deploy.yml
-  - ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml
+  - ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml --skip-tags selinux_verify


### PR DESCRIPTION
We know that the SELinux tests are going to fail because of the
following [RHBZ#1381588](https://bugzilla.redhat.com/show_bug.cgi?id=1381588)

So we will skip them for now.