### PR TITLE
roles: fix selinux_verify for F24

### DIFF
--- a/roles/selinux_verify/vars/fedora-24.yml
+++ b/roles/selinux_verify/vars/fedora-24.yml
@@ -1,0 +1,9 @@
+---
+distro_files:
+  - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-storage-setup', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+
+distro_procs:
+  - { key: 'docker', value: 'system_u:system_r:container_runtime_t:s0' }
+


### PR DESCRIPTION
I got tired of seeing the Fedora 24 test failing on SELinux checks, so
I created the necessary config for it.