### PR TITLE
Separate reboot from rpm-ostree install

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -96,9 +96,14 @@
     # Install package using package layering
     - role: rpm_ostree_install
       packages: "{{ g_pkg }}"
-      reboot: true
+      reboot: false
       tags:
         - rpm_ostree_install
+        - cloud_image
+
+    - role: reboot
+      tags:
+        - reboot
         - cloud_image
 
     - role: rpm_ostree_install_verify


### PR DESCRIPTION
Eliminating the -r flag will make errors easier to triage on rpm-ostree
install failures.