### PR TITLE
Add test + roles to verify docker RPMs can be built

### DIFF
--- a/tests/docker-rpm/README.md
+++ b/tests/docker-rpm/README.md
@@ -1,0 +1,47 @@
+This playbook builds the docker-latest RPMs, installs them,
+then verifies the basic docker functions.
+
+Core Functionality
+  - Building RPMs from spec + source
+  - Building RPMs from spec + alternate source (e.g. a PR)
+  - Install the built RPMs
+  - docker build
+  - docker images
+  - docker ps
+  - docker pull
+  - docker rm
+  - docker rmi
+  - docker run
+  - docker start
+  - docker stop
+
+### Prerequisites
+  - Ansible version 2.2 (other versions are not supported)
+
+  - A RHEL or Fedora system
+
+  - Configure subscription data
+
+    If running against a RHEL, you should provide subscription
+    data that can be used by `subscription-manager`.  See
+    [roles/redhat_subscription/tasks/main.yml](roles/redhat_subscription/tasks/main.yml)
+    for additional details.
+
+  - Some other stuff
+
+  - Configure the required variables to your liking in [tests/docker-rpm/vars.yml](vars.yml).
+
+### Running the Playbook
+
+To run the test, simply invoke as any other Ansible playbook:
+
+```
+$ ansible-playbook -i inventory tests/docker-rpm/main.yml -e subscription_file="/path/to/subscription_data.csv"  -e @/path/to/vars.yml
+```
+
+By default, this test will test docker-latest.  If you would like to test the
+out-of-box release of docker, set `g_docker_latest` to false
+in [tests/docker-rpm/vars.yml](vars.yml).
+
+*NOTE*: You are responsible for providing a host to run the test against and the
+inventory file for that host.

--- a/tests/docker-rpm/builder.sh
+++ b/tests/docker-rpm/builder.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+. env.sh
+
+case "$PACKAGE" in
+    docker)
+        . pkgs/$PACKAGE.sh
+        ;;
+    docker-latest)
+        . pkgs/$PACKAGE.sh
+        ;;
+    *)
+        . pkgs/default.sh
+        ;;
+esac
+
+update_sources_and_spec
+
+. common.sh
+cleanup_stale
+fetch_and_build
+
+if [ $BUILDTYPE == "tagged" ]; then
+    commit_to_dist_git
+fi

--- a/tests/docker-rpm/callback_plugins
+++ b/tests/docker-rpm/callback_plugins
@@ -1,0 +1,1 @@
+../../callback_plugins

