### PR TITLE
redhat_subscription: remove unconfigured-state after registering

### DIFF
--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -73,10 +73,19 @@
     shell: >
       systemctl mask rhsmcertd && systemctl stop rhsmcertd
 
-  - name: Revert refspec in origin after susbcription if it not the default refspec
-    replace:
-      dest: "{{ origin_file.stdout }}.origin"
-      regexp: '^refspec.*$'
-      replace: "{{ refspec.stdout }}"
-    when: is_atomic and
-          refspec.stdout.find("refspec=rhel-atomic-host") == -1
+  - block:
+
+    - name: Revert refspec in origin after susbcription if it not the default refspec
+      replace:
+        dest: "{{ origin_file.stdout }}.origin"
+        regexp: '^refspec.*$'
+        replace: "{{ refspec.stdout }}"
+      when: refspec.stdout.find("refspec=rhel-atomic-host") == -1
+
+    - name: Remove unconfigured state in origin file
+      lineinfile:
+        dest: "{{ origin_file.stdout }}.origin"
+        regexp: '^unconfigured-state.*$'
+        state: absent
+
+    when: is_atomic


### PR DESCRIPTION
When provisioning RHELAH hosts in our interal Jenkins jobs, we end up
with an origin file that has an `unconfigured-state` present.  And
when the system is registered via `subscription-manager`, that line is
not removed as part of the process.

This changes the `redhat_subscription` role to remove the
`unconfigured-state` line in the current origin file.  If the line is
already missing, this is no-op.