### PR TITLE
Check for rootfs dir in remote sys container

### DIFF
--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -359,7 +359,7 @@
     - name: Fail when rootfs dir exists for rootfs container
       fail:
         msg: "/var/lib/containers/atomic/{{ g_hw_name }}-remote/rootfs exists"
-      when: hwr.stat.exists == True
+      when: hwr.stat.exists != True
 
     - include: 'roles/atomic_system_uninstall/tasks/main.yml'
       vars:


### PR DESCRIPTION
Update the test to reflect the symlink of the rootfs dir when using
--rootfs.  See https://github.com/projectatomic/atomic/pull/922