### PR TITLE
Update handling of /etc/sysconfig/docker for docker-latest

### DIFF
--- a/roles/docker_build_httpd/tasks/main.yml
+++ b/roles/docker_build_httpd/tasks/main.yml
@@ -47,6 +47,10 @@
 
 - name: Build httpd image
   command: "docker build -t {{ g_httpd_name }} -f {{ build_dir }}/{{ g_httpd_name }}_Dockerfile {{ build_dir }}"
+  register: db
+  retries: 5
+  delay: 60
+  until: db|success
 
 - name: Get docker images after build
   command: docker images

--- a/roles/docker_latest_setup/tasks/main.yml
+++ b/roles/docker_latest_setup/tasks/main.yml
@@ -10,17 +10,20 @@
     state: stopped
     enabled: no
 
+- name: Change docker binary
+  blockinfile:
+    dest: /etc/sysconfig/docker
+    block: |
+      DOCKERBINARY=/usr/bin/docker-latest
+      DOCKERDBINARY=/usr/bin/dockerd-latest
+      DOCKER_CONTAINERD_BINARY=/usr/bin/docker-containerd-latest
+      DOCKER_CONTAINERD_SHIM_BINARY=/usr/bin/docker-containerd-shim-latest
+
 - name: Enable and start docker-latest service
   service:
     name: docker-latest
     state: started
     enabled: yes
-
-- name: Change docker binary
-  replace:
-    dest: /etc/sysconfig/docker
-    regexp: '#DOCKERBINARY=/usr/bin/docker-latest'
-    replace: 'DOCKERBINARY=/usr/bin/docker-latest'
 
 - name: Get docker version
   command: docker --version

--- a/tests/docker/main.yml
+++ b/tests/docker/main.yml
@@ -121,10 +121,13 @@
           state: stopped
 
       - name: Revert docker-latest binary
-        replace:
+        blockinfile:
           dest: /etc/sysconfig/docker
-          regexp: 'DOCKERBINARY=/usr/bin/docker-latest'
-          replace: '#DOCKERBINARY=/usr/bin/docker-latest'
+          block: |
+            #DOCKERBINARY=/usr/bin/docker-latest
+            #DOCKERDBINARY=/usr/bin/dockerd-latest
+            #DOCKER_CONTAINERD_BINARY=/usr/bin/docker-containerd-latest
+            #DOCKER_CONTAINERD_SHIM_BINARY=/usr/bin/docker-containerd-shim-latest
 
       - name: Re-enable docker
         service:


### PR DESCRIPTION
The more recent versions (1.13, I think) of `docker-latest`
require additional lines to be modified in `/etc/sysconfig/docker` for
everything to play happy together.

Closes #192