### PR TITLE
Minor improvements to checking the journal for fatal messages

### DIFF
--- a/roles/journal_fatal_msgs/meta/main.yml
+++ b/roles/journal_fatal_msgs/meta/main.yml
@@ -7,7 +7,7 @@
 dependencies:
   # check for SELinux denials
   - role: journal_search
-    search_string: denied
+    search_string: 'avc:  denied'
     fail_if_found: true
 
   # check for kernel Oops

--- a/roles/journal_search/tasks/main.yml
+++ b/roles/journal_search/tasks/main.yml
@@ -17,9 +17,17 @@
   set_fact:
     fif: "{{ fail_if_found | default(false) | bool }}"
 
+#
 # We hide the stdout of this task, since the journal could be 1000s of lines
+# This method is used because if we did something like:
+#
+#  'journalctl -b | grep foo'
+#
+# ...that command itself would show up in the journal because of how Ansible
+# executes commands on the host.
+#
 - name: Grab the journal
-  shell: journalctl -b --no-pager
+  command: journalctl -b --no-pager
   register: j
   no_log: true
 

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -59,6 +59,7 @@
     - role: journal_fatal_msgs
       tags:
         - journal_fatal_msgs_first_boot
+        - journal_fatal_msgs
 
     # Subscribe if the system is RHEL
     - role: redhat_subscription
@@ -315,6 +316,7 @@
     - role: journal_fatal_msgs
       tags:
         - journal_fatal_msgs_reboot
+        - journal_fatal_msgs
 
     - role: reboot
       wait_for_services:
@@ -363,6 +365,7 @@
     - role: journal_fatal_msgs
       tags:
         - journal_fatal_msgs_second_boot
+        - journal_fatal_msgs
 
     # We remove any subscriptions after the upgrade to verify that
     # 'rpm-ostree status' with the 'unconfigured-state' field present.
@@ -610,6 +613,7 @@
     - role: journal_fatal_msgs
       tags:
         - journal_fatal_msgs_second_reboot
+        - journal_fatal_msgs
 
     - role: reboot
       wait_for_services:
@@ -651,6 +655,7 @@
     - role: journal_fatal_msgs
       tags:
         - journal_fatal_msgs_third_boot
+        - journal_fatal_msgs
 
     - role: selinux_verify
       tags:
@@ -758,3 +763,4 @@
     - role: journal_fatal_msgs
       tags:
         - journal_fatal_msgs_final
+        - journal_fatal_msgs


### PR DESCRIPTION
This updates the SELinux denial string that is sought to be more precise
to denials related to SELinux.

Additionally, I added more tags to the `journal_fatal_msgs` roles used
in the `improved-sanity-test` to allow better selection of which roles
should or should not run.