### PR TITLE
tests: drop 'rpm_signature_verify' after upgrade

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -375,11 +375,6 @@
         - journal_fatal_msgs_second_boot
         - journal_fatal_msgs
 
-    # Check RPM signatures again
-    - role: rpm_signature_verify
-      tags:
-        - rpm_signature_verify
-
     # We remove any subscriptions after the upgrade to verify that
     # 'rpm-ostree status' with the 'unconfigured-state' field present.
     # https://bugzilla.redhat.com/show_bug.cgi?id=1421867


### PR DESCRIPTION
At the beginning of the `improved-sanity-test`, we run the
`rpm_signature_verify` check to ensure that the supported streams are
checked to have the correct RPM signatures.  We skip this check on
certain streams which are known not to always have RPMs signed by a
single key.

Because the upgrade is performed against a local branch created from
the original commit, the content of the local branch is already well
known and has been checked for RPM signatures.  Thus we can skip the
RPM signature check for the second time.