--- a/tests/docker-rpm/common.sh
+++ b/tests/docker-rpm/common.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+. env.sh
+
+# delete stale packages, tarballs and build dirs
+cleanup_stale ()
+{
+    pushd $PKG_DIR/$PACKAGE
+    git clean -dfx
+    popd
+}
+
+# update spec changelog and release value
+bump_spec ()
+{
+    export CURRENT_VERSION=$(cat $PACKAGE.spec | grep -m 1 "Version:" | sed -e "s/Version: //")
+    if [ $CURRENT_VERSION == $VERSION ]; then
+        rpmdev-bumpspec -c "$(cat /tmp/$PACKAGE.changelog)" $PACKAGE.spec
+    else
+        rpmdev-bumpspec -n $VERSION -c "$(cat /tmp/$PACKAGE.changelog)" $PACKAGE.spec
+        sed -i "s/Release: 1\%{?dist}/Release: 1.git\%{shortcommit0}\%{?dist}/" $PACKAGE.spec
+        sed -i "s/$VERSION-1/$VERSION-1.git$SHORTCOMMIT/1" $PACKAGE.spec
+    fi
+}
+
+# rpmbuild
+fetch_and_build ()
+{
+    pushd $PKG_DIR/$PACKAGE
+    git checkout $DIST_GIT_TAG
+    bump_spec
+    spectool -g $PACKAGE.spec
+    sudo $BUILDDEP $PACKAGE.spec -y
+    rpmbuild -ba $PACKAGE.spec
+    popd
+}
+
+# update dist-git
+commit_to_dist_git ()
+{
+    pushd $PKG_DIR/$PACKAGE
+    git reset --hard
+    $DIST_PKG import --skip-diffs SRPMS/*
+    export NVR=$(grep -A 1 '%changelog' $PACKAGE.spec | sed '$!d' | sed -e "s/[^']* - //")
+    git commit -as -m "$PACKAGE-$NVR" -m "$(cat /tmp/$PACKAGE.changelog)"
+    popd
+}
+

--- a/tests/docker-rpm/env.sh
+++ b/tests/docker-rpm/env.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+export REPO_DIR=~/repositories
+export PKG_DIR=~/repositories/pkgs
+export DIST=$(rpm --eval %{?dist})
+if [ $DIST == '.el7' ]; then
+    export DISTRO="rhel"
+    export DIST_PKG="rhpkg"
+    export BUILDDEP="yum-builddep"
+else
+    export DISTRO="fedora"
+    export DIST_PKG="fedpkg"
+    export BUILDDEP="dnf builddep"
+fi
+
+while getopts ":t:p:u:r:b:d:f:k:" opt; do
+    case $opt in
+        t)
+            export BUILDTYPE=$OPTARG
+            ;;
+        p)
+            export PACKAGE=$OPTARG
+            ;;
+        u)
+            export USER=$OPTARG
+            ;;
+        r)
+            export USER_REPO=$OPTARG
+            ;;
+        b)
+            export BRANCH=$OPTARG
+            ;;
+        d)
+            export UPSTREAM_USER=$OPTARG
+            ;;
+        f)
+            export UPSTREAM_BRANCH=$OPTARG
+            ;;
+        k)
+            export KOJI_TAG=$OPTARG
+            if [ $KOJI_TAG = "rawhide" ]; then
+                export DIST_GIT_TAG="master"
+            else
+                export DIST_GIT_TAG=$KOJI_TAG
+            fi
+            ;;
+    esac
+done

--- a/tests/docker-rpm/info.txt
+++ b/tests/docker-rpm/info.txt
@@ -1,0 +1,10 @@
+Test Coverage:
+* docker build
+* docker images
+* docker ps
+* docker pull
+* docker rm
+* docker rmi
+* docker run
+* docker start
+* docker stop

--- a/tests/docker-rpm/main.yml
+++ b/tests/docker-rpm/main.yml
@@ -1,0 +1,137 @@
+---
+
+# All plays expect passed-in variables from the command-line
+# e.g. ansible-playbook ... --extra-vars=@vars.yml
+
+- name: docker-rpm - setup
+  hosts: all
+  # Fedora hosts need python installed first
+  gather_facts: False
+  tags: "setup"
+  vars:
+    empty: [Null,[],{},'']
+  pre_tasks:
+    - name: Python is installed when missing
+      raw: "type -P python || $(type -P dnf || type -P yum) install -y python"
+      args:
+        executable: "/bin/bash"
+    - name: Gather facts
+      setup:
+    - name: A RHEL or Fedora host is required
+      assert:
+        that: 'ansible_distribution in ["RedHat","Fedora"]'
+  roles:
+    # This playbook requires Ansible 2.2
+    - role: ansible_version_check
+      avc_major: "2"
+      avc_minor: "2"
+      tags: "ansible_version_check"
+
+    - role: redhat_subscription
+      when: "ansible_distribution == 'RedHat'"
+      tags: "redhat_subscription"
+
+    - role: yumrepos
+      when: enable_rh_repos | default() not in empty or
+            yum_repos | default() not in empty
+
+    - role: installed
+      install_rpms: "{{ fedora_install_rpms if ansible_distribution == 'Fedora' else rhel_install_rpms }}"
+      all_updated: True
+
+
+- name: docker-rpm - build
+  hosts: builders
+  tags:
+    - build
+  vars:
+    empty: [Null,[],{},'']
+  roles:
+
+    - git_repo_cloned
+
+    - rpmdistro_gitoverlay
+
+
+
+##### TODO: Make it (below) chooch
+
+
+
+- name: Docker - Functional Tests
+  hosts: testers
+
+  tags:
+    - functional
+
+  roles:
+    - role: osname_set_fact
+      tags:
+        - osname_set_fact
+
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+
+    - role: docker_latest_setup
+      tags:
+        - docker_latest_setup
+      when: g_docker_latest
+
+    - role: docker_pull_base_image
+      tags:
+        - docker_pull_base_image
+
+    - role: docker_build_httpd
+      tags:
+        - docker_build_httpd
+
+    - role: docker_run_httpd
+      tags:
+        - docker_run_httpd
+
+    - role: docker_rm_httpd_container
+      tags:
+        - docker_rm_httpd_container
+
+    - role: docker_rmi_httpd_image
+      tags:
+        - docker_rmi_httpd_image
+
+- name: Docker - Cleanup
+  hosts: all
+  become: yes
+
+  tags:
+    - cleanup
+
+  pre_tasks:
+    - block:
+      - name: Stop and disable docker-latest
+        service:
+          name: docker-latest
+          enabled: no
+          state: stopped
+
+      - name: Revert docker-latest binary
+        replace:
+          dest: /etc/sysconfig/docker
+          regexp: 'DOCKERBINARY=/usr/bin/docker-latest'
+          replace: '#DOCKERBINARY=/usr/bin/docker-latest'
+
+      - name: Re-enable docker
+        service:
+          name: docker
+          enabled: yes
+          state: started
+      when: g_docker_latest
+
+  roles:
+    - role: docker_remove_all
+      tags:
+        - docker_remove_all
+
+    - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
+      tags:
+        - redhat_unsubscribe

--- a/tests/docker-rpm/pkgs/README
+++ b/tests/docker-rpm/pkgs/README
@@ -1,0 +1,26 @@
+Copy $(pwd)/.rpmmacros into ~/
+
+source repos assumed to be in ~/repositories/
+dist-git repos assumed to be in ~/repositories/pkgs
+
+To run the script:
+# bash builder.sh -t $BUILDTYPE -p $PACKAGE -u $USER \
+    -r $USER_REPO -b $BRANCH \
+    -d $UPSTREAM_USER -f $UPSTREAM_BRANCH -k $KOJI_TAG
+
+BUILDTYPE: 'tagged' or 'scratch'
+
+PACKAGE: rpm name
+
+USER: PR author's github user id
+
+USER_REPO: repo/fork name
+
+BRANCH: repo/fork branch name
+
+UPSTREAM_USER: PR recipient / upstream's github user id
+
+UPSTREAM_BRANCH: PR destination's branch name
+
+KOJI_TAG: koji tag (NOT NECESSARILY the dist-git branch name)
+In the case of rawhide, KOJI_BRANCH will be "rawhide" and not "master"

--- a/tests/docker-rpm/pkgs/builder.sh
+++ b/tests/docker-rpm/pkgs/builder.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+. env.sh
+
+case "$PACKAGE" in
+    docker)
+        . pkgs/$PACKAGE.sh
+        ;;
+    docker-latest)
+        . pkgs/$PACKAGE.sh
+        ;;
+    *)
+        . pkgs/default.sh
+        ;;
+esac
+
+update_sources_and_spec
+
+. common.sh
+cleanup_stale
+fetch_and_build
+
+if [ $BUILDTYPE == "tagged" ]; then
+    commit_to_dist_git
+fi

--- a/tests/docker-rpm/pkgs/common.sh
+++ b/tests/docker-rpm/pkgs/common.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+. env.sh
+
+# delete stale packages, tarballs and build dirs
+cleanup_stale ()
+{
+    pushd $PKG_DIR/$PACKAGE
+    git clean -dfx
+    popd
+}
+
+# update spec changelog and release value
+bump_spec ()
+{
+    export CURRENT_VERSION=$(cat $PACKAGE.spec | grep -m 1 "Version:" | sed -e "s/Version: //")
+    if [ $CURRENT_VERSION == $VERSION ]; then
+        rpmdev-bumpspec -c "$(cat /tmp/$PACKAGE.changelog)" $PACKAGE.spec
+    else
+        rpmdev-bumpspec -n $VERSION -c "$(cat /tmp/$PACKAGE.changelog)" $PACKAGE.spec
+        sed -i "s/Release: 1\%{?dist}/Release: 1.git\%{shortcommit0}\%{?dist}/" $PACKAGE.spec
+        sed -i "s/$VERSION-1/$VERSION-1.git$SHORTCOMMIT/1" $PACKAGE.spec
+    fi
+}
+
+# rpmbuild
+fetch_and_build ()
+{
+    pushd $PKG_DIR/$PACKAGE
+    git checkout $DIST_GIT_TAG
+    bump_spec
+    spectool -g $PACKAGE.spec
+    sudo $BUILDDEP $PACKAGE.spec -y
+    rpmbuild -ba $PACKAGE.spec
+    popd
+}
+
+# update dist-git
+commit_to_dist_git ()
+{
+    pushd $PKG_DIR/$PACKAGE
+    git reset --hard
+    $DIST_PKG import --skip-diffs SRPMS/*
+    export NVR=$(grep -A 1 '%changelog' $PACKAGE.spec | sed '$!d' | sed -e "s/[^']* - //")
+    git commit -as -m "$PACKAGE-$NVR" -m "$(cat /tmp/$PACKAGE.changelog)"
+    popd
+}
+

--- a/tests/docker-rpm/pkgs/default.sh
+++ b/tests/docker-rpm/pkgs/default.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+. env.sh
+
+# update sources
+update_sources_and_spec ()
+{
+    pushd $REPO_DIR/$PACKAGE
+    git remote add $USER git://github.com/$USER/$USER_REPO.git
+    git fetch --all
+    git checkout $USER/$BRANCH
+    export COMMIT=$(git show --pretty=%H -s $USER/$BRANCH)
+    export SHORTCOMMIT=$(c=$COMMIT; echo ${c:0:7})
+    if [ $PACKAGE == "skopeo" ]; then
+        export VERSION=$(grep 'const Version' version/version.go | sed -e 's/const Version =\"//' | sed -e 's/-.*//')
+    elif [ $PACKAGE == "atomic" ]; then
+        export VERSION=$(grep '__version__' Atomic/__init__.py | sed -e "s/__version__ = '//" | sed -e "s/'//")
+    elif [ $PACKAGE == "rkt" ]; then
+         export VERSION=$(grep AC_INIT configure.ac | cut -d' ' -f2 | tr -d \]\[, | tr -d +git)
+    else
+        export VERSION=$(sed -e 's/-.*//' VERSION)
+    fi
+    popd
+
+    pushd $PKG_DIR/$PACKAGE
+    git checkout $DIST_GIT_TAG
+    sed -i "s/\%global commit0.*/\%global commit0 $COMMIT/" $PACKAGE.spec
+
+    echo "- built @$USER/$BRANCH commit $SHORTCOMMIT" > /tmp/$PACKAGE.changelog
+    popd
+}

