### PR TITLE
Re-enable SELinux tests

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -12,4 +12,4 @@ packages:
 
 tests:
   - ansible-playbook -vi testnode, common/ans_ah_head-1_deploy.yml
-  - ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml --skip-tags selinux_verify
+  - ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -78,13 +78,11 @@
   register: find_default_t
   with_items: "{{ mountpoints }}"
 
-# Until RHBZ #1381588 is fixed, we are commenting out this test rather than
-# excluding the whole role from being run by various executors.
-#- name: Fail if a file/dir is found with 'default_t' label
-#  fail:
-#    msg: "The file {{ item.item }} had an SELinux label of 'default_t'"
-#  when: "{{ item.stdout | length }} != 0"
-#  with_items: "{{ find_default_t.results }}"
+- name: Fail if a file/dir is found with 'default_t' label
+  fail:
+    msg: "The file {{ item.item }} had an SELinux label of 'default_t'"
+  when: "{{ item.stdout | length }} != 0"
+  with_items: "{{ find_default_t.results }}"
 
 - name: Look for files/dir with 'file_t' label
   command: find {{ item }} -context '*:file_t:*'

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -78,11 +78,13 @@
   register: find_default_t
   with_items: "{{ mountpoints }}"
 
-- name: Fail if a file/dir is found with 'default_t' label
-  fail:
-    msg: "The file {{ item.item }} had an SELinux label of 'default_t'"
-  when: "{{ item.stdout | length }} != 0"
-  with_items: "{{ find_default_t.results }}"
+# Until RHBZ #1381588 is fixed, we are commenting out this test rather than
+# excluding the whole role from being run by various executors.
+#- name: Fail if a file/dir is found with 'default_t' label
+#  fail:
+#    msg: "The file {{ item.item }} had an SELinux label of 'default_t'"
+#  when: "{{ item.stdout | length }} != 0"
+#  with_items: "{{ find_default_t.results }}"
 
 - name: Look for files/dir with 'file_t' label
   command: find {{ item }} -context '*:file_t:*'

--- a/roles/selinux_verify/vars/main.yml
+++ b/roles/selinux_verify/vars/main.yml
@@ -23,9 +23,11 @@ etc_files:
       - '/etc/shadow-'
     label: 'system_u:object_r:shadow_t:s0'
 
+
+# Until RHBZ #1381588 is fixed, we are removing the `/sysroot` entry from
+# this list.
 mountpoints:
   - '/boot'
-  - '/sysroot'
   - '/usr'
   - '/var'
 


### PR DESCRIPTION
Rather than configure all the executors of the tests to skip an entire
role, we'll just comment out the failing part of the role until the
necessary bug ([RHBZ #1381588](https://bugzilla.redhat.com/show_bug.cgi?id=1381588)) is fixed.