### PR TITLE
Enable Fedora 26 testing via PAPR

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -34,6 +34,18 @@ inherit: true
 cluster:
   hosts:
     - name: testnode
+      distro: fedora/26/atomic
+  container:
+    image: registry.fedoraproject.org/fedora:25
+
+context: fedora/26/atomic
+
+---
+inherit: true
+
+cluster:
+  hosts:
+    - name: testnode
       distro: centos/7/atomic
   container:
     image: registry.fedoraproject.org/fedora:25


### PR DESCRIPTION
Today is the release of Fedora 26, so we should start using it in our
own PAPR tests.