### PR TITLE
add support for /etc/containers/registries.conf

### DIFF
--- a/roles/docker_private_registry/tasks/main.yml
+++ b/roles/docker_private_registry/tasks/main.yml
@@ -9,17 +9,32 @@
     when: ansible_docker0.ipv4.address is not defined
     run_once: true
 
+  - name: Check for /etc/containers/registries.conf
+    stat:
+      path: /etc/containers/registries.conf
+    register: reg
+
+  - name: add registeries
+    blockinfile:
+      dest: /etc/containers/registries.conf
+      block: |
+        insecure_registries:
+          - {{ ansible_docker0.ipv4.address }}:5000
+    when: reg.stat.exists
+
   - name: edit /etc/sysconfig/docker file to add private registry
     replace:
       dest=/etc/sysconfig/docker
       regexp="^ADD_REGISTRY='--add-registry registry.access.redhat.com'"
       replace="ADD_REGISTRY='--add-registry {{ ansible_docker0.ipv4.address }}:5000 --add-registry registry.access.redhat.com'"
+    when: reg.stat.exists == False
 
   - name: edit /etc/sysconfig/docker file to enable insecure registry
     replace:
       dest=/etc/sysconfig/docker
       regexp='^# INSECURE_REGISTRY=\'--insecure-registry\s?\''
       replace='INSECURE_REGISTRY=\'--insecure-registry {{ ansible_docker0.ipv4.address }}:5000\''
+    when: reg.stat.exists == False
 
   - name: stop docker
     service:


### PR DESCRIPTION
Supported is needed for an additional  scenario now for adding
registries and insecure registries.  The current way to add
registries is in /etc/sysconfig/docker.  The new way is to add
registries to /etc/containers/registries.conf which uses yaml
format.  If /etc/containers/registries.conf exists, it the
registry will be added in the file, otherwise it will be added
in /etc/sysconfig/docker.