### PR TITLE
.papr.yml: Add CentOS AH back to PAPR coverage

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -26,3 +26,14 @@ cluster:
 
 context: fedora/26/atomic
 
+---
+inherit: true
+
+cluster:
+  hosts:
+    - name: testnode
+      distro: centos/7/atomic
+  container:
+    image: registry.fedoraproject.org/fedora:25
+
+context: centos/7/atomic


### PR DESCRIPTION
We were having issues deploying `HEAD-1` of the CentOS AH stream,
because the commit history of that stream had an unsigned commit in
it.  Since we no longer need to deploiy `HEAD-1` for the purposes of
running the `improved-sanity-test`, we can add the broken stream back
in.

Note:  I believe the `centos-atomic-host/7/x86_64/devel/smoketested`
branch still has issues, so I am leaving this out for now.