### PR TITLE
Use correct git diff to determine tests to run

### DIFF
--- a/.test_director
+++ b/.test_director
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# check commit
-HEAD=${PAPR_COMMIT:-HEAD}
-NEW_TESTS=( $(git diff --name-only origin/master..$HEAD | grep 'tests/.*/main.yml' || true) )
+NEW_TESTS=( $(git diff --name-only $(git merge-base origin/master HEAD) | grep 'tests/.*/main.yml' || true) )
 
 # no new tests found, just run improved sanity test
 if [ ${#NEW_TESTS[@]} -eq 0 ]; then


### PR DESCRIPTION
The two dot notation used originally does not work the same way in
git diff as other git commands.  Git diff expects two endpoints as
opposed to a range.  This was causing the diff to return files that
were not a part of the PR to be included in the automatic tests that
are run when there is a new PR.