### PR TITLE
roles:  fix b_d_s_f to work with local branches

### DIFF
--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -25,6 +25,8 @@
 
 - name: Save refspec and checksum
   set_fact:
-     saved_checksum: "{{ ros_booted['checksum'] }}"
-     saved_refspec: "{{ ros_booted['origin'].split(':')[1] }}"
-     saved_remote_name: "{{ ros_booted['origin'].split(':')[0] }}"
+    saved_checksum: "{{ ros_booted['checksum'] }}"
+    # If the host is on a local branch, we have to skip splitting the 'origin'
+    # because there is no remote portion
+    saved_refspec: "{{ ros_booted['origin'].split(':')[1] if ':' in ros_booted['origin'] else ros_booted['origin'] }}"
+    saved_remote_name: "{{ ros_booted['origin'].split(':')[0] if ':' in ros_booted['origin'] else '' }}"


### PR DESCRIPTION
If the `booted_deployment_set_fact` role is used after the host has
been upgraded/rebased to a local branch, it will currently fail
because the refspec has no `remote` portion.

This fixes the role to work with a local branch by checking for the
`remote:refspec` syntax (just the presence of the `:` actually) and
then setting up the facts appropriately.