### PR TITLE
i-s-t: cleanup any extra deployments at the end

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -643,6 +643,12 @@
       tags:
         - var_files_present
 
+    # cleanup any extra deployments
+    - role: rpm_ostree_cleanup_all
+      tags:
+        - rpm_ostree_cleanup_all
+        - cloud_image
+
     # cleanup our subscriptions because we are nice people
     - role: redhat_unsubscribe
       when: ansible_distribution == 'RedHat'

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -643,14 +643,30 @@
       tags:
         - var_files_present
 
-    # uninstall and verify that 'httpd' is no longer there
-    # this works even if the 'httpd' RPM wasn't originally installed
+    # The hacks will continue until...well, forever.
+    # In an Ansible play, variables set in one role are available to other
+    # roles in the same play.  So we make use of this 'feature' by getting
+    # the packages installed in the booted deployment (having high
+    # confidence that the booted deployment here is '0'), which we can then
+    # use to determine if we need to uninstall the 'httpd' package.
+    - role: rpm_ostree_status
+      tags:
+        - rpm_ostree_status
+
     - role: rpm_ostree_uninstall
       packages: httpd
-      reboot: yes
+      reboot: true
+      when: "'httpd' in ros_json['deployments'][0]['packages']"
+      tags:
+        - rpm_ostree_uninstall
+        - cloud_image
 
     - role: rpm_ostree_uninstall_verify
       package: httpd
+      when: "'httpd' in ros_json['deployments'][0]['packages']"
+      tags:
+        - rpm_ostree_uninstall_verify
+        - cloud_image
 
     # cleanup any extra deployments
     - role: rpm_ostree_cleanup_all

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -643,6 +643,15 @@
       tags:
         - var_files_present
 
+    # uninstall and verify that 'httpd' is no longer there
+    # this works even if the 'httpd' RPM wasn't originally installed
+    - role: rpm_ostree_uninstall
+      packages: httpd
+      reboot: yes
+
+    - role: rpm_ostree_uninstall_verify
+      package: httpd
+
     # cleanup any extra deployments
     - role: rpm_ostree_cleanup_all
       tags:


### PR DESCRIPTION
When running the `improved-sanity-test` using `--tags cloud_image` the
system is left with a 'hotfix' deployment in the waiting.  If we want
to use the system again to run additional tests, the nice thing to do
is to cleanup after ourselves.

In the case of normal execution, where the system starts at HEAD-1,
upgrades, than rolls back to HEAD-1, we will end up cleaning the
deployment at HEAD.  I'm of the opinion this isn't a deal-breaker.