### PR TITLE
tests: allow users to skip images in docker-build-httpd

### DIFF
--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -22,7 +22,7 @@
   become: yes
 
   tags:
-    - setup
+    - docker_build_setup
 
   vars_files:
     - vars.yml
@@ -82,7 +82,7 @@
   become: yes
 
   tags:
-    - tests
+    - docker_build_test
 
   vars_files:
     - vars.yml
@@ -103,10 +103,23 @@
       # compatible with the 'with_items' loop control, so I stuck all
       # the tasks into a single role file and used an 'include:'
       # statement on that file.
-    - include: tasks/build_run_remove.yml base_dir={{ working_dir }} image_name={{ item }}
+      #
+      # Added the ability to skip broken images with the 'cli_skipped_images'
+      # variable.  This can be set via the CLI like so:
+      # ansible-playbook -e "cli_skipped_images=busybox_httpd,debian_httpd"
+      #
+    - include: tasks/build_run_remove.yml
+      vars:
+        base_dir: "{{ working_dir }}"
+        image_name: "{{ item }}"
+        skipped_images: "{{ cli_skipped_images | default('') }}"
       with_items: "{{ image_names }}"
 
-    - include: tasks/build_run_remove.yml base_dir={{ working_dir }} image_name={{ item }}
+    - include: tasks/build_run_remove.yml
+      vars:
+        base_dir: "{{ working_dir }}"
+        image_name: "{{ item }}"
+        skipped_images: "{{ cli_skipped_images | default('') }}"
       with_items: "{{ rhel_image_names }}"
       when: ansible_distribution == "RedHat"
 
@@ -116,7 +129,7 @@
   become: yes
 
   tags:
-    - cleanup
+    - docker_build_cleanup
 
   roles:
     - role: docker_remove_all

--- a/tests/docker-build-httpd/tasks/build_run_remove.yml
+++ b/tests/docker-build-httpd/tasks/build_run_remove.yml
@@ -6,39 +6,42 @@
 # tasks needed to be stuck into a single role that is actually used via
 # 'include:' statement.
 #
-- name: Build the httpd image
-  command: "docker build --pull --rm -t {{ image_name }} -f {{ base_dir }}/{{ image_name }}/Dockerfile {{ base_dir }}/{{ image_name }}"
+- block:
+   - name: Build the httpd image
+     command: "docker build --pull --rm -t {{ image_name }} -f {{ base_dir }}/{{ image_name }}/Dockerfile {{ base_dir }}/{{ image_name }}"
 
-- name: Run the httpd image
-  command: "docker run -d -p 80:80 --name {{ image_name }} {{ image_name }}"
+   - name: Run the httpd image
+     command: "docker run -d -p 80:80 --name {{ image_name }} {{ image_name }}"
 
-- name: Wait for port 80
-  wait_for:
-    port: 80
-    delay: 5
+   - name: Wait for port 80
+     wait_for:
+       port: 80
+       delay: 5
 
-- name: Test connectivity
-  get_url:
-    url: http://localhost:80
-    dest: "{{ base_dir }}/index"
-  register: geturl
-  retries: 5
-  delay: 3
-  until: geturl | succeeded
+   - name: Test connectivity
+     get_url:
+       url: http://localhost:80
+       dest: "{{ base_dir }}/index"
+     register: geturl
+     retries: 5
+     delay: 3
+     until: geturl | succeeded
 
-- name: Test the content from httpd container
-  command: "grep 'SUCCESS {{ image_name }}' {{ base_dir }}/index"
+   - name: Test the content from httpd container
+     command: "grep 'SUCCESS {{ image_name }}' {{ base_dir }}/index"
 
-- name: Cleanup content
-  file:
-    path: "{{ base_dir }}/index"
-    state: absent
+   - name: Cleanup content
+     file:
+       path: "{{ base_dir }}/index"
+       state: absent
 
-- name: Stop the httpd container
-  command: "docker stop {{ image_name }}"
+   - name: Stop the httpd container
+     command: "docker stop {{ image_name }}"
 
-- name: Remove the httpd container
-  command: "docker rm {{ image_name }}"
+   - name: Remove the httpd container
+     command: "docker rm {{ image_name }}"
 
-- name: Remove the httpd image
-  command: "docker rmi {{ image_name }}"
+   - name: Remove the httpd image
+     command: "docker rmi {{ image_name }}"
+
+  when: image_name not in skipped_images


### PR DESCRIPTION
I ran into the following bug while testing:

https://bugzilla.redhat.com/show_bug.cgi?id=1460341

...and realized there was no easy way to skip the images that were
failing.  This was frustrating, so I fixed it.

The test can now accept an extra var named `cli_skipped_images` which
will take a string of image names to be skipped by the test.  If the
name of the current image under test is in that string, the test skips
that image.

There is no validation that the string contains valid values or
anything like that, so it is up to the user to be smart when using it.