### PR TITLE
Cleanup after test completion

### DIFF
--- a/roles/atomic_images_delete_all/tasks/main.yml
+++ b/roles/atomic_images_delete_all/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# vim: set ft=ansible:
+#
+- name: Remove all images
+  command: atomic --assumeyes images delete --all
+  ignore_errors: yes
+
+- name: Prune images
+  command: atomic images prune
+
+- name: Verify no images exist
+  command: atomic images list -q
+  register: ail
+  failed_when: "{{ ail.stdout_lines | length }} > 0"

--- a/roles/k8_remove_all/tasks/main.yml
+++ b/roles/k8_remove_all/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Remove all the manifests
+  file:
+    path: "/etc/kubernetes/manifests/{{ item }}"
+    state: absent
+  with_items:
+    - apiserver-pod.json
+    - controller-mgr-pod.json
+    - scheduler-pod.json
+
+- name: Disable services
+  service:
+    name: "{{ item }}"
+    enabled: no
+    state: stopped
+  with_items:
+    - kube-proxy
+    - kubelet
+
+- name: Remove all services
+  command: kubectl delete svc --all
+
+- name: Remove all RCs
+  command: kubectl delete rc --all
+
+- name: Remove all pods
+  command: kubectl delete po --all

--- a/roles/rpm_ostree_cleanup_all/tasks/main.yml
+++ b/roles/rpm_ostree_cleanup_all/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# vim: set ft=ansible:
+#
+- name: Cleanup everything
+  command: rpm-ostree cleanup -rpmb

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -317,3 +317,31 @@
         msg: "Error message is incorrect"
       when: "'Deployment is already in unlocked state: hotfix' not in double_unlock.stderr"
 
+
+- name: Ostree Admin Unlock - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  vars_files:
+    - vars.yml
+
+  roles:
+    - role: rpm_ostree_rollback
+      tags:
+        - rpm_ostree_rollback
+
+    - role: reboot
+      tags:
+        - reboot
+
+    - role: rpm_ostree_cleanup_all
+      tags:
+        - rpm_ostree_cleanup_all
+
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe

--- a/tests/docker-build-httpd/README.md
+++ b/tests/docker-build-httpd/README.md
@@ -30,7 +30,7 @@ The following base images are tested:
 
     If running against a RHEL Atomic Host, you should provide subscription
     data that can be used by `subscription-manager`.  See
-    [roles/redhat_subscribe/tasks/main.yaml](roles/redhat_subscribe/tasks/main.yaml)
+    [roles/redhat_subscription/tasks/main.yaml](roles/redhat_subscription/tasks/main.yaml)
     for additional details.
 
 ### Running the Playbook

--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -14,7 +14,7 @@
 # Afterwards, the container and build image are removed from the system.
 #
 # In order to use less 'hacks', the playbook is actually multiple playbooks
-# that are divided into setup, tests, and teardown.  As such, this playbook
+# that are divided into setup, tests, and cleanup.  As such, this playbook
 # is meant to be run in its entirety and not separately.
 #
 - name: Docker build httpd - setup
@@ -111,12 +111,12 @@
       when: ansible_distribution == "RedHat"
 
 
-- name: Docker build httpd - teardown
+- name: Docker build httpd - Cleanup
   hosts: all
   become: yes
 
   tags:
-    - teardown
+    - cleanup
 
   roles:
     - role: docker_remove_all

--- a/tests/docker-swarm/main.yml
+++ b/tests/docker-swarm/main.yml
@@ -183,3 +183,20 @@
       fail:
         msg: "Swarm is not inactive"
       when: "'Swarm: inactive' not in di.stdout"
+
+- name: Docker Swarm - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  roles:
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe

--- a/tests/docker/main.yml
+++ b/tests/docker/main.yml
@@ -109,6 +109,30 @@
   tags:
     - cleanup
 
+  vars_files:
+    - vars.yml
+
+  pre_tasks:
+    - block:
+      - name: Stop and disable docker-latest
+        service:
+          name: docker-latest
+          enabled: no
+          state: stopped
+
+      - name: Revert docker-latest binary
+        replace:
+          dest: /etc/sysconfig/docker
+          regexp: 'DOCKERBINARY=/usr/bin/docker-latest'
+          replace: '#DOCKERBINARY=/usr/bin/docker-latest'
+
+      - name: Re-enable docker
+        service:
+          name: docker
+          enabled: yes
+          state: started
+      when: g_docker_latest
+
   roles:
     - role: docker_remove_all
       tags:

--- a/tests/docker/main.yml
+++ b/tests/docker/main.yml
@@ -102,6 +102,19 @@
       tags:
         - docker_rmi_httpd_image
 
+- name: Docker - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  roles:
     - role: docker_remove_all
       tags:
-        - docker_remove_all2
+        - docker_remove_all
+
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -56,3 +56,25 @@
   post_tasks:
     - name: check if everything works!
       shell: curl http://localhost:80/cgi-bin/action | grep "RedHat rocks"
+
+
+- name: Kubernetes Cluster - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  roles:
+    - role: k8_remove_all
+      tags:
+        - k8_remove_all
+
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -430,3 +430,30 @@
       register: unprivileged
       become: false
       failed_when: unprivileged.rc != 1
+
+
+- name: Package Layering - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  vars_files:
+    - vars.yml
+
+  pre_tasks:
+    - name: Uninstall all packages
+      command: rpm-ostree uninstall {{ g_pkg1 }} {{ g_epel_pkg }} {{ g_deployed_pkg }}
+
+    - include: '../../common/ans_reboot.yml'
+
+  roles:
+    - role: rpm_ostree_cleanup_all
+      tags:
+        - rpm_ostree_cleanup_all
+
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe

--- a/tests/runc/main.yml
+++ b/tests/runc/main.yml
@@ -137,3 +137,31 @@
         'exit status 1' in result.stdout or
         'error' in result.stdout or
         'Traceback' in result.stdout
+
+- name: runc - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  vars_files:
+    - vars.yml
+
+  roles:
+    - role: rpm_ostree_rollback
+      tags:
+        - rpm_ostree_rollback
+
+    - role: reboot
+      tags:
+        - reboot
+
+    - role: rpm_ostree_cleanup_all
+      tags:
+        - rpm_ostree_cleanup_all
+
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe

--- a/tests/runc/main.yml
+++ b/tests/runc/main.yml
@@ -161,6 +161,10 @@
       tags:
         - rpm_ostree_cleanup_all
 
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+
     - role: redhat_unsubscribe
       when: ansible_distribution == 'RedHat'
       tags:

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -559,3 +559,19 @@
     - include: 'roles/atomic_system_uninstall_verify/tasks/main.yml'
       vars:
         image: "{{ g_hw_image }}"
+
+
+- name: System Containers - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  vars_files:
+    - vars.yml
+
+  roles:
+    - role: atomic_images_delete_all
+      tags:
+        - atomic_images_delete_all


### PR DESCRIPTION
If we want to run the tests in succession, we should cleanup what the
tests have left around.  This typically includes docker
images/containers, kubernetes artifacts, and layered packages.

This change attempts to cleanup after most* tests and return the host
under test to its original state.  This includes two new roles that
assist in the cleanup of the host.

* The improved-sanity-test and system-containers test were not
addressed in this change, but should be addressed in the future.