### PR TITLE
Collect journal on failure

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -84,9 +84,13 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
             self._display.display("fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
 
     def v2_runner_on_failed(self,result, ignore_errors=False):
-        # Save last failure and set environment variable
         if ignore_errors is not True:
+            # Sets environment variable for test failures for use in playboks.
+            # Handlers tasks can conditionalize themselves using this variable
+            # to run only on failure.
             os.environ["AHT_FAILURE"] = "1"
+
+            # Save last failure
             self.failed_task = result
 
         if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:

--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -84,8 +84,9 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
             self._display.display("fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
 
     def v2_runner_on_failed(self,result, ignore_errors=False):
-        '''Save last failure'''
+        # Save last failure and set environment variable
         if ignore_errors is not True:
+            os.environ["AHT_FAILURE"] = "1"
             self.failed_task = result
 
         if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:

--- a/roles/handler_notify_on_failure/handlers/main.yml
+++ b/roles/handler_notify_on_failure/handlers/main.yml
@@ -1,0 +1,37 @@
+---
+#
+# This file is a collection of generic handlers that could be used in multiple
+# playbooks.  Please use the h_get_journal handler as a template for other
+# reusable handlers or to create a playbook specific handler in that is included
+# in your playbook.
+#
+- name: Get test status from environment variable
+  set_fact:
+    aht_result: "{{ lookup('env', 'AHT_FAILURE') }}"
+  listen: h_get_status
+
+# h_get_journal handler
+- name: Get playbook name
+  shell:  echo {{ playbook_dir }} | awk -F/ '{print $NF}'
+  register: playbook_name
+  listen: h_get_journal
+  when: aht_result == "1"
+
+- name: Set journal name
+  set_fact:
+    journal_name: "{{ playbook_name.stdout }}-{{ inventory_hostname }}-journal"
+  listen: h_get_journal
+  when: aht_result == "1"
+
+- name: Get journal
+  shell: journalctl -r -b > /tmp/{{ journal_name }}
+  listen: h_get_journal
+  when: aht_result == "1"
+
+- name: Retrieve journal
+  synchronize:
+    mode: pull
+    dest: ./{{ journal_name }}
+    src: /tmp/{{ journal_name }}
+  listen: h_get_journal
+  when: aht_result == "1"

--- a/roles/handler_notify_on_failure/tasks/main.yml
+++ b/roles/handler_notify_on_failure/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# vim: set ft=ansible:
+#
+# handler_notify_on_failure - This task will notify all handlers listening
+#   for a <handler_name> to run on failure of the playbook.  Below are the
+#   required guidelines for using the handler on failure.
+#
+#   force_handlers: true must be added to every play in a playbook
+#
+#   This role must be called once per pre_task, post_tasks, roles, or play.
+#
+#   To add a handler to run on failure the handler task must:
+#     - Have when: aht_result == "1"
+#     - Have listen: <handler_name>
+#
+#   Note: For multiple tasks, make sure each task has the same
+#         listen: <handle_name>
+#
+#   Handlers can be added to ../handlers/main.yml if it is generic and
+#   can be re-used.  For handlers specific to your playbook, create a
+#   yml file with the handlers, add a handler section to your playbook,
+#   and use include to pull the handlers in.
+#
+#     i.e.  handlers:
+#             - include: 'my_handlers.yml'
+#
+# parameters:
+#   handler_name (the unique name the handler is listening for)
+#
+
+- name: fail if handler_name is undefined
+  fail:
+    msg: "handler_name is undefined"
+  when: handler_name is undefined
+
+- name: Notify test status handler
+  command: /bin/true
+  notify:
+    - h_get_status
+
+- name: Notify {{ handler_name }}
+  command: /bin/true
+  notify:
+    - "{{ handler_name }}"

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -29,6 +29,7 @@
 - name: Improved Sanity Test - Pre-Upgrade
   hosts: all
   become: yes
+  force_handlers: true
 
   tags:
     - pre_upgrade
@@ -43,6 +44,12 @@
       avc_minor: "2"
       tags:
         - ansible_version_check
+        - cloud_image
+
+    - role: handler_notify_on_failure
+      handler_name: h_get_journal
+      tags:
+        - handler_notify_on_failure
         - cloud_image
 
     - role: atomic_host_check
@@ -288,6 +295,7 @@
 - name: Improved Sanity Test - Post-Upgrade
   hosts: all
   become: yes
+  force_handlers: true
 
   tags:
     - post_upgrade
@@ -303,6 +311,13 @@
       tags:
         - ansible_version_check
         - cloud_image
+
+    - role: handler_notify_on_failure
+      handler_name: h_get_journal
+      tags:
+        - handler_notify_on_failure
+        - cloud_image
+      check_mode: no
 
     - role: atomic_host_check
       tags:
@@ -530,6 +545,7 @@
 - name: Improved Sanity Test - Post-Rollback
   hosts: all
   become: yes
+  force_handlers: true
 
   tags:
     - post_rollback
@@ -545,6 +561,13 @@
       tags:
         - ansible_version_check
         - cloud_image
+
+    - role: handler_notify_on_failure
+      handler_name: h_get_journal
+      tags:
+        - handler_notify_on_failure
+        - cloud_image
+      check_mode: no
 
     - role: atomic_host_check
       tags:


### PR DESCRIPTION
This commit will collect the journal for the improved sanity test and
save it locally.  It also enables running other tasks on failure.

This is a giant workaround since Ansible does not have direct support to
run post execution tasks on failure..  Ansible's only mechanism for running
tasks after a play completes is a handler.  The problem with a handler
is that it will not run on failure without the force_handlers set to true.
If force_handlers is set to true it will run after every block of
pre_tasks, post_task, roles, and plays (not desirable).  The way to
workaround that is to conditionalize the tasks to only run when there
is a failure; however, Ansible does not have a direct variable that holds
the pass/fail status of a playbook.

In order to get the fail status, I leveraged the v2_runner_on_failed
method in the callback plugin that is called when Ansible fails.
An environment variable with the fail status of the result. Now the
handler tasks can be conditionalized to run on failure based on the
environment variable.

The handler can notify tasks individually by name or tasks can listen for
a notification.  Since multiple tasks need to be run, I opted to have
all tasks that need to be run together to listen for the same notification.
Notified tasks are run in the order they coded and not by the time they
are notified.