--- a/tests/docker-rpm/pkgs/docker-latest.sh
+++ b/tests/docker-rpm/pkgs/docker-latest.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+. env.sh
+export PACKAGE_REPO="docker"
+
+# update sources
+update_sources_and_spec ()
+{
+    pushd $REPO_DIR/$PACKAGE_REPO
+    git remote add $USER git://github.com/$USER/$USER_REPO.git
+    git fetch $USER
+    git checkout $USER/$BRANCH
+    export COMMIT_DOCKER=$(git show --pretty=%H -s $USER/$BRANCH)
+    export SHORTCOMMIT_DOCKER=$(c=$COMMIT_DOCKER; echo ${c:0:7})
+    export VERSION=$(sed -e 's/-.*//' VERSION)
+    popd
+
+    #pushd $REPO_DIR/$PACKAGE-storage-setup
+    #git fetch origin
+    #export DSS_COMMIT=$(git show --pretty=%H -s origin/master)
+    #export DSS_SHORTCOMMIT=$(c=$DSS_COMMIT; echo ${c:0:7})
+    #popd
+
+    pushd $REPO_DIR/runc
+    git remote add projectatomic git://github.com/projectatomic/runc.git
+    git fetch --all
+    export COMMIT_RUNC=$(git show --pretty=%H -s $UPSTREAM_USER/$UPSTREAM_BRANCH)
+    export SHORTCOMMIT_RUNC=$(c=$COMMIT_RUNC; echo ${c:0:7})
+    popd
+
+    pushd $REPO_DIR/containerd
+    git remote add projectatomic git://github.com/projectatomic/containerd.git
+    git fetch --all
+    export COMMIT_CONTAINERD=$(git show --pretty=%H -s $UPSTREAM_USER/$UPSTREAM_BRANCH)
+    export SHORTCOMMIT_CONTAINERD=$(c=$COMMIT_CONTAINERD; echo ${c:0:7})
+    popd
+
+    pushd $REPO_DIR/tini
+    git fetch origin
+    export COMMIT_TINI=$(git show --pretty=%H -s origin/master)
+    export SHORTCOMMIT_TINI=$(c=$COMMIT_TINI; echo ${c:0:7})
+    popd
+
+    pushd $REPO_DIR/libnetwork
+    git fetch origin
+    export COMMIT_LIBNETWORK=$(git show --pretty=%H -s origin/master)
+    export SHORTCOMMIT_LIBNETWORK=$(c=$COMMIT_LIBNETWORK; echo ${c:0:7})
+    popd
+
+    pushd $PKG_DIR/$PACKAGE
+    git checkout $DIST_GIT_TAG
+    sed -i "s/\%global git_docker.*/\%global git_docker https:\/\/github.com\/$USER\/$USER_REPO/" $PACKAGE.spec
+    sed -i "s/\%global commit_docker.*/\%global commit_docker $COMMIT_DOCKER/" $PACKAGE.spec
+    #sed -i "s/\%global commit_dss.*/\%global commit_dss $DSS_COMMIT/" $PACKAGE.spec
+    sed -i "s/\%global commit_runc.*/\%global commit_runc $COMMIT_RUNC/" $PACKAGE.spec
+    sed -i "s/\%global commit_containerd.*/\%global commit_containerd $COMMIT_CONTAINERD/" $PACKAGE.spec
+    sed -i "s/\%global commit_tini.*/\%global commit_tini $COMMIT_TINI/" $PACKAGE.spec
+    sed -i "s/\%global commit_libnetwork.*/\%global commit_libnetwork $COMMIT_LIBNETWORK/" $PACKAGE.spec
+
+
+
+    echo "- built docker @$USER/$BRANCH commit $SHORTCOMMIT_DOCKER" > /tmp/$PACKAGE.changelog
+    #echo "- built d-s-s commit $SHORTCOMMIT_DSS" >> /tmp/$PACKAGE.changelog
+    echo "- built docker-runc @projectatomic/$UPSTREAM_BRANCH commit $SHORTCOMMIT_RUNC" >> /tmp/$PACKAGE.changelog
+    echo "- built docker-containerd @projectatomic/$UPSTREAM_BRANCH commit $SHORTCOMMIT_CONTAINERD" >> /tmp/$PACKAGE.changelog
+    echo "- built docker-init commit $SHORTCOMMIT_TINI" >> /tmp/$PACKAGE.changelog
+    echo "- built libnetwork commit $SHORTCOMMIT_LIBNETWORK" >> /tmp/$PACKAGE.changelog
+
+    popd
+}

