### PR TITLE
Add additional tests for package layering

### DIFF
--- a/roles/rpm_ostree_uninstall_verify/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall_verify/tasks/main.yml
@@ -28,6 +28,9 @@
   set_fact:
     installed_json: "{{ installed.stdout | from_json }}"
 
+# This is a hack for packages being displayed in rpm-ostree v2017.3 that should
+# be fixed in v2017.4.  Once all streams are at v2017.4 we can fix this.  See
+# https://github.com/projectatomic/rpm-ostree/pull/670
 - name: Set packages when deployment 0 is booted
   set_fact:
     installed_pkgs: "{{ installed_json['deployments'][0]['packages'] if installed_json['deployments'][0]['packages'] is defined else {} }}"

--- a/roles/rpm_ostree_uninstall_verify/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall_verify/tasks/main.yml
@@ -30,13 +30,13 @@
 
 - name: Set packages when deployment 0 is booted
   set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][0]['packages'] }}"
-  when: installed_json['deployments'][0]['packages'] is defined and installed_json['deployments'][0]['booted']
+    installed_pkgs: "{{ installed_json['deployments'][0]['packages'] if installed_json['deployments'][0]['packages'] is defined else {} }}"
+  when: installed_json['deployments'][0]['booted']
 
 - name: Set packages when deployment 1 is booted
   set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][1]['packages'] }}"
-  when: installed_json['deployments'][1]['packages'] is defined and installed_json['deployments'][1]['booted']
+    installed_pkgs: "{{ installed_json['deployments'][1]['packages'] if installed_json['deployments'][1]['packages'] is defined else {} }}"
+  when:  installed_json['deployments'][1]['booted']
 
 - name: Fail if packages not found in rpm-ostree status output
   fail:

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -321,7 +321,7 @@
       when: "'No package' not in nonexist.stderr"
 
 
-- name: Package Layering - Negative Test - Installing existing package
+- name: Package Layering - Installing existing package
   hosts: all
   become: yes
 
@@ -334,13 +334,31 @@
   tasks:
     - name: Attempt to install package that is already in the deployment
       command: rpm-ostree install {{ g_deployed_pkg }}
-      register: already
-      failed_when: already.rc != 1
 
-    - name: Fail if error message is incorrect
+    - include: '../../common/ans_reboot.yml'
+
+    - name: Get rpm-ostree status --json output
+      command: rpm-ostree status --json
+      register: req
+
+    - name: Convert rpm-ostree status output to jinja2 json
+      set_fact:
+        req_json: "{{ req.stdout | from_json }}"
+
+    - name: Set packages when deployment 0 is booted
+      set_fact:
+        req_pkgs: "{{ req_json['deployments'][0]['requested-packages'] if req_json['deployments'][0]['requested-packages'] is defined else {} }}"
+      when: req_json['deployments'][0]['booted']
+
+    - name: Set packages when deployment 1 is booted
+      set_fact:
+        req_pkgs: "{{ req_json['deployments'][1]['requested-packages'] if req_json['deployments'][1]['requested-packages'] is defined else {} }}"
+      when:  req_json['deployments'][1]['booted']
+
+    - name: Fail if {{ g_deployed_pkg }} is not in requested packages
       fail:
-        msg: "Error is incorrect"
-      when: "'package \\'{{ g_deployed_pkg }}\\' is already in the deployment' not in already.stderr"
+        msg: "{{ g_deployed_pkg }} not found in rpm-ostree status output"
+      when: "'{{ g_deployed_pkg }}' not in req_pkgs"
 
 - name: Package Layering - Installing non-root ownership package
   hosts: all
@@ -376,6 +394,22 @@
     - include: verify_package_not_deployed.yml
       vars:
         package: httpd
+
+- name: Package Layering - Negative - Install already layered package
+  hosts: all
+  become: yes
+
+  tags:
+    - install_previously_layered
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+     - name: Install already layered package
+       command: rpm-ostree install {{ g_pkg1 }}
+       register: ros_install
+       failed_when: ros_install.rc == 0
 
 - name: Package Layering - Negative Test - Installing without sufficient privileges
   hosts: all

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -345,6 +345,9 @@
       set_fact:
         req_json: "{{ req.stdout | from_json }}"
 
+    # This is a hack for requested-packages being displayed in rpm-ostree v2017.3 that should
+    # be fixed in v2017.4.  Once all streams are at v2017.4 we can fix this.  See
+    # https://github.com/projectatomic/rpm-ostree/pull/670
     - name: Set packages when deployment 0 is booted
       set_fact:
         req_pkgs: "{{ req_json['deployments'][0]['requested-packages'] if req_json['deployments'][0]['requested-packages'] is defined else {} }}"


### PR DESCRIPTION
The functionality for package layering has changed slightly so the
test need to be updated.  Two tests were added to verify the new
fucntionality.  The first test verifies that packages that are
being layered is added to a list of requested packages even if it is
already in the deployment.  The second test is that rpm-ostree should
error out when attempting to layer a package that already exists.

There was also a change in the rpm-ostree status output.  When there
are no packages are layered, there will be no "packages" listed in
the rpm-ostree status output. This caused an error when setting facts
in  rpm_ostree_uninstall_verify role.  To get around this, I only
set the fact to {} if it is undefined or to the list of packages if
it is defined.