### PR TITLE
tests: implement retries on network operations

### DIFF
--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -70,10 +70,18 @@
     - name: Pull all the upstream base images
       command: "docker pull {{ item }}"
       with_items: "{{ base_images }}"
+      register: dp_upstream
+      retries: 5
+      delay: 60
+      until: dp_upstream|success
 
     - name: Pull the Red Hat base images
       command: "docker pull {{ item }}"
       with_items: "{{ rhel_base_images }}"
+      register: dp_rhel
+      retries: 5
+      delay: 60
+      until: dp_rhel|success
       when: ansible_distribution == "RedHat"
 
 

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -199,6 +199,10 @@
   tasks:
     - name: Test Install {{ g_pkg1 }} and do not reboot
       command: rpm-ostree install {{ g_pkg1 }}
+      register: roi_pkg1
+      retries: 5
+      delay: 60
+      until: roi_pkg1|success
 
     - name: Dry run install {{ g_pkg2 }}
       command: rpm-ostree install {{ g_pkg2 }} --dry-run
@@ -270,6 +274,10 @@
 
     - name: Install {{ g_epel_pkg }} from EPEL
       command: rpm-ostree install {{ g_epel_pkg }}
+      register: roi_epel
+      retries: 5
+      delay: 60
+      until: roi_epel|success
 
     - include: ../../common/ans_reboot.yml
 

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -59,9 +59,9 @@
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
       register: osp
-      until: osp.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: ops|success
 
     - name: Get HEAD-1 version
       shell: ostree show $(ostree rev-parse {{ refspec }}^) --print-metadata-key version | tr -d \'
@@ -70,9 +70,9 @@
     - name: Deploy HEAD-1
       command: rpm-ostree deploy {{ hmo_version.stdout }}
       register: ros_deploy
-      until: ros_deploy.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: ros_deploy|success
 
     # reboot
     - include: ../../common/ans_reboot.yml
@@ -139,9 +139,9 @@
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
       register: osp
-      until: osp.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: osp|success
 
     - name: Get HEAD-1 checksum
       shell: ostree rev-parse {{ refspec }}^
@@ -150,9 +150,9 @@
     - name: Deploy HEAD-1
       command: rpm-ostree deploy {{ hmo_csum.stdout }}
       register: ros_deploy
-      until: ros_deploy.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: ros_deploy|success
 
     # reboot
     - include: ../../common/ans_reboot.yml
@@ -218,9 +218,9 @@
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
       register: osp
-      until: osp.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: osp|success
 
     - name: Get HEAD-1 checksum
       command: ostree rev-parse {{ refspec }}^
@@ -229,9 +229,9 @@
     - name: Deploy version HEAD-1
       command: rpm-ostree deploy {{ hmo_csum.stdout }}
       register: ros_deploy
-      until: ros_deploy.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: ros_deploy|success
 
     # verify pending deployment info
     - include: roles/rpm_ostree_status_verify/tasks/main.yml
@@ -321,6 +321,10 @@
 
     - name: Rebase back to original deployment
       command: rpm-ostree rebase {{ refspec }} {{ head_csum }}
+      register: ros_rebase
+      retries: 5
+      delay: 60
+      until: ros_rebase|success
 
     # reboot
     - include: ../../common/ans_reboot.yml
@@ -390,9 +394,9 @@
     - name: Upgrade
       command: rpm-ostree upgrade --install {{ g_pkg }}
       register: ros_upgrade
-      until: ros_upgrade.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: ros_upgrade|success
 
     # reboot
     - include: ../../common/ans_reboot.yml
@@ -435,9 +439,9 @@
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
       register: osp
-      until: osp.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: osp|success
 
     - name: Get HEAD-1 checksum
       command: ostree rev-parse {{ refspec }}^
@@ -446,9 +450,9 @@
     - name: Deploy HEAD-1
       command: rpm-ostree deploy {{ hmo_csum.stdout }} --uninstall {{ g_pkg }}
       register: ros_deploy
-      until: ros_deploy.rc == 0
       retries: 5
-      delay: 5
+      delay: 60
+      until: ros_deploy|success
 
     # reboot
     - include: ../../common/ans_reboot.yml

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -61,7 +61,7 @@
       register: osp
       retries: 5
       delay: 60
-      until: ops|success
+      until: osp|success
 
     - name: Get HEAD-1 version
       shell: ostree show $(ostree rev-parse {{ refspec }}^) --print-metadata-key version | tr -d \'

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -397,6 +397,10 @@
         --system
         --name=etcd
         {{ etcd_image }}
+      register: ai_etcd
+      retries: 5
+      delay: 60
+      until: ai_etcd|success
 
     - name: Start etcd
       command: systemctl start etcd
@@ -422,6 +426,10 @@
         --system
         --name=flannel
         {{ flannel_image }}
+      register: ai_flannel
+      retries: 5
+      delay: 60
+      until: ai_flannel|success
 
     - name: Start flannel
       command: systemctl start flannel


### PR DESCRIPTION
Some of the tests use bare tasks to perform the operations they need,
so I've implemented retries on those that access the network.

Any existing retries that I found were rewritten to the new format of:

```
register: result
retries: 5
delay: 60
until: result|success
```