### PR TITLE
Small fixes for Ansible 2.2 support

### DIFF
--- a/roles/atomic_host_check/tasks/main.yml
+++ b/roles/atomic_host_check/tasks/main.yml
@@ -11,7 +11,7 @@
     path: "/run/ostree-booted"
   register: s
   changed_when: false
-  always_run: yes
+  check_mode: no
 
 - name: Init the is_atomic fact
   set_fact:

--- a/roles/httpd_start/tasks/main.yml
+++ b/roles/httpd_start/tasks/main.yml
@@ -7,8 +7,8 @@
   replace:
     dest: /etc/httpd/conf/httpd.conf
     regexp: '^Listen 80$'
-    replace: 'Listen {{ port }}'
-  when: port is defined
+    replace: 'Listen {{ httpd_port }}'
+  when: httpd_port is defined
 
 - name: Start httpd
   service:

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -299,13 +299,13 @@
       tags:
         - atomic_host_check
 
-    # Setup facts again. (Need to use the 'always_run' option to ensure the
+    # Setup facts again. (Need to use the 'check_mode: no' option to ensure the
     # role runs again)
     - role: osname_set_fact
       tags:
         - osname_set_fact
         - cloud_image
-      always_run: yes
+      check_mode: no
 
     # We remove any subscriptions after the upgrade to verify that
     # 'rpm-ostree status' with the 'unconfigured-state' field present.
@@ -378,10 +378,10 @@
       tags:
         - rpm_ostree_install_verify
         - cloud_image
-      always_run: yes
+      check_mode: no
 
     - role: httpd_start
-      port: 8080
+      httpd_port: 8080
       tags:
         - httpd_start
         - cloud_image


### PR DESCRIPTION
When running playbooks that use the `always_run` option¸ Ansible 2.2
will print a deprecation warning that states that users should switch
to `check_mode: no` instead.

Additionally, another warning is printed about using `port` as a
parameter to role.  The offending role was `httpd_start` and it was
updated to use a different parameter name.