### PR TITLE
add support for removing all installed packages

### DIFF
--- a/roles/rpm_ostree_uninstall/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall/tasks/main.yml
@@ -41,31 +41,35 @@
         ros_not_booted: "{{ ros_json['deployments'][0] if ros_json['deployments'][0] is defined else false }}"
       when: ros_json['deployments'][1] is defined and ros_json['deployments'][1]['booted']
 
+    # If the 'packages' key has a value, we create a list of packages to
+    # uninstall, otherwise skip it
     - name: Get all installed packages
       set_fact:
         all_installed: "{{ ros_booted['packages']|join(' ') }}"
+      when: ros_booted['packages']|length > 0
   when: packages == "all"
 
-# If the 'all_installed' variable is defined, we use that otherwise just use
-# the supplied 'packages' variable.  NOTE: 'all_installed' could be an empty
-# string and we don't check for it because I'm making the wrong assumption
-# that users are well behaved.  ¯\_(ツ)_/¯
+# Check to see if 'all_installed' was defined above, otherwise we use the
+# original value of 'packages'.  It could be 'all', which means we want to
+# uninstall all packages but there were no packages actually installed.
+#
+# Hat tip to @mike-nguyen for the logic to do this
 - name: Setup 'rm_packages' variable
   set_fact:
     rm_packages: "{{ all_installed if all_installed is defined else packages }}"
 
 - name: Uninstall {{ rm_packages }}
   command: rpm-ostree uninstall {{ rm_packages }}
-  when: not reboot
+  when: not reboot and rm_packages != "all"
 
 - name: Uninstall {{ rm_packages }} and reboot
   command: rpm-ostree uninstall {{ rm_packages }} -r
   async: 60
   poll: 0
-  when: reboot
+  when: reboot and rm_packages != "all"
   ignore_errors: true
 
 - include: ../../../common/ans_reboot.yml
   vars:
     skip_shutdown: true # shutdown was already initiated
-  when: reboot
+  when: reboot and rm_packages != "all"

--- a/roles/rpm_ostree_uninstall/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall/tasks/main.yml
@@ -6,6 +6,7 @@
 #
 # Parameters:
 #  packages - string of one or more packages separated by a space
+#             or use the 'all' keyword to uninstall everything
 #  reboot - boolean - pass -r flag to install command
 #
 
@@ -19,12 +20,46 @@
     msg: "Reboot is not defined"
   when: reboot is undefined
 
-- name: Uninstall {{ packages }}
-  command: rpm-ostree uninstall {{ packages }}
+- block:
+    - name: Get rpm-ostree status
+      command: rpm-ostree status --json
+      register: ros
+
+    - name: Convert to JSON
+      set_fact:
+        ros_json: "{{ ros.stdout|from_json }}"
+
+    - name: Set ros variable if deployment 0 is booted
+      set_fact:
+        ros_booted: "{{ ros_json['deployments'][0] }}"
+        ros_not_booted: "{{ ros_json['deployments'][1] if ros_json['deployments'][1] is defined else false }}"
+      when: ros_json['deployments'][0] is defined and ros_json['deployments'][0]['booted']
+
+    - name: Set ros variable if deployment 1 is booted
+      set_fact:
+        ros_booted: "{{ ros_json['deployments'][1] }}"
+        ros_not_booted: "{{ ros_json['deployments'][0] if ros_json['deployments'][0] is defined else false }}"
+      when: ros_json['deployments'][1] is defined and ros_json['deployments'][1]['booted']
+
+    - name: Get all installed packages
+      set_fact:
+        all_installed: "{{ ros_booted['packages']|join(' ') }}"
+  when: packages == "all"
+
+# If the 'all_installed' variable is defined, we use that otherwise just use
+# the supplied 'packages' variable.  NOTE: 'all_installed' could be an empty
+# string and we don't check for it because I'm making the wrong assumption
+# that users are well behaved.  ¯\_(ツ)_/¯
+- name: Setup 'rm_packages' variable
+  set_fact:
+    rm_packages: "{{ all_installed if all_installed is defined else packages }}"
+
+- name: Uninstall {{ rm_packages }}
+  command: rpm-ostree uninstall {{ rm_packages }}
   when: not reboot
 
-- name: Uninstall {{ packages }} and reboot
-  command: rpm-ostree uninstall {{ packages }} -r
+- name: Uninstall {{ rm_packages }} and reboot
+  command: rpm-ostree uninstall {{ rm_packages }} -r
   async: 60
   poll: 0
   when: reboot

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -644,29 +644,12 @@
       tags:
         - var_files_present
 
-    # The hacks will continue until...well, forever.
-    # In an Ansible play, variables set in one role are available to other
-    # roles in the same play.  So we make use of this 'feature' by getting
-    # the packages installed in the booted deployment (having high
-    # confidence that the booted deployment here is '0'), which we can then
-    # use to determine if we need to uninstall the 'httpd' package.
-    - role: rpm_ostree_status
-      tags:
-        - rpm_ostree_status
-
+    # use 'all' keyword to remove all installed pacakges
     - role: rpm_ostree_uninstall
-      packages: httpd
+      packages: all
       reboot: true
-      when: "'httpd' in ros_json['deployments'][0]['packages']"
       tags:
         - rpm_ostree_uninstall
-        - cloud_image
-
-    - role: rpm_ostree_uninstall_verify
-      package: httpd
-      when: "'httpd' in ros_json['deployments'][0]['packages']"
-      tags:
-        - rpm_ostree_uninstall_verify
         - cloud_image
 
     # cleanup any extra deployments


### PR DESCRIPTION
Sometimes you just want all the installed packages removed, so this
introduces support for the `all` keyword in the `rpm_ostree_uninstall`
role.  It is not 100% bulletproof, since it is possible a user could
use the `all` keyword when there is nothing installed and then the
role will probably blow up.  But I'm hoping that we are better than that.

There could be additional work done in the
`rpm_ostree_uninstall_verify` role to support the `all` keyword, too.
But I was unable to arrive a solution that would both verify the
packages were uninstalled and the binaries were removed.