### PR TITLE
roles: add retries to network operations

### DIFF
--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -24,6 +24,10 @@
 
 - name: Install cockpit container with tag
   command: "atomic install {{ cockpit_cname }}:latest"
+  register: aic
+  retries: 5
+  delay: 60
+  until: aic|success
 
 - name: Check for /etc/pam.d/cockpit
   stat:

--- a/roles/atomic_scan_verify/tasks/main.yml
+++ b/roles/atomic_scan_verify/tasks/main.yml
@@ -21,6 +21,9 @@
 - name: Install openscap
   command: atomic install {{ scanner_image }}
   register: result
+  retries: 5
+  delay: 60
+  until: result|success
 
 - name: Check installation of openscap
   fail:
@@ -31,6 +34,10 @@
   # streams have support for v1 schema manifests
 - name: Pull scanner target
   command: docker pull {{ scanner_target }}
+  register: dps
+  retries: 5
+  delay: 60
+  until: dps|success
 
 - name: Run atomic scan
   command: atomic --debug scan --scanner {{ scanner_type }} {{ scanner_target }}

--- a/roles/atomic_system_install/tasks/main.yml
+++ b/roles/atomic_system_install/tasks/main.yml
@@ -11,3 +11,7 @@
 
 - name: Install system container
   command: atomic install --system {{ image }}
+  register: ais
+  retries: 5
+  delay: 60
+  until: ais|success

--- a/roles/docker_pull_base_image/tasks/main.yml
+++ b/roles/docker_pull_base_image/tasks/main.yml
@@ -8,6 +8,10 @@
 
 - name: Pull base image
   command: "docker pull {{ g_osname }}"
+  register: dpi
+  retries: 5
+  delay: 60
+  until: dpi|success
 
 - name: List Docker images
   command: docker images

--- a/roles/docker_pull_run_remove/tasks/main.yml
+++ b/roles/docker_pull_run_remove/tasks/main.yml
@@ -6,6 +6,10 @@
 - name: Pull the popular images from Docker Hub
   command: "docker pull docker.io/{{ item }}"
   with_items: "{{ popular_images }}"
+  register: dpd
+  retries: 5
+  delay: 60
+  until: dpd|success
 
 - name: Run the popular images
   command: "docker run --rm docker.io/{{ item }} echo 'hello'"

--- a/roles/epel_rpm_url/tasks/main.yml
+++ b/roles/epel_rpm_url/tasks/main.yml
@@ -30,6 +30,9 @@
 - name: Scrape HTML for package name
   shell: curl -LsSk {{ epel_subdir }}/ | sed -n 's/.*"\({{ rpm_name }}.*.rpm\)\".*/\1/p'
   register: epel_output
+  retries: 5
+  delay: 60
+  until: epel_output|success
 
 - name: Set epel_rpm_url
   set_fact:

--- a/roles/rpm_install/tasks/main.yml
+++ b/roles/rpm_install/tasks/main.yml
@@ -12,4 +12,8 @@
   when: rpm_url is undefined
 
 - name: Install {{ rpm_url }}
-  command:  rpm -i {{ rpm_url }}
+  command: rpm -i {{ rpm_url }}
+  register: rpmi
+  retries: 5
+  delay: 60
+  until: rpmi|success

--- a/roles/rpm_ostree_install/tasks/main.yml
+++ b/roles/rpm_ostree_install/tasks/main.yml
@@ -21,6 +21,9 @@
 - name: Install {{ packages }} and no reboot
   command: rpm-ostree install {{ packages }}
   register: install
+  retries: 5
+  delay: 60
+  until: install|success
   when: not reboot
 
 - name: Install {{ packages }} and reboot

--- a/roles/rpm_ostree_rebase/tasks/main.yml
+++ b/roles/rpm_ostree_rebase/tasks/main.yml
@@ -19,6 +19,6 @@
 - name: Rebase
   command: rpm-ostree rebase {{ remote_name }}:{{ refspec }}
   register: rebase
-  until: rebase.rc == 0
-  retries: 3
-  delay: 5
+  retries: 5
+  delay: 60
+  until: rebase|success

--- a/roles/rpm_ostree_upgrade/tasks/main.yml
+++ b/roles/rpm_ostree_upgrade/tasks/main.yml
@@ -6,6 +6,6 @@
 - name: Perform the upgrade
   command: rpm-ostree upgrade --upgrade-unchanged-exit-77
   register: upgrade
-  until: upgrade.rc == 0
-  retries: 3
-  delay: 5
+  retries: 5
+  delay: 60
+  until: upgrade|success


### PR DESCRIPTION
This adds retry logic to roles that rely on external network
operations.  I settled on 5 retries per action with delays of 60s
between each attempt.  This should help mitigate some of the failures
we encounter when the network is flaky.

Additionally, I re-wrote some of the existing retries to follow the
format of:

```
register: <var>
retries: 5
delay: 60
until: <var>|success
```

This makes our retry logic more consistent across roles.

This is another commit to address #156