### PR TITLE
atomic_scan_verify:  remove /etc/atomic.d/ workaround

### DIFF
--- a/roles/atomic_scan_verify/tasks/main.yml
+++ b/roles/atomic_scan_verify/tasks/main.yml
@@ -27,20 +27,6 @@
     msg="Atomic install was unsuccessful"
   when: "'Installation complete' not in result.stdout"
 
-  # Because the 'atomic install' of the 'rhel7/openscap' image drops a config
-  # file in '/etc/atomic.d/' which doesn't use a fully-qualified image name,
-  # this causes a problem on non RHEL hosts. See:
-  #
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1418464
-  #
-  # We need to work around it until it gets fixed. It's a safe change to make
-  # for RHEL hosts too, so let's just do it everywhere.
-- name: Modify image name in /etc/atomic.d/openscap
-  lineinfile:
-    destfile: /etc/atomic.d/openscap
-    regexp: '^image_name:*'
-    line: 'image_name: registry.access.redhat.com/rhel7/openscap'
-
   # Use 'docker pull' for now; maybe switch to 'atomic pull' once all the
   # streams have support for v1 schema manifests
 - name: Pull scanner target


### PR DESCRIPTION
We no longer need to modify `/etc/atomic.d/openscap` because the
OpenSCAP container we use has been fixed.

See [RHBZ#1418464](https://bugzilla.redhat.com/show_bug.cgi?id=1418464)