### PR TITLE
Use empty string for extra args if undefined

### DIFF
--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -36,6 +36,10 @@
     when: subscription_file is not defined
     run_once: true
 
+  - name: Set extra args
+    set_fact:
+      extra_args: "{{ lookup('csvfile', 'extra file={} delimiter=,'.format(subscription_file)) if lookup('csvfile', 'extra file={} delimiter=,'.format(subscription_file)) != [] else '' }}"
+
   - name: Register with subscription-manager
     command: >
       subscription-manager register --auto-attach --force
@@ -43,7 +47,7 @@
       --serverurl="{{ lookup('csvfile', 'serverurl file={} delimiter=,'.format(subscription_file)) }}"
       --username="$USERNAME"
       --password="$PASSWORD"
-      {{ lookup('csvfile', 'extra file={} delimiter=,'.format(subscription_file)) | default('') }}
+      {{ extra_args }}
     environment:
       USERNAME: "{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
       PASSWORD: "{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"

--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -36,10 +36,6 @@
     when: subscription_file is not defined
     run_once: true
 
-  - name: Set extra args
-    set_fact:
-      extra_args: "{{ lookup('csvfile', 'extra file={} delimiter=,'.format(subscription_file)) if lookup('csvfile', 'extra file={} delimiter=,'.format(subscription_file)) != [] else '' }}"
-
   - name: Register with subscription-manager
     command: >
       subscription-manager register --auto-attach --force
@@ -47,7 +43,7 @@
       --serverurl="{{ lookup('csvfile', 'serverurl file={} delimiter=,'.format(subscription_file)) }}"
       --username="$USERNAME"
       --password="$PASSWORD"
-      {{ extra_args }}
+      {{ lookup('csvfile', 'extra file={} default='' delimiter=,'.format(subscription_file)) }}
     environment:
       USERNAME: "{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
       PASSWORD: "{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"


### PR DESCRIPTION
In #153  support was added for passing extra arguments to the
subscription manager command.  If no value was defined in the
subscription csv for 'extras' the lookup command would return []
which would then be added to the end of the subscription manager
command and fail.  Since the return from the lookup is [], the
jinja2 default filter of empty string did not get applied.

The fix I came up with was to set extra_args to the extras lookup
only if the extra lookup is not [].  Otherwise it will set it to
empty string.  This preserves backwards compatability to the old
subscription csv format for people that are already using the test.