### PR TITLE
Delete container before uninstall

### DIFF
--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -57,6 +57,9 @@
 - name: Stop the cockpit container
   command: "atomic stop {{ cockpit_cid.stdout }}"
 
+- name: Delete the cockpit container
+  command: atomic --assumeyes containers delete {{ cockpit_cid.stdout }}
+
 - name: Uninstall cockpit container
   shell: atomic uninstall {{ cockpit_cname }}
 
@@ -100,6 +103,9 @@
 
 - name: Stop the cockpit container
   command: "atomic stop {{ cockpit_cid.stdout }}"
+
+- name: Delete container
+  command: atomic --assumeyes containers delete {{ cockpit_cid.stdout }}
 
 - name: Uninstall cockpit container without tag
   shell: atomic uninstall {{ cockpit_cname }}


### PR DESCRIPTION
There is a new requirement that does not allow uninstall if a
container is using the image.  See [1] for details.  This includes
exited containers.  This was causing a failure in this test so
now the exited container is deleted before uninstallation.

[1] https://github.com/projectatomic/atomic/pull/1050