### PR TITLE
Move 'atomic scan' tests ahead of 'ostree admin unlock'

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -102,6 +102,30 @@
         - docker_pull_run_remove
         - cloud_image
 
+    # Validate 'atomic pull', 'atomic scan' works correctly.
+    # Remove images after test of each command.
+    # Do this ahead of 'ostree admin unlock' because of overlay + SELinux
+    # incompatibility on RHEL. (This should be fixed in 7.4)
+    - role: atomic_pull_verify
+      tags:
+        - atomic_pull_verify
+        - cloud_image
+
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+        - cloud_image
+
+    - role: atomic_scan_verify
+      tags:
+        - atomic_scan_verify
+        - cloud_image
+
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+        - cloud_image
+
     # Install package using package layering
     - role: rpm_ostree_install
       packages: "{{ g_pkg }}"
@@ -194,28 +218,6 @@
       vfp_dirname: "{{ g_dir1 }}"
       tags:
         - var_files_present
-        - cloud_image
-
-    # Validate 'atomic pull', 'atomic scan' works correctly.
-    # Remove images after test of each command.
-    - role: atomic_pull_verify
-      tags:
-        - atomic_pull_verify
-        - cloud_image
-
-    - role: docker_remove_all
-      tags:
-        - docker_remove_all
-        - cloud_image
-
-    - role: atomic_scan_verify
-      tags:
-        - atomic_scan_verify
-        - cloud_image
-
-    - role: docker_remove_all
-      tags:
-        - docker_remove_all
         - cloud_image
 
     # Pull down docker base images, build a layered image, run it, then


### PR DESCRIPTION
We have been seeing multiple failures during the `atomic scan` tests
because of an incompatibility between overlay mounts and SELinux.
This won't be fully fixed until RHEL 7.4 ships, so we'll just work
around it for now.