### PR TITLE
papr: install 'python2-jmespath'

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -10,6 +10,7 @@ context: fedora/25/atomic
 packages:
   - ansible
   - git
+  - python2-jmespath
 
 tests:
   - ./.test_director

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible<2.3
+jmespath


### PR DESCRIPTION
If we want to use the `json_query` filter in our roles (and we do), we
need the `jmespath` library installed.