### PR TITLE
Remove broken distros from papr.yml

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -1,13 +1,11 @@
 cluster:
   hosts:
     - name: testnode
-      distro: centos/7/atomic/alpha
-      ostree:
-        branch: centos-atomic-host/7/x86_64/devel/smoketested
+      distro: fedora/25/atomic
   container:
     image: registry.fedoraproject.org/fedora:25
 
-context: centos/7/atomic/smoketested
+context: fedora/25/atomic
 
 packages:
   - ansible
@@ -22,32 +20,9 @@ inherit: true
 cluster:
   hosts:
     - name: testnode
-      distro: fedora/25/atomic
-  container:
-    image: registry.fedoraproject.org/fedora:25
-
-context: fedora/25/atomic
-
----
-inherit: true
-
-cluster:
-  hosts:
-    - name: testnode
       distro: fedora/26/atomic
   container:
     image: registry.fedoraproject.org/fedora:25
 
 context: fedora/26/atomic
 
----
-inherit: true
-
-cluster:
-  hosts:
-    - name: testnode
-      distro: centos/7/atomic
-  container:
-    image: registry.fedoraproject.org/fedora:25
-
-context: centos/7/atomic


### PR DESCRIPTION
The `centos/7/atomic` and `centos/7/atomic/smoketested` distros are
having issues that are affecting our PAPR tests.  I've removed them
temporarily until they are stable again.

Related issues:

CentOS/sig-atomic-buildscripts#282

CentOS/sig-atomic-buildscripts#283