--- a/tests/docker-rpm/pkgs/docker.sh
+++ b/tests/docker-rpm/pkgs/docker.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+
+. env.sh
+
+# update sources
+update_sources_and_spec ()
+{
+    pushd $REPO_DIR/$PACKAGE
+    git remote add $USER git://github.com/$USER/$USER_REPO.git
+    git fetch $USER
+    git checkout $USER/$BRANCH
+    export COMMIT_DOCKER=$(git show --pretty=%H -s $USER/$BRANCH)
+    export SHORTCOMMIT_DOCKER=$(c=$COMMIT_DOCKER; echo ${c:0:7})
+    export VERSION=$(sed -e 's/-.*//' VERSION)
+    popd
+
+    #pushd $REPO_DIR/$PACKAGE-storage-setup
+    #git fetch origin
+    #export DSS_COMMIT=$(git show --pretty=%H -s origin/master)
+    #export DSS_SHORTCOMMIT=$(c=$DSS_COMMIT; echo ${c:0:7})
+    #popd
+
+    pushd $REPO_DIR/$PACKAGE-novolume-plugin
+    git fetch origin
+    export COMMIT_NOVOLUME=$(git show --pretty=%H -s origin/master)
+    export SHORTCOMMIT_NOVOLUME=$(c=$COMMIT_NOVOLUME; echo ${c:0:7})
+    popd
+
+    pushd $REPO_DIR/rhel-push-plugin
+    git fetch origin
+    export COMMIT_RHEL_PUSH=$(git show --pretty=%H -s origin/master)
+    export SHORTCOMMIT_RHEL_PUSH=$(c=$COMMIT_RHEL_PUSH; echo ${c:0:7})
+    popd
+
+    pushd $REPO_DIR/$PACKAGE-lvm-plugin
+    git fetch origin
+    export COMMIT_LVM=$(git show --pretty=%H -s origin/master)
+    export SHORTCOMMIT_LVM=$(c=$COMMIT_LVM; echo ${c:0:7})
+    popd
+
+    pushd $REPO_DIR/runc
+    git remote add projectatomic git://github.com/projectatomic/runc.git
+    git fetch --all
+    export COMMIT_RUNC=$(git show --pretty=%H -s projectatomic/$UPSTREAM_BRANCH)
+    export SHORTCOMMIT_RUNC=$(c=$COMMIT_RUNC; echo ${c:0:7})
+    popd
+
+    pushd $REPO_DIR/containerd
+    git remote add projectatomic git://github.com/projectatomic/containerd.git
+    git fetch --all
+    export COMMIT_CONTAINERD=$(git show --pretty=%H -s projectatomic/$UPSTREAM_BRANCH)
+    export SHORTCOMMIT_CONTAINERD=$(c=$COMMIT_CONTAINERD; echo ${c:0:7})
+    popd
+
+    if [ $UPSTREAM_BRANCH == "docker-1.13.1" ]; then
+        pushd $REPO_DIR/tini
+        git fetch origin
+        export COMMIT_TINI=$(git show --pretty=%H -s origin/master)
+        export SHORTCOMMIT_TINI=$(c=$COMMIT_TINI; echo ${c:0:7})
+        popd
+
+        pushd $REPO_DIR/libnetwork
+        git fetch origin
+        export COMMIT_LIBNETWORK=$(git show --pretty=%H -s origin/master)
+        export SHORTCOMMIT_LIBNETWORK=$(c=$COMMIT_LIBNETWORK; echo ${c:0:7})
+        popd
+    fi
+
+    pushd $PKG_DIR/$PACKAGE
+    git checkout $DIST_GIT_TAG
+    sed -i "s/\%global git_docker.*/\%global git_docker https:\/\/github.com\/$USER\/$USER_REPO/" $PACKAGE.spec
+    sed -i "s/\%global commit_docker.*/\%global commit_docker $COMMIT_DOCKER/" $PACKAGE.spec
+    #sed -i "s/\%global commit_dss.*/\%global commit_dss $DSS_COMMIT/" $PACKAGE.spec
+    sed -i "s/\%global commit_novolume.*/\%global commit_novolume $COMMIT_NOVOLUME/" $PACKAGE.spec
+    sed -i "s/\%global commit_rhel_push.*/\%global commit_rhel_push $COMMIT_RHEL_PUSH/" $PACKAGE.spec
+    sed -i "s/\%global commit_lvm.*/\%global commit_lvm $COMMIT_LVM/" $PACKAGE.spec
+    sed -i "s/\%global commit_runc.*/\%global commit_runc $COMMIT_RUNC/" $PACKAGE.spec
+    sed -i "s/\%global commit_containerd.*/\%global commit_containerd $COMMIT_CONTAINERD/" $PACKAGE.spec
+
+    echo "- built docker @$USER/$BRANCH commit $SHORTCOMMIT_DOCKER" > /tmp/$PACKAGE.changelog
+    #echo "- built d-s-s commit $SHORTCOMMIT_DSS" >> /tmp/$PACKAGE.changelog
+    echo "- built docker-novolume-plugin commit $SHORTCOMMIT_NOVOLUME" >> /tmp/$PACKAGE.changelog
+    echo "- built rhel-push-plugin commit $SHORTCOMMIT_RHEL_PUSH" >> /tmp/$PACKAGE.changelog
+    echo "- built docker-lvm-plugin commit $SHORTCOMMIT_LVM" >> /tmp/$PACKAGE.changelog
+    echo "- built docker-runc @projectatomic/$UPSTREAM_BRANCH commit $SHORTCOMMIT_RUNC" >> /tmp/$PACKAGE.changelog
+    echo "- built docker-containerd @projectatomic/$UPSTREAM_BRANCH commit $SHORTCOMMIT_CONTAINERD" >> /tmp/$PACKAGE.changelog
+
+    if [ $UPSTREAM_BRANCH == "docker-1.13.1" ]; then
+        sed -i "s/\%global commit_tini.*/\%global commit_tini $COMMIT_TINI/" $PACKAGE.spec
+        sed -i "s/\%global commit_libnetwork.*/\%global commit_libnetwork $COMMIT_LIBNETWORK/" $PACKAGE.spec
+        echo "- built docker-init commit $SHORTCOMMIT_TINI" >> /tmp/$PACKAGE.changelog
+        echo "- built libnetwork commit $SHORTCOMMIT_LIBNETWORK" >> /tmp/$PACKAGE.changelog
+    fi
+
+    popd
+}

