### PR TITLE
selinux_verify: add support for RHELAH 7.4

### DIFF
--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Include distribution specific vars
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml"
     - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution|lower }}.yml"
 

--- a/roles/selinux_verify/vars/redhat-7.4.yml
+++ b/roles/selinux_verify/vars/redhat-7.4.yml
@@ -1,0 +1,28 @@
+---
+distro_files:
+  - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-shim', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-shim-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-shim-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-ctr-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-ctr-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/dockerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/dockerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/dockerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-latest-storage-setup', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/container-storage-setup', value: 'system_u:object_r:bin_t:s0' }
+  - { key: '/usr/libexec/docker/docker-init-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-lvm-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-novolume-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-proxy-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-proxy-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-runc-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-runc-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+
+distro_procs:
+  - { key: 'docker', value: 'system_u:system_r:container_runtime_t:s0' }


### PR DESCRIPTION
In RHELAH 7.4, a few changes made that required an update to the files
being checked for SELinux labels.

This allows to test RHELAH 7.3 and the pre-release version of RHELAH
7.4 at the same time.  When 7.4 is released, we could remove this
specialized file if we decide to.