### PR TITLE
Add status table to repo landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+Stream | Version/Status | Log File
+:--- | :--- | :---:
+Centos Atomic Host Continuous | ![cahc status](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/cahc/latest/status.png) | [log](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/cahc/latest/improved-sanity-test.log)
+Fedora Atomic Host Continuous | ![fahc status](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fahc/latest/status.png) | [log](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fahc/latest/improved-sanity-test.log)
+Fedora 24 Atomic Host | ![fedora 24 atomic status](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-24-atomic/latest/status.png) | [log](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-24-atomic/latest/improved-sanity-test.log)
+Fedora 25 Atomic Host | ![fedora 25 atomic status](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-25-atomic/latest/status.png) | [log](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-25-atomic/latest/improved-sanity-test.log)
+Fedora 25 Atomic Testing| ![fedora 25 atomic testing status](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-25-atomic-testing/latest/status.png) | [log](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-25-atomic-testing/latest/improved-sanity-test.log)
+Fedora 25 Atomic Updates | ![fedora 25 atomic updates status](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-25-atomic-updates/latest/status.png) | [log](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-25-atomic-updates/latest/improved-sanity-test.log)
+Fedora 26 Atomic Host | ![fedora 26 atomic status](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-26-atomic/latest/status.png) | [log](https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fedora-26-atomic/latest/improved-sanity-test.log)
+
+---
+
 # Atomic Host Tests
 This repo contains a number of Ansible playbooks that can be used to run
 tests against an Atomic Host.


### PR DESCRIPTION
This commit adds a status table of the latest improved sanity test
runs for the streams we test.  It uses shields.io badges containing
the version and result of the test run.  The badges are not directly
from shields.io, instead badges and logs are saved in a s3 bucket.