--- a/tests/docker-rpm/pkgs/env.sh
+++ b/tests/docker-rpm/pkgs/env.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+export REPO_DIR=~/repositories
+export PKG_DIR=~/repositories/pkgs
+export DIST=$(rpm --eval %{?dist})
+if [ $DIST == '.el7' ]; then
+    export DISTRO="rhel"
+    export DIST_PKG="rhpkg"
+    export BUILDDEP="yum-builddep"
+else
+    export DISTRO="fedora"
+    export DIST_PKG="fedpkg"
+    export BUILDDEP="dnf builddep"
+fi
+
+while getopts ":t:p:u:r:b:d:f:k:" opt; do
+    case $opt in
+        t)
+            export BUILDTYPE=$OPTARG
+            ;;
+        p)
+            export PACKAGE=$OPTARG
+            ;;
+        u)
+            export USER=$OPTARG
+            ;;
+        r)
+            export USER_REPO=$OPTARG
+            ;;
+        b)
+            export BRANCH=$OPTARG
+            ;;
+        d)
+            export UPSTREAM_USER=$OPTARG
+            ;;
+        f)
+            export UPSTREAM_BRANCH=$OPTARG
+            ;;
+        k)
+            export KOJI_TAG=$OPTARG
+            if [ $KOJI_TAG = "rawhide" ]; then
+                export DIST_GIT_TAG="master"
+            else
+                export DIST_GIT_TAG=$KOJI_TAG
+            fi
+            ;;
+    esac
+done

--- a/tests/docker-rpm/roles/ansible_version_check
+++ b/tests/docker-rpm/roles/ansible_version_check
@@ -1,0 +1,1 @@
+../../../roles/ansible_version_check

--- a/tests/docker-rpm/roles/command_privilege_verify
+++ b/tests/docker-rpm/roles/command_privilege_verify
@@ -1,0 +1,1 @@
+../../../roles/command_privilege_verify

--- a/tests/docker-rpm/roles/docker_build_httpd
+++ b/tests/docker-rpm/roles/docker_build_httpd
@@ -1,0 +1,1 @@
+../../../roles/docker_build_httpd

--- a/tests/docker-rpm/roles/docker_build_tag_push
+++ b/tests/docker-rpm/roles/docker_build_tag_push
@@ -1,0 +1,1 @@
+../../../roles/docker_build_tag_push

--- a/tests/docker-rpm/roles/docker_latest_setup
+++ b/tests/docker-rpm/roles/docker_latest_setup
@@ -1,0 +1,1 @@
+../../../roles/docker_latest_setup

--- a/tests/docker-rpm/roles/docker_private_registry
+++ b/tests/docker-rpm/roles/docker_private_registry
@@ -1,0 +1,1 @@
+../../../roles/docker_private_registry

--- a/tests/docker-rpm/roles/docker_pull_base_image
+++ b/tests/docker-rpm/roles/docker_pull_base_image
@@ -1,0 +1,1 @@
+../../../roles/docker_pull_base_image

--- a/tests/docker-rpm/roles/docker_pull_run_remove
+++ b/tests/docker-rpm/roles/docker_pull_run_remove
@@ -1,0 +1,1 @@
+../../../roles/docker_pull_run_remove

--- a/tests/docker-rpm/roles/docker_remove_all
+++ b/tests/docker-rpm/roles/docker_remove_all
@@ -1,0 +1,1 @@
+../../../roles/docker_remove_all

--- a/tests/docker-rpm/roles/docker_rm_httpd_container
+++ b/tests/docker-rpm/roles/docker_rm_httpd_container
@@ -1,0 +1,1 @@
+../../../roles/docker_rm_httpd_container

--- a/tests/docker-rpm/roles/docker_rmi_httpd_image
+++ b/tests/docker-rpm/roles/docker_rmi_httpd_image
@@ -1,0 +1,1 @@
+../../../roles/docker_rmi_httpd_image

--- a/tests/docker-rpm/roles/docker_run_httpd
+++ b/tests/docker-rpm/roles/docker_run_httpd
@@ -1,0 +1,1 @@
+../../../roles/docker_run_httpd

--- a/tests/docker-rpm/roles/docker_version_check
+++ b/tests/docker-rpm/roles/docker_version_check
@@ -1,0 +1,1 @@
+../../../roles/docker_version_check

--- a/tests/docker-rpm/roles/etc_modify
+++ b/tests/docker-rpm/roles/etc_modify
@@ -1,0 +1,1 @@
+../../../roles/etc_modify

--- a/tests/docker-rpm/roles/etc_verify_changes
+++ b/tests/docker-rpm/roles/etc_verify_changes
@@ -1,0 +1,1 @@
+../../../roles/etc_verify_changes

--- a/tests/docker-rpm/roles/git_repo_cloned/defaults/main.yml
+++ b/tests/docker-rpm/roles/git_repo_cloned/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+
+# Maximum time to wait (in seconds) for each git operation to complete
+git_op_timeout: '{{ 60 * 30 }}'
+# Interval time (in seconds) to wait between each git status check
+git_op_status_delay: '10'
+
+# List of dictionaries, with options to the git ansible module.
+git_ops:
+#    - repo: https://github.com/example/repo.git
+#      dest: "{{ ansible_user_dir }}/repo"
+#      depth: "{{ git_def_depth | int }}"
+
+# Default depth to use when no depth option specified (above).
+#     1: shallow clone only HEAD
+#     None: clone all commits
+git_def_depth: 1
+

