### PR TITLE
tests: unsubscribe at end of system-containers test

### DIFF
--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -575,3 +575,7 @@
     - role: atomic_images_delete_all
       tags:
         - atomic_images_delete_all
+
+    - role: redhat_unsubscribe
+      tags:
+        - redhat_unsubscribe

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -577,5 +577,6 @@
         - atomic_images_delete_all
 
     - role: redhat_unsubscribe
+      when: ansible_distribution == 'RedHat'
       tags:
         - redhat_unsubscribe


### PR DESCRIPTION
We should be removing our subscriptions at the end of the
`system-containers` test.