### PR TITLE
Support atomic_host_check !fail when !is_atomic

### DIFF
--- a/roles/atomic_host_check/defaults/main.yml
+++ b/roles/atomic_host_check/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+# Set false if role should NOT fail when is_atomic == False
+fail_if_not_atomic_host: True

--- a/roles/atomic_host_check/tasks/main.yml
+++ b/roles/atomic_host_check/tasks/main.yml
@@ -5,7 +5,11 @@
 #
 # Logic borrowed from:
 # https://github.com/kubernetes/contrib/blob/master/ansible/roles/common/tasks/main.yml
-#
+
+- assert:
+    that:
+      - 'fail_if_not_atomic_host in [True,False]'
+
 - name: Determine if Atomic Host
   stat:
     path: "/run/ostree-booted"
@@ -25,5 +29,4 @@
 - name: Fail if system is not an Atomic Host
   fail:
     msg: "The system is not an Atomic Host"
-  when: not is_atomic
-
+  when: not is_atomic and fail_if_not_atomic_host


### PR DESCRIPTION
Support all existing playbooks by adding an optional flag to shut-off
the fail task.  This allows the role to be re-used on all platforms, and
gives the caller the power to decide whether or not to enforce
verification-failure.

Signed-off-by: Chris Evich <cevich@redhat.com>