### PR TITLE
Adjust requirements.txt to stay at 2.2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible>=2.2.0
+ansible<2.3


### PR DESCRIPTION
In the previous version, `requirements.txt` would install Ansible 2.3.  Probably wouldn't break anything, but let's just stay paranoid and require users to stick at 2.2