### PR TITLE
Hide subscription-manager username/password

### DIFF
--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -41,8 +41,11 @@
       subscription-manager register --auto-attach --force
       --baseurl="{{ lookup('csvfile', 'baseurl file={} delimiter=,'.format(subscription_file)) }}"
       --serverurl="{{ lookup('csvfile', 'serverurl file={} delimiter=,'.format(subscription_file)) }}"
-      --username="{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
-      --password="{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"
+      --username="$USERNAME"
+      --password="$PASSWORD"
+    environment:
+      USERNAME: "{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
+      PASSWORD: "{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"
     register: result
     until: result.rc == 0
     retries: 3


### PR DESCRIPTION
It's almost always a good idea to protect in-flight credentials.  Wrap
the username & password values inside temporary environment variables.
These env. vars. only exist for the life of the ``bash`` process.
Though they will still be exposed in a process-listing (on the target),
they won't show up inside any ansible logs.

Signed-off-by: Chris Evich <cevich@redhat.com>