--- a/tests/docker-rpm/roles/git_repo_cloned/tasks/async_git.yml
+++ b/tests/docker-rpm/roles/git_repo_cloned/tasks/async_git.yml
@@ -1,0 +1,19 @@
+---
+
+- name: git_op's options are fed to git module
+  git:
+    dest: "{{ git_op.dest }}"
+    repo: "{{ git_op.repo }}"
+    depth: "{{ git_op.depth | default(git_def_depth | int) }}"
+    recursive: "{{ git_op['recursive'] | default(omit) }}"
+    reference: "{{ git_op.reference | default(omit) }}"
+    refspec: "{{ git_op.refspec | default(omit) }}"
+    remote: "{{ git_op.remote | default(omit) }}"
+    version: "{{ git_op.version | default(omit) }}"
+  register: result
+  async: "{{ git_op_timeout }}"
+  poll: 0
+
+- name: git_op's result is added into async_results
+  set_fact:
+    async_results: "{{ async_results | union([result]) }}"

--- a/tests/docker-rpm/roles/git_repo_cloned/tasks/async_status.yml
+++ b/tests/docker-rpm/roles/git_repo_cloned/tasks/async_status.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Async job async_result.ansible_job_id completes or times out
+  async_status:
+    jid: "{{ async_result.ansible_job_id }}"
+  failed_when: result | failed
+  register: result
+  until: result.finished | bool
+  # Always at least one retry
+  retries: "{{ (git_op_timeout|int / git_op_status_delay|int) | round(method='ceil')|int }}"
+  delay: "{{ git_op_status_delay|int }}"

--- a/tests/docker-rpm/roles/git_repo_cloned/tasks/main.yml
+++ b/tests/docker-rpm/roles/git_repo_cloned/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+
+- name: async_results and results variables are initialized
+  set_fact:
+    async_results: []
+    result:
+
+- assert:
+    that:
+        # Verify confirmance with defaults, expected types, and values
+        - "git_op_timeout | default(0) >= 1"
+        - "git_op_status_delay | default(0) >= 1"
+        - "git_ops | default(None) not in ['',{}]"
+        # Verify wasn't overriden on command-line
+        - "async_results == []"
+        - "result == None"
+
+- name: All git operations are run in parallel
+  include: "{{ role_path }}/tasks/async_git.yml"
+  with_items: "{{ git_ops }}"
+  loop_control:
+    loop_var: "git_op"
+
+- name: All parallel git operations are completed and are successful
+  include: "{{ role_path }}/tasks/async_status.yml"
+  with_items: "{{ async_results }}"
+  loop_control:
+    loop_var: "async_result"
+
+- name: Fact namespace kept clean by setting temporaries to None
+  set_fact:
+    async_results:
+    result:

--- a/tests/docker-rpm/roles/git_repo_cloned/vars/main.yml
+++ b/tests/docker-rpm/roles/git_repo_cloned/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+async_results: []
+result:

--- a/tests/docker-rpm/roles/handler_notify_on_failure
+++ b/tests/docker-rpm/roles/handler_notify_on_failure
@@ -1,0 +1,1 @@
+../../../roles/handler_notify_on_failure

--- a/tests/docker-rpm/roles/installed/defaults/main.yml
+++ b/tests/docker-rpm/roles/installed/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+
+# Optional, names / URLs of repository-rpms to install
+repo_rpms:
+
+# Mandatory, List of Names / URLs of packages to install / update
+install_rpms:
+
+# Optional, list of repositories to always enable
+enable_repos:
+
+# Optional, list of repositories to disable, unless enabled
+disable_repos:
+
+# Optional, True if all installed packages should also be updated
+all_updated: False
+
+# Optional, timeout in minutes allowed for package install to complete
+install_timeout: 60

--- a/tests/docker-rpm/roles/installed/tasks/main.yml
+++ b/tests/docker-rpm/roles/installed/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+
+- assert:
+    that:
+        - 'empty is defined'
+        - 'install_rpms is defined'
+        - 'repo_rpms is defined'
+        - 'enable_repos is defined'
+        - 'disable_repos is defined'
+        - 'install_timeout is defined'
+        - 'all_updated in [True,False]'
+        - 'ansible_distribution in ["RedHat","Fedora","CentOS"]'
+
+# Assume repositories are needed to install listed packages (below)
+- name: Repository rpms are installed
+  shell: "$(type -P dnf || type -P yum) install -y {{ item }}"
+  when: item not in empty
+  with_items: "{{ repo_rpms | default([]) }}"
+  # Avoid running into task timeouts.
+  async: "{{ 60 * install_timeout }}"
+  poll: 5
+
+- name: Packages are installed from desired repo set using yum
+  yum:
+    name: '{{ item }}'
+    disablerepo: '{{ disable_repos | join(",") if disable_repos not in empty else omit }}'
+    enablerepo: '{{ enable_repos | join(",") if enable_repos not in empty else omit }}'
+  when: item not in empty and ansible_distribution != 'Fedora'
+  with_items: "{{ install_rpms | default([]) }}"
+  # This could take longer than ssh timeout
+  async: "{{ 60 * install_timeout }}"
+  poll: 5
+
+- name: Packages are installed from desired repo set using dnf
+  dnf:
+    name: '{{ item }}'
+    disablerepo: '{{ disable_repos | join(",") if disable_repos not in empty else omit }}'
+    enablerepo: '{{ enable_repos | join(",") if enable_repos not in empty else omit }}'
+  when: item not in empty and ansible_distribution == 'Fedora'
+  with_items: "{{ install_rpms | default([]) }}"
+  # This could take longer than ssh timeout
+  async: "{{ 60 * install_timeout }}"
+  poll: 5
+
+
+- block:
+
+  - name: Packages are updated from desired repo set using yum
+    yum:
+      name: '*'
+      state: 'latest'
+      disablerepo: '{{ disable_repos | join(",") if disable_repos not in empty else omit }}'
+      enablerepo: '{{ enable_repos | join(",") if enable_repos not in empty else omit }}'
+    when: "ansible_distribution != 'Fedora'"
+    # This could take longer than ssh timeout
+    async: "{{ 60 * install_timeout }}"
+    poll: 5
+
+  - name: Packages are updated from desired repo set using dnf
+    dnf:
+      name: '*'
+      state: 'latest'
+      disablerepo: '{{ disable_repos | join(",") if disable_repos not in empty else omit }}'
+      enablerepo: '{{ enable_repos | join(",") if enable_repos not in empty else omit }}'
+    when: "ansible_distribution == 'Fedora'"
+    # This could take longer than ssh timeout
+    async: "{{ 60 * install_timeout }}"
+    poll: 5
+
+  when: all_updated | default(True)

--- a/tests/docker-rpm/roles/machine_id_compare
+++ b/tests/docker-rpm/roles/machine_id_compare
@@ -1,0 +1,1 @@
+../../../roles/machine_id_compare

--- a/tests/docker-rpm/roles/osname_set_fact
+++ b/tests/docker-rpm/roles/osname_set_fact
@@ -1,0 +1,1 @@
+../../../roles/osname_set_fact

--- a/tests/docker-rpm/roles/package_verify_missing
+++ b/tests/docker-rpm/roles/package_verify_missing
@@ -1,0 +1,1 @@
+../../../roles/package_verify_missing

--- a/tests/docker-rpm/roles/package_verify_present
+++ b/tests/docker-rpm/roles/package_verify_present
@@ -1,0 +1,1 @@
+../../../roles/package_verify_present

--- a/tests/docker-rpm/roles/reboot
+++ b/tests/docker-rpm/roles/reboot
@@ -1,0 +1,1 @@
+../../../roles/reboot

--- a/tests/docker-rpm/roles/redhat_subscription
+++ b/tests/docker-rpm/roles/redhat_subscription
@@ -1,0 +1,1 @@
+../../../roles/redhat_subscription

--- a/tests/docker-rpm/roles/redhat_unsubscribe
+++ b/tests/docker-rpm/roles/redhat_unsubscribe
@@ -1,0 +1,1 @@
+../../../roles/redhat_unsubscribe

--- a/tests/docker-rpm/roles/rpm_install
+++ b/tests/docker-rpm/roles/rpm_install
@@ -1,0 +1,1 @@
+../../../roles/rpm_install

--- a/tests/docker-rpm/roles/rpm_uninstall
+++ b/tests/docker-rpm/roles/rpm_uninstall
@@ -1,0 +1,1 @@
+../../../roles/rpm_uninstall

--- a/tests/docker-rpm/roles/rpmdb_verify
+++ b/tests/docker-rpm/roles/rpmdb_verify
@@ -1,0 +1,1 @@
+../../../roles/rpmdb_verify

--- a/tests/docker-rpm/roles/rpmdistro_gitoverlay/defaults/main.yml
+++ b/tests/docker-rpm/roles/rpmdistro_gitoverlay/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+
+# The path containing the rpmdistro-gitoverlay source
+rdgo_src:
+
+# List of shell module option values for building/installing rpmdistro-gitoverlay
+# (default chdir is rdgo_src)
+rdgo_build_cmds:
+  - command: ./autogen.sh
+    creates: configure
+  - command: ./configure --disable-silent-rules --prefix=/usr
+  - command: make install INSTALL="install -p -c"
+    creates: /usr/bin/rpmdistro-gitoverlay

--- a/tests/docker-rpm/roles/rpmdistro_gitoverlay/tasks/main.yml
+++ b/tests/docker-rpm/roles/rpmdistro_gitoverlay/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+- assert:
+    that:
+      - "empty is defined"
+      - "rdgo_src | default() not in empty"
+      - "rdgo_build_cmds | default() not in [None,'',{}]"
+
+# TODO: Better to build/install an rpm?
+- name: Commands to build rpmdistro_gitoverlay are executed
+  shell: '{{ item.command }}'
+  args:
+    chdir: '{{ item.chdir | default(rdgo_src) }}'
+    creates: '{{ item.creates | default(omit) }}'
+    executable: '{{ item.executable | default(omit) }}'
+    removes: '{{ item.removes | default(omit) }}'
+    warn: '{{ item.warn | default(omit) }}'
+  with_items: '{{ rdgo_build_cmds }}'

--- a/tests/docker-rpm/roles/runc_version_check
+++ b/tests/docker-rpm/roles/runc_version_check
@@ -1,0 +1,1 @@
+../../../roles/runc_version_check

--- a/tests/docker-rpm/roles/selinux_boolean
+++ b/tests/docker-rpm/roles/selinux_boolean
@@ -1,0 +1,1 @@
+../../../roles/selinux_boolean

--- a/tests/docker-rpm/roles/selinux_boolean_verify
+++ b/tests/docker-rpm/roles/selinux_boolean_verify
@@ -1,0 +1,1 @@
+../../../roles/selinux_boolean_verify

--- a/tests/docker-rpm/roles/selinux_verify
+++ b/tests/docker-rpm/roles/selinux_verify
@@ -1,0 +1,1 @@
+../../../roles/selinux_verify

--- a/tests/docker-rpm/roles/semanage_fcontext_mod
+++ b/tests/docker-rpm/roles/semanage_fcontext_mod
@@ -1,0 +1,1 @@
+../../../roles/semanage_fcontext_mod

--- a/tests/docker-rpm/roles/semanage_fcontext_verify
+++ b/tests/docker-rpm/roles/semanage_fcontext_verify
@@ -1,0 +1,1 @@
+../../../roles/semanage_fcontext_verify

--- a/tests/docker-rpm/roles/tmp_check_perms
+++ b/tests/docker-rpm/roles/tmp_check_perms
@@ -1,0 +1,1 @@
+../../../roles/tmp_check_perms

--- a/tests/docker-rpm/roles/url_verify
+++ b/tests/docker-rpm/roles/url_verify
@@ -1,0 +1,1 @@
+../../../roles/url_verify

--- a/tests/docker-rpm/roles/user_add
+++ b/tests/docker-rpm/roles/user_add
@@ -1,0 +1,1 @@
+../../../roles/user_add

--- a/tests/docker-rpm/roles/user_verify_missing
+++ b/tests/docker-rpm/roles/user_verify_missing
@@ -1,0 +1,1 @@
+../../../roles/user_verify_missing

