### PR TITLE
Add etcd system container test to I-S-T

### DIFF
--- a/roles/command/tasks/main.yml
+++ b/roles/command/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# vim: set ft=ansible:
+#
+# Runs a command and optionally checks stdout output
+#
+# Parameters:
+#   cmd (string) - command to run
+#   output (string) - optional substring to check for in stdout
+#                     use caution as it is a substring search
+#
+
+- name: Fail if cmd is not defined
+  fail:
+    msg: "cmd is undefined"
+  when: cmd is undefined
+
+- name: Run command
+  command: "{{ cmd }}"
+  register: cmd_output
+
+- name: Verify output
+  fail:
+    msg: "{{ output }} is not in command output"
+  when: output is defined and
+        output not in cmd_output.stdout

--- a/roles/etcd_sys_container_install/tasks/main.yml
+++ b/roles/etcd_sys_container_install/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+# vim: set ft=ansible:
+#
+# This role installs etcd system container and verifies installation by setting
+#   and retrieving the /atomic.io/network/config key/pair.  It will optionally
+#   delete the key after
+#
+# Parameters:
+#   delete_key (boolean) - optional parameter to delete key after
+#     verifying the set and get of the key.  This is useful since etcd
+#     keys are preserved even after uninstalling the system container
+#
+
+- name: Set facts
+  set_fact:
+    etcd_image: 'registry.access.redhat.com/rhel7/etcd'
+    etcd_name: 'etcd'
+  when: ansible_distribution == 'RedHat'
+
+- name: Set facts
+  set_fact:
+    etcd_image: 'registry.fedoraproject.org/f25/etcd'
+    etcd_name: 'etcd'
+  when: ansible_distribution != 'RedHat'
+
+- name: Install etcd
+  command: >
+    atomic install
+    --system
+    --name=etcd
+    {{ etcd_image }}
+  register: ai_etcd
+  retries: 5
+  delay: 60
+  until: ai_etcd|success
+
+- name: Start etcd
+  command: systemctl start etcd
+
+- name: Verify etcd is active
+  command: systemctl is-active etcd
+  register: etcd_output
+  failed_when: "'active' not in etcd_output.stdout"
+
+- name: Wait for etcd port to open
+  wait_for:
+    port: 2379
+    timeout: 30
+
+- name: Configure etcd
+  command: >
+    runc exec etcd etcdctl
+    set /atomic.io/network/config '{"Network":"172.17.0.0/16"}'
+  register: set_etcd
+
+- name: Verify etcd settings
+  command: >
+    runc exec etcd etcdctl
+    get /atomic.io/network/config
+  register: get_etcd
+  failed_when: set_etcd.stdout != get_etcd.stdout
+
+- name: Delete key
+  command: >
+    runc exec etcd etcdctl
+    rm /atomic.io/network/config
+  when: delete_key is defined and delete_key
+
+- name: Verify key is deleted
+  command: >
+    runc exec etcd etcdctl
+    get /atomic.io/network/config
+  register: get_etcd
+  failed_when: get_etcd.rc == 0
+  when: delete_key is defined and delete_key

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# vim: set ft=ansible:
+#
+# Runs a command and optionally checks stdout output
+#
+# Parameters:
+#   cmd (string) - command to run
+#   output (string) - optional string to check for in stdout
+#                     use caution as it is a substring search
+#
+
+- name: Fail if cmd is not defined
+  fail:
+    msg: "cmd is undefined"
+  when: cmd is undefined
+
+- name: Run command
+  shell: "{{ cmd }}"
+  register: cmd_output
+
+- name: Verify output
+  fail:
+    msg: "{{ output }} is not in command output"
+  when: output is defined and
+        output not in cmd_output.stdout

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -282,6 +282,11 @@
         - atomic_installation_verify
         - cloud_image
 
+    # Install etcd system container
+    - role: etcd_sys_container_install
+      tags:
+        - etcd_sys_container_install
+
     # Upgrade and reboot
     - role: rpm_ostree_upgrade
       tags:
@@ -388,6 +393,48 @@
       package: "{{ g_pkg }}"
       tags:
         - rpm_ostree_install_verify
+
+    # Check etcd system container is still running
+    - role: command
+      cmd: systemctl status etcd
+      output: 'active (running)'
+      tags:
+        - command
+
+    # Uninstall etcd system container
+    - role: atomic_system_uninstall
+      name: etcd
+      tags:
+        - atomic_system_uninstall
+
+    # Verify etcd system container uninstall
+    - role: atomic_system_uninstall_verify
+      image: etcd
+      tags:
+        - atomic_system_uninstall_verify
+
+    # Install etcd system container
+    - role: etcd_sys_container_install
+      delete_key: True
+      tags:
+        - etcd_sys_container_install
+        - cloud_image
+      check_mode: no
+
+    # Uninstall etcd system container
+    - role: atomic_system_uninstall
+      name: etcd
+      tags:
+        - atomic_system_uninstall
+        - cloud_image
+      check_mode: no
+
+    # Verify etcd system container uninstall
+    - role: atomic_system_uninstall_verify
+      image: etcd
+      tags:
+        - atomic_system_uninstall_verify
+        - cloud_image
 
     - role: rpm_ostree_install
       packages: httpd


### PR DESCRIPTION
etcd_sys_container_install role:
This check-in is a simple system container test for the improved sanity test (IST)
Because the IST is comprised of only roles (and cannot be mixed with tasks), the
etcd_sys_container_install role was made specifically to validate the install
and configuration of etcd for IST.

improved sanity test:
In the IST, the etcd system container is installed and configured pre-upgrade
and checked post upgrade for its existence.  Then it is removed and re-installed
to test the system container installation on HEAD.  On a cloud_image test, the
installation, configuration, and uninstallation is only checked once in the post
upgrade section. This was done to ensure we have some coverage on the upgrade
scenario and when running the test on a cloud_image with no upgrade.

command / shell role:
I added these two simple roles because sometimes you just want to run a command
and check the output when you are in a role block.  The command role was used
to quickly validate the etcd service is running.