### PR TITLE
Handle unreachable scenario in callback plugin

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -71,6 +71,18 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
 
         return output
 
+    def v2_runner_on_unreachable(self, result):
+        self.failed_task = result
+
+        if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        if delegated_vars:
+            self._display.display("fatal: [%s -> %s]: UNREACHABLE! => %s" % (result._host.get_name(), delegated_vars['ansible_host'], self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
+        else:
+            self._display.display("fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
+
     def v2_runner_on_failed(self,result, ignore_errors=False):
         '''Save last failure'''
         if ignore_errors is not True:


### PR DESCRIPTION
Captures the unreachable message in the result array when there is
a connection error while running a playbook.