### PR TITLE
callback_plugins: init '_ansible_no_log' in plugin

### DIFF
--- a/callback_plugins/default.py
+++ b/callback_plugins/default.py
@@ -55,6 +55,9 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
         '''Return the text to output for a result.'''
         result['_ansible_verbose_always'] = True
 
+        if '_ansible_no_log' not in result.keys():
+            result['_ansible_no_log'] = False
+
         save = {}
         for key in ['stdout', 'stdout_lines', 'stderr', 'stderr_lines', 'msg']:
             if key in result:


### PR DESCRIPTION
The `_ansible_no_log` variable does not appear to be defined by
default by Ansible.  This was causing the callback plugin to suppress
any error messages about other undefined variables in a task, as
described in #226.

This change causes the variable to be initialized to `False` if the
variable is found to be undefined.  Doing so allows the other
undefined errors to bubble up.

Closes #226