### PR TITLE
Support passing extra options to sub. man.

### DIFF
--- a/roles/redhat_subscription/files/subscription_data.csv.sample
+++ b/roles/redhat_subscription/files/subscription_data.csv.sample
@@ -2,3 +2,4 @@ baseurl,https://cdn.redhat.com
 serverurl,subscription.rhn.redhat.com:443/subscription
 username,username@example.com
 password,yourPa$sW0rd
+extra,--force

--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -43,6 +43,7 @@
       --serverurl="{{ lookup('csvfile', 'serverurl file={} delimiter=,'.format(subscription_file)) }}"
       --username="$USERNAME"
       --password="$PASSWORD"
+      {{ lookup('csvfile', 'extra file={} delimiter=,'.format(subscription_file)) | default('') }}
     environment:
       USERNAME: "{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
       PASSWORD: "{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"


### PR DESCRIPTION
Sometimes additonal options are needed during registration, such as
``--force`` or ``--org``.  Support this with an optional 'extra' key in
the CSV file.  When this key is not present, treat it as an empty
string to the sub. man. command-line.

Signed-off-by: Chris Evich <cevich@redhat.com>