### PR TITLE
Update Dockerfiles to use proper FROM field

### DIFF
--- a/roles/docker_build_httpd/files/centos_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/centos_httpd_Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM registry.centos.org/centos/centos:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.2

--- a/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/fedora_httpd_Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM registry.fedoraproject.org/fedora:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.2

--- a/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
+++ b/roles/docker_build_httpd/files/rhel7_httpd_Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.3

--- a/roles/docker_build_tag_push/files/centos/db/Dockerfile
+++ b/roles/docker_build_tag_push/files/centos/db/Dockerfile
@@ -1,5 +1,5 @@
 # Pull the rhel image from the local repository
-FROM docker.io/centos:7
+FROM registry.centos.org/centos/centos:latest
 USER root
 
 MAINTAINER Maintainer_Name

--- a/roles/docker_build_tag_push/files/centos/web/Dockerfile
+++ b/roles/docker_build_tag_push/files/centos/web/Dockerfile
@@ -3,7 +3,7 @@
 # Version 1
 
 # Pull the rhel image from the local repository
-FROM docker.io/centos:7
+FROM registry.centos.org/centos/centos:latest
 USER root
 
 MAINTAINER Maintainer_Name

--- a/roles/docker_build_tag_push/files/fedora/db/Dockerfile
+++ b/roles/docker_build_tag_push/files/fedora/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:25
+FROM registry.fedoraproject.org/fedora:latest
 USER root
 
 MAINTAINER Maintainer_Name

--- a/roles/docker_build_tag_push/files/fedora/web/Dockerfile
+++ b/roles/docker_build_tag_push/files/fedora/web/Dockerfile
@@ -1,5 +1,5 @@
 # Pull the rhel image from the local repository
-FROM registry.fedoraproject.org/fedora:25
+FROM registry.fedoraproject.org/fedora:latest
 USER root
 
 MAINTAINER Maintainer_Name

--- a/roles/docker_build_tag_push/files/rhel7/db/Dockerfile
+++ b/roles/docker_build_tag_push/files/rhel7/db/Dockerfile
@@ -3,7 +3,7 @@
 # Version 1
 
 # Pull the rhel image from the local repository
-FROM registry.access.redhat.com/rhel:7.3
+FROM registry.access.redhat.com/rhel:latest
 USER root
 
 MAINTAINER Maintainer_Name

--- a/roles/docker_build_tag_push/files/rhel7/web/Dockerfile
+++ b/roles/docker_build_tag_push/files/rhel7/web/Dockerfile
@@ -3,7 +3,7 @@
 # Version 1
 
 # Pull the rhel image from the local repository
-FROM registry.access.redhat.com/rhel:7.3
+FROM registry.access.redhat.com/rhel:latest
 USER root
 
 MAINTAINER Maintainer_Name

--- a/tests/docker-build-httpd/files/alpine_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/alpine_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine
+FROM docker.io/alpine:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.1

--- a/tests/docker-build-httpd/files/apache_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/apache_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/httpd
+FROM docker.io/httpd:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.0

--- a/tests/docker-build-httpd/files/busybox_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/busybox_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/busybox
+FROM docker.io/busybox:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.0

--- a/tests/docker-build-httpd/files/debian_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/debian_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian
+FROM docker.io/debian:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.2

--- a/tests/docker-build-httpd/files/nginx_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/nginx_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nginx
+FROM docker.io/nginx:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.0

--- a/tests/docker-build-httpd/files/rhel7-atomic_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/rhel7-atomic_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7-atomic
+FROM registry.access.redhat.com/rhel7-atomic:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.0

--- a/tests/docker-build-httpd/files/rhel7_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/rhel7_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.3

--- a/tests/docker-build-httpd/files/ubuntu_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/ubuntu_httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu
+FROM docker.io/ubuntu:latest
 MAINTAINER Micah Abbott <micah@redhat.com>
 
 LABEL Version=1.3


### PR DESCRIPTION
The Dockerfiles we use in our tests had a myriad of FROM formats, so
this cleans up the state of those.  Now all the FROM lines have the
following:

- fully-qualified domain
- explict tag (:latest or otherwise)

Additionally, the CentOS and Fedora base images are changed to be
pulled from the community registries instead of docker.io