### PR TITLE
Fix typo in atomic_run_verify

### DIFF
--- a/roles/atomic_run_verify/tasks/main.yml
+++ b/roles/atomic_run_verify/tasks/main.yml
@@ -22,4 +22,4 @@
 - name: Fail if container is not running
   fail:
     msg="Container is not Up or Created in docker ps -a output"
-  when: (dps.stdout.find("Up") == -1 and dps.std.outfind("Created") == -1)
+  when: (dps.stdout.find("Up") == -1 and dps.stdout.find("Created") == -1)


### PR DESCRIPTION
In a recent FAHC test run [0], it failed with the following error:

```
The conditional check '(dps.stdout.find("Up") == -1 and
dps.std.outfind("Created") == -1)' failed. The error was: error while
evaluating conditional ((dps.stdout.find("Up") == -1 and
dps.std.outfind("Created") == -1)): 'dict object' has no attribute
'std'

The error appears to have been in
'/home/jenkins/workspace/atomic-host-jobs-treecompose-improved-sanity-test-fahc/atomic-host-tests/roles/atomic_run_verify/tasks/main.yml':
line 22, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
```

Turns out there was a small typo in that role, which is fixed in this
change.

[0]
https://s3.amazonaws.com/aos-ci/atomic-host-tests/improved-sanity-test/fahc/jenkins-atomic-host-jobs-treecompose-improved-sanity-test-fahc-274/improved-sanity-test.log