### PR TITLE
roles: set 'saved_remote_name' to 'origin' value

### DIFF
--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -29,4 +29,4 @@
     # If the host is on a local branch, we have to skip splitting the 'origin'
     # because there is no remote portion
     saved_refspec: "{{ ros_booted['origin'].split(':')[1] if ':' in ros_booted['origin'] else ros_booted['origin'] }}"
-    saved_remote_name: "{{ ros_booted['origin'].split(':')[0] if ':' in ros_booted['origin'] else '' }}"
+    saved_remote_name: "{{ ros_booted['origin'].split(':')[0] if ':' in ros_booted['origin'] else ros_booted['origin'] }}"


### PR DESCRIPTION
When the host is using a local-branch as its deployment, there is no
remote name by default.  This may cause problems when attempting to
rebase the system.  To work around this, we use the `origin` value as
the remote.