### PR TITLE
Update fedora vars files now that 27 has branched.

### DIFF
--- a/roles/selinux_verify/vars/fedora-28.yml
+++ b/roles/selinux_verify/vars/fedora-28.yml
@@ -1,0 +1,1 @@
+fedora-27.yml

--- a/roles/selinux_verify/vars/fedora.yml
+++ b/roles/selinux_verify/vars/fedora.yml
@@ -1,1 +1,1 @@
-fedora-25.yml
+fedora-28.yml


### PR DESCRIPTION
Now that fedora 27 has branched from rawhide we need to add
a fedora 28 profile. Also let's update the generic fedora symlink
to point to fedora-28.