### PR TITLE
selinux_verify:  enable support for rawhide

### DIFF
--- a/roles/selinux_verify/vars/fedora-27.yml
+++ b/roles/selinux_verify/vars/fedora-27.yml
@@ -1,0 +1,1 @@
+fedora-26.yml


### PR DESCRIPTION
The `selinux_verify` role was failing when run against the Rawhide
version of Atomic Host.  Rawhide Atomic Host reports itself as Fedora
27 via Ansible, but has the same files/procs as Fedora 26 (in the
context of this role), so just symlink to the `fedora-26.yml`.

Closes #180