### PR TITLE
.test_director: no longer deploy HEAD-1

### DIFF
--- a/.test_director
+++ b/.test_director
@@ -5,7 +5,6 @@ NEW_TESTS=( $(git diff --name-only $(git merge-base origin/master HEAD) | grep '
 
 # no new tests found, just run improved sanity test
 if [ ${#NEW_TESTS[@]} -eq 0 ]; then
-    ansible-playbook -vi testnode, common/ans_ah_head-1_deploy.yml
     ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml
 else
     # added or modified tests found, iterate through and run each one
@@ -13,11 +12,6 @@ else
     for NEW_TEST in "${NEW_TESTS[@]}"; do
         # diff may contain deleted tests so only run tests that exist
         if [ -f $NEW_TEST ]; then
-            # improved-sanity-test could be the test that was modified so
-            # deploy head-1 if improved-sanity-test is found
-            if [[ $NEW_TEST == *"improved-sanity-test"* ]]; then
-                ansible-playbook -vi testnode, common/ans_ah_head-1_deploy.yml
-            fi
             ansible-playbook -vi testnode, $NEW_TEST
         fi
     done


### PR DESCRIPTION
We shouldn't need this anymore since we support running directly on
`HEAD`.

Closes: #215