### PR TITLE
Change to more complex rpm-ostree install package

### DIFF
--- a/roles/httpd_start/tasks/main.yml
+++ b/roles/httpd_start/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# vim: set ft=ansible:
+#
+# configures httpd port and starts service
+#
+- name: Change port in http conf file
+  replace:
+    dest: /etc/httpd/conf/httpd.conf
+    regexp: '^Listen 80$'
+    replace: 'Listen {{ port }}'
+  when: port is defined
+
+- name: Start httpd
+  service:
+    name: httpd
+    state: started

--- a/roles/rpm_ostree_install_verify/tasks/main.yml
+++ b/roles/rpm_ostree_install_verify/tasks/main.yml
@@ -7,7 +7,7 @@
 #  that the binary is available by using which.
 #
 # Parameter:
-#   package - list of name of a single package
+#   package - name of a single package
 #
 # Requirements:
 #  Package must install a binary that is the same as the package name

--- a/roles/url_verify/tasks/main.yml
+++ b/roles/url_verify/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# vim: set ft=ansible:
+#
+# Retrieves a URL to a destination
+#
+- name: Fail if url or destination is undefined
+  fail:
+    msg: "url or destination is undefined"
+  when: url is undefined or destination is undefined
+
+- name: Get URI {{ url }}
+  get_url:
+    url: "{{ url }}"
+    dest: "{{ destination }}"

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -96,15 +96,33 @@
     # Install package using package layering
     - role: rpm_ostree_install
       packages: "{{ g_pkg }}"
-      reboot: true
+      reboot: false
       tags:
         - rpm_ostree_install
+        - cloud_image
+
+    - role: reboot
+      tags:
+        - reboot
         - cloud_image
 
     - role: rpm_ostree_install_verify
       package: "{{ g_pkg }}"
       tags:
         - rpm_ostree_install_verify
+        - cloud_image
+
+    - role: httpd_start
+      port: 8080
+      tags:
+        - httpd_start
+        - cloud_image
+
+    - role: url_verify
+      url: http://localhost:8080
+      destination: /dev/null
+      tags:
+        - url_verify
         - cloud_image
 
     # Verify admin unlock by installing an RPM
@@ -335,6 +353,19 @@
       package: "{{ g_pkg }}"
       tags:
         - rpm_ostree_install_verify
+        - cloud_image
+
+    - role: httpd_start
+      port: 8080
+      tags:
+        - httpd_start
+        - cloud_image
+
+    - role: url_verify
+      url: http://localhost:8080
+      destination: /dev/null
+      tags:
+        - url_verify
         - cloud_image
 
     # Check admin unlock overlayfs is no longer there after upgrade

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -99,31 +99,15 @@
       reboot: false
       tags:
         - rpm_ostree_install
-        - cloud_image
 
     - role: reboot
       tags:
         - reboot
-        - cloud_image
 
     - role: rpm_ostree_install_verify
       package: "{{ g_pkg }}"
       tags:
         - rpm_ostree_install_verify
-        - cloud_image
-
-    - role: httpd_start
-      port: 8080
-      tags:
-        - httpd_start
-        - cloud_image
-
-    - role: url_verify
-      url: http://localhost:8080
-      destination: /dev/null
-      tags:
-        - url_verify
-        - cloud_image
 
     # Verify admin unlock by installing an RPM
     - role: ostree_admin_unlock_hotfix
@@ -353,7 +337,30 @@
       package: "{{ g_pkg }}"
       tags:
         - rpm_ostree_install_verify
+
+    - role: rpm_ostree_install
+      packages: httpd
+      reboot: false
+      tags:
+        - rpm_ostree_install
         - cloud_image
+
+    - role: reboot
+      tags:
+        - reboot
+        - cloud_image
+
+    - role: rpm_ostree_install_verify
+      package: "{{ g_pkg }}"
+      tags:
+        - rpm_ostree_install_verify
+
+    - role: rpm_ostree_install_verify
+      package: httpd
+      tags:
+        - rpm_ostree_install_verify
+        - cloud_image
+      always_run: yes
 
     - role: httpd_start
       port: 8080
@@ -517,16 +524,16 @@
       tags:
         - rpm_ostree_install_verify
 
-    # Check admin unlock overlayfs still present
-    - role: overlayfs_verify_present
+    # Check http package is not installed
+    - role: rpm_ostree_uninstall_verify
+      package: httpd
       tags:
-        - overlayfs_verify_present
+        - rpm_ostree_uninstall_verify
 
-    # Verify admin unlocked package still installed
-    - role: package_verify_present
-      rpm_name: "{{ g_rpm_name }}"
+    # Check admin unlock overlayfs missing
+    - role: overlayfs_verify_missing
       tags:
-        - package_verify_present
+        - overlayfs_verify_missing
 
     # Check that /tmp is properly setup yet again
     - role: tmp_check_perms

--- a/tests/improved-sanity-test/vars.yml
+++ b/tests/improved-sanity-test/vars.yml
@@ -7,5 +7,5 @@ g_file2: 'commit2'
 g_dir2: 'qe2'
 g_hostname: 'myhostname'
 g_rpm_name: "fpaste"
-g_pkg: "wget"
+g_pkg: "httpd"
 g_seboolean: "virt_use_nfs"

--- a/tests/improved-sanity-test/vars.yml
+++ b/tests/improved-sanity-test/vars.yml
@@ -7,5 +7,5 @@ g_file2: 'commit2'
 g_dir2: 'qe2'
 g_hostname: 'myhostname'
 g_rpm_name: "fpaste"
-g_pkg: "httpd"
+g_pkg: "wget"
 g_seboolean: "virt_use_nfs"


### PR DESCRIPTION
A new feature was added to allow non-root packages to be layered
using rpm-ostree install.  Instead of using a simple package like
wget, the httpd package  tests a broader code path because it has
multiple dependencies, creates an apache user, and is a non root
package.

The default settings for httpd conflicted with the docker container
tests in improved sanity tests so it was changed to port 8080 in the
httpd_start role.  The httpd service is validated by retrieving the
default apache page.