--- a/tests/docker-rpm/roles/user_verify_present
+++ b/tests/docker-rpm/roles/user_verify_present
@@ -1,0 +1,1 @@
+../../../roles/user_verify_present

--- a/tests/docker-rpm/roles/yumrepos/defaults/main.yml
+++ b/tests/docker-rpm/roles/yumrepos/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+
+# There are situations where default repositories are broken.
+# Setting this true causes ALL subscription-manager supplied repos
+# to be disabled.
+disable_all_rh_repos: False
+
+# This is the opposite of ``disable_all_rh_repos`` (above).  It's
+# a list of subscription-manager supplied repos to explicitly enable.
+enable_rh_repos:
+
+# When neither of the above meet testing requirements, or additional
+# local repositories should be added, this specifies them.  Each item
+# in the list is a dictionary of arguments to the standard
+# ``yum_repository`` Ansible module.  e.g.
+#
+# yum_repos:
+#     - name: "My special Repo"
+#       baseurl: "https://my.special.repo.example.com/"
+#       gpgcheck: False
+#       includepkgs: rocket2moon
+#     - name: "Other special repo"
+#       baseurl: "https://you.get.the.idea"
+#
+yum_repos:

--- a/tests/docker-rpm/roles/yumrepos/tasks/main.yml
+++ b/tests/docker-rpm/roles/yumrepos/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+
+- assert:
+    that:
+        - 'empty is defined'
+        - 'ansible_distribution in ["RedHat","Fedora","CentOS"]'
+        - >
+            disable_all_rh_repos in [True,False] or
+            enable_rh_repos | default() not in empty or
+            yum_repos | default() not in empty
+
+# There are situations where default repositories are broken
+- name: All RH repositories are disabled in subscription manager
+  command: /usr/sbin/subscription-manager repos --disable=*
+  when: ansible_distribution == "RedHat" and
+        disable_all_rh_repos | default(False)
+
+- name: Select RH repos are enabled
+  command: /usr/sbin/subscription-manager repos --enable={{ item }}
+  when: ansible_distribution == "RedHat"
+  with_items: '{{ enable_rh_repos | default([]) }}'
+
+- name: yum repository is setup
+  yum_repository:
+    name: "{{ item.name | mandatory }}"
+    baseurl: "{{ item.baseurl }}"
+    description: "Ansible added {{ item.name | mandatory }} repo"
+    gpgcheck: "{{ item.gpgcheck | default(True) }}"
+    exclude: "{{ item.excludepkgs | default(omit) }}"
+    includepkgs: "{{ item.includepkgs | default(omit) }}"
+    metadata_expire: 900  # quarter-hour
+    protect: "{{ item.protect | default(False) }}"
+    # Subscription manager can't disable non-redhat repos.
+    enabled: True
+    state: present
+  with_items: '{{ yum_repos | default([])}}'

--- a/tests/docker-rpm/vars.yml
+++ b/tests/docker-rpm/vars.yml
@@ -1,0 +1,69 @@
+---
+
+yum_repos:
+    # FIXME: These were used in source playbook (maybe/probably not needed with rpmdistro-gitoverlay)
+    - name: beaker-client
+      baseurl: "https://beaker-project.org/yum/client/Fedora$releasever/"
+      gpgcheck: False
+
+install_rpms:
+    # For convenience
+    - xz
+    - bzip2
+    - vim
+    # Needed for ansible &| playbook
+    - python
+    - git
+    - rsync
+    - curl
+    - wget
+    - dnf
+    - yum
+    # Needed for rpmdistro-gitoverlay
+    # FIXME: Some python/mock stuff seems to be missing? (import errors at runtime)
+    - autoconf
+    - automake
+    - libtool
+    - pygobject2
+    - PyYAML
+    - pygobject3
+    - python-six
+    - rpm-build
+    - mock
+    - yum-plugin-priorities
+    - pyrpkg
+    - glib2
+    - fedpkg
+    - gcc
+    - make
+    - libsolv
+    # Needed for building rpms
+    - rpm-build
+
+# List of dictionaries, with options to the git ansible module.
+git_ops:
+    - repo: "https://github.com/cgwalters/rpmdistro-gitoverlay.git"
+      dest: "{{ ansible_user_dir }}/repositories/rpmdistro-gitoverlay"
+    # FIXME: These were used in source playbook (maybe/probably not needed with rpmdistro-gitoverlay)
+    - repo: "https://src.fedoraproject.org/git/rpms/docker.git"
+      dest: "{{ ansible_user_dir }}/docker_{{ ansible_distribution }}"
+    - repo: "https://github.com/docker/docker.git"
+      dest: "{{ ansible_user_dir }}/repositories/docker"
+    - repo: "https://github.com/projectatomic/docker-storage-setup.git"
+      dest: "{{ ansible_user_dir }}/repositories/docker-storage-setup"
+    - repo: "https://github.com/docker/v1.10-migrator.git"
+      dest: "{{ ansible_user_dir }}/repositories/v1.10-migrator"
+    - repo: "https://github.com/projectatomic/docker-novolume-plugin.git"
+      dest: "{{ ansible_user_dir }}/repositories/docker-novolume-plugin"
+    - repo: "https://github.com/projectatomic/rhel-push-plugin.git"
+      dest: "{{ ansible_user_dir }}/repositories/rhel-push-plugin"
+    - repo: "https://github.com/projectatomic/docker-lvm-plugin.git"
+      dest: "{{ ansible_user_dir }}/repositories/docker-lvm-plugin"
+    - repo: "https://github.com/opencontainers/runc.git"
+      dest: "{{ ansible_user_dir }}/repositories/runc"
+    - repo: "https://github.com/docker/containerd.git"
+      dest: "{{ ansible_user_dir }}/repositories/containerd"
+
+rdgo_src: "{{ ansible_user_dir }}/repositories/rpmdistro-gitoverlay"
+
+g_docker_latest: true


### PR DESCRIPTION
Support two test-cases for docker-current and docker-latest
on RHEL or Fedora:

1) Can the current .spec file + upstream sources, produce
   installable and minimaly functional docker RPMs.

-or-

2) Can #1 be achieved with an alternate .spec file
   and/or alternate upstream sourc(es) (e.g. a commit
   to a branch by a PR)

Signed-off-by: Chris Evich <cevich@redhat.com>