### PR TITLE
Add support for checking the journal for strings

### DIFF
--- a/roles/journal_fatal_msgs/meta/main.yml
+++ b/roles/journal_fatal_msgs/meta/main.yml
@@ -1,0 +1,16 @@
+---
+# vim: set ft=ansible:
+#
+# Use this role to specify any strings or phrases that should be considered
+# fatal if they appear in the journal of a host under test.
+#
+dependencies:
+  # check for SELinux denials
+  - role: journal_search
+    search_string: denied
+    fail_if_found: true
+
+  # check for kernel Oops
+  - role: journal_search
+    search_string: Oops
+    fail_if_found: true

--- a/roles/journal_fatal_msgs/meta/main.yml
+++ b/roles/journal_fatal_msgs/meta/main.yml
@@ -14,3 +14,9 @@ dependencies:
   - role: journal_search
     search_string: Oops
     fail_if_found: true
+
+  # check for unmapped SELinux contexts
+  # see https://bugzilla.redhat.com/show_bug.cgi?id=1465650#c8
+  - role: journal_search
+    search_string: unmapped
+    fail_if_found: true

--- a/roles/journal_search/tasks/main.yml
+++ b/roles/journal_search/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# vim: set ft=ansible:
+#
+# This role will search the journal from the latest boot for the string
+# supplied as an argument.  It can optionally fail if the string is found.
+#
+# Parameters:
+#   search_string (string) - string to search the journal for
+#   fail_if_found (bool) - cause the role to fail if the string is found (optional)
+#
+- name: Fail if the 'search_string' is undefined
+  fail:
+    msg: "The variable 'search_string' is undefined"
+  when: search_string is undefined
+
+- name: Setup "fail_if_found" variable
+  set_fact:
+    fif: "{{ fail_if_found | default(false) | bool }}"
+
+# We hide the stdout of this task, since the journal could be 1000s of lines
+- name: Grab the journal
+  shell: journalctl -b --no-pager
+  register: j
+  no_log: true
+
+- name: Search for string in the journal
+  fail:
+    msg: "Unable to find string '{{ search_string }}' in the journal"
+  when:
+    - not fif
+    - search_string not in j.stdout
+
+- name: Fail if the string was found in the journal
+  fail:
+    msg: "Found the string '{{ search_string }}' in the journal"
+  when:
+    - fif
+    - search_string in j.stdout

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -54,6 +54,12 @@
       tags:
         - atomic_host_check
 
+    # Before we do anything substantial, let's check the journal to see if
+    # anything blew up on boot
+    - role: journal_fatal_msgs
+      tags:
+        - journal_fatal_msgs_first_boot
+
     # Subscribe if the system is RHEL
     - role: redhat_subscription
       when: ansible_distribution == 'RedHat'
@@ -305,6 +311,11 @@
         - rpm_ostree_upgrade
       check_mode: no
 
+    # Before we reboot, check the journal for anything that blew up
+    - role: journal_fatal_msgs
+      tags:
+        - journal_fatal_msgs_reboot
+
     - role: reboot
       wait_for_services:
         - docker
@@ -346,6 +357,12 @@
       tags:
         - osname_set_fact
       check_mode: no
+
+    # Before we do any additional actions, let's check the journal to see if
+    # anything blew up after reboot
+    - role: journal_fatal_msgs
+      tags:
+        - journal_fatal_msgs_second_boot
 
     # We remove any subscriptions after the upgrade to verify that
     # 'rpm-ostree status' with the 'unconfigured-state' field present.
@@ -589,6 +606,11 @@
       tags:
         - rpm_ostree_rollback
 
+    # Before we reboot, check the journal for anything that blew up
+    - role: journal_fatal_msgs
+      tags:
+        - journal_fatal_msgs_second_reboot
+
     - role: reboot
       wait_for_services:
         - docker
@@ -623,6 +645,12 @@
     - role: atomic_host_check
       tags:
         - atomic_host_check
+
+    # Before we do any additional actions, let's check the journal to see if
+    # anything blew up after reboot
+    - role: journal_fatal_msgs
+      tags:
+        - journal_fatal_msgs_third_boot
 
     - role: selinux_verify
       tags:
@@ -725,3 +753,8 @@
       when: ansible_distribution == 'RedHat'
       tags:
         - redhat_unsubscribe
+
+    # As the final action, check the journal for any fatal problems
+    - role: journal_fatal_msgs
+      tags:
+        - journal_fatal_msgs_final


### PR DESCRIPTION
This introduces two roles that can be used for checking the journal of
a host for particular strings.

`journal_search`:  A role that will search the journal for a specific
                   string supplied to the role.  Optionally can specify
                   that the role fails when the string is found.

`journal_fatal_msgs`:  A 'meta' role that calls out to `journal_search`
                       to look for certain phrases that are considered
                       fatal to the overall test.

The `journal_fatal_msgs` role is used in the `improved-sanity-test` to
inspect the state of the journal before and after the host is
rebooted during the test duration.

Closes #186