### PR TITLE
hide stdout and stderr when no_log is true

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -63,7 +63,7 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
         output = BASECLASS._dump_results(self, result)  # pylint: disable=protected-access
 
         for key in ['stdout', 'stderr', 'msg']:
-            if key in save and save[key]:
+            if key in save and save[key] and result['_ansible_no_log'] is False:
                 output += '\n\n%s:\n---\n%s\n---' % (key.upper(), save[key])
 
         for key, value in save.items():


### PR DESCRIPTION
Resolves issue #217 

Ansible has a no_log option that will hide stdout and stderr when
set to true.  The callback plugin was not respecting this option
when formatting the ansible output.  This commit checks the result
_ansible_no_log value before adding it to the output.