### PR TITLE
papr:  add CAHC to the list of hosts

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -38,3 +38,15 @@ cluster:
     image: registry.fedoraproject.org/fedora:25
 
 context: centos/7/atomic
+
+---
+inherit: true
+
+cluster:
+  hosts:
+    - name: testnode
+      distro: centos/7/atomic/continuous
+  container:
+    image: registry.fedoraproject.org/fedora:25
+
+context: centos/7/atomic/continuous


### PR DESCRIPTION
In #220, I tried to get fancy with some Ansible conditionals and
default filters, but failed to test all the possible paths, resulting
in false failures.  One of the missing paths was testing with CAHC, so
I think it would be useful to include that in the automated PAPR
checks.