### PR TITLE
Fix metadata cache generation for RHEL case

### DIFF
--- a/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
@@ -6,9 +6,9 @@ LABEL RUN="docker run -d --name NAME -p 80:80 IMAGE"
 
 ENV container docker
 
-ADD makecache.sh /
+ADD rhel_makecache.sh /
 
-RUN /makecache.sh && \
+RUN /rhel_makecache.sh && \
     yum install --disablerepo=\* \
                 --enablerepo=rhel-7-server-rpms \
                 -y httpd && \

--- a/roles/docker_build_httpd/files/rhel_makecache.sh
+++ b/roles/docker_build_httpd/files/rhel_makecache.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xeou pipefail
+retries=5
+while [ $retries -gt 0 ]; do
+	if yum --disablerepo=\* --enablerepo=rhel-7-server-rpms makecache; then
+		break
+	fi
+	retries=$((retries - 1))
+done
+

--- a/roles/docker_build_httpd/tasks/main.yml
+++ b/roles/docker_build_httpd/tasks/main.yml
@@ -34,6 +34,16 @@
     owner: root
     group: root
     mode: 0744
+  when: ansible_distribution != 'RedHat'
+
+- name: Copy rhel_makecache.sh to temp directory
+  copy:
+    src: rhel_makecache.sh
+    dest: "{{ build_dir }}"
+    owner: root
+    group: root
+    mode: 0744
+  when: ansible_distribution == 'RedHat'
 
 - name: Build httpd image
   command: "docker build -t {{ g_httpd_name }} -f {{ build_dir }}/{{ g_httpd_name }}_Dockerfile {{ build_dir }}"


### PR DESCRIPTION
We have seen instances on RHEL hosts where the `makecache.sh` script
inside the `docker build` process tries to generate the cache for every
repo a subscription provides.  Not only is this costly in terms of
time required to generate the cache, but it is also incorrect since we
explicitly disable all the repos and re-enable only those we care about
during the subscription phase.

To work around this, a copy of the `makecache.sh` script was made with
RHEL specific instructions to use only certain repos.