### PR TITLE
roles: refactor 'rpm_ostree_status*' to use json_query filter

### DIFF
--- a/roles/reboot/meta/main.yml
+++ b/roles/reboot/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_ostree_status/meta/main.yml
+++ b/roles/rpm_ostree_status/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_ostree_status/tasks/main.yml
+++ b/roles/rpm_ostree_status/tasks/main.yml
@@ -11,16 +11,19 @@
 
 - name: Convert to JSON
   set_fact:
-    ros_json: "{{ ros.stdout|from_json }}"
+    ros_json: "{{ ros.stdout | from_json }}"
 
-- name: Set ros variable if deployment 0 is booted
+- name: Set ros_num_deployments
   set_fact:
-    ros_booted: "{{ ros_json['deployments'][0] }}"
-    ros_not_booted: "{{ ros_json['deployments'][1] if ros_json['deployments'][1] is defined else false }}"
-  when: ros_json['deployments'][0] is defined and ros_json['deployments'][0]['booted']
+    ros_num_deployments: "{{ ros_json|json_query('length(deployments)') }}"
 
-- name: Set ros variable if deployment 1 is booted
+- name: Set ros_booted variable for multi-deployments
   set_fact:
-    ros_booted: "{{ ros_json['deployments'][1] }}"
-    ros_not_booted: "{{ ros_json['deployments'][0] if ros_json['deployments'][0] is defined else false }}"
-  when: ros_json['deployments'][1] is defined and ros_json['deployments'][1]['booted']
+    ros_booted: "{{ item }}"
+  with_items: "{{ ros_json | json_query('deployments[?booted]') }}"
+
+- name: Set ros_not_booted variable
+  set_fact:
+    ros_not_booted: "{{ item | default(false) }}"
+  with_items: "{{ ros_json | json_query('deployments[?!booted]') }}"
+

--- a/roles/rpm_ostree_status_verify/meta/main.yml
+++ b/roles/rpm_ostree_status_verify/meta/main.yml
@@ -1,0 +1,5 @@
+---
+allow_duplicates: true
+
+dependencies:
+  - role: rpm_ostree_status

--- a/roles/rpm_ostree_status_verify/tasks/main.yml
+++ b/roles/rpm_ostree_status_verify/tasks/main.yml
@@ -17,8 +17,8 @@
 # We use 'include:' here instead of a 'meta' dependency because the meta
 # dependency will only be run once if this role is used multiple times in
 # a playbook.
-- name: Pull in the 'rpm_ostree_status' role
-  include: rpm_ostree_status.yml
+#- name: Pull in the 'rpm_ostree_status' role
+#  include: rpm_ostree_status.yml
 
 - name: Verify number of deployments
   fail:

--- a/roles/rpm_ostree_status_verify/tasks/main.yml
+++ b/roles/rpm_ostree_status_verify/tasks/main.yml
@@ -7,44 +7,28 @@
 #   deployment (int) REQUIRED - index of deployment to verify
 #   expected (dict) REQUIRED - a dict of expected key/value pairs
 #   num_deployments (int) OPTIONAL - the number of deployments in output
-
+#
 - name: Fail if deployment or expected is undefined
   fail:
     msg: "deployment or expected is undefined"
   when: expected is undefined or
         deployment is undefined
 
-- name: Get rpm-ostree status output
-  command: rpm-ostree status --json
-  register: ros_status
-
-- name: Set json output
-  set_fact:
-     ros_json: "{{ ros_status.stdout | from_json }}"
-
-- name: Set ros variable if deployment 0 is booted
-  set_fact:
-    ros_booted: "{{ ros_json['deployments'][0] }}"
-    ros_not_booted: "{{ ros_json['deployments'][1] if ros_json['deployments'][1] is defined else false }}"
-  when: ros_json['deployments'][0] is defined and ros_json['deployments'][0]['booted']
-
-- name: Set ros variable if deployment 1 is booted
-  set_fact:
-    ros_booted: "{{ ros_json['deployments'][1] }}"
-    ros_not_booted: "{{ ros_json['deployments'][0] if ros_json['deployments'][0] is defined else false }}"
-  when: ros_json['deployments'][1] is defined and ros_json['deployments'][1]['booted']
-
-- name: Set number of deployments
-  set_fact:
-     ros_num_deployments: "{{ ros_json['deployments'] | length }}"
+# We use 'include:' here instead of a 'meta' dependency because the meta
+# dependency will only be run once if this role is used multiple times in
+# a playbook.
+- name: Pull in the 'rpm_ostree_status' role
+  include: rpm_ostree_status.yml
 
 - name: Verify number of deployments
   fail:
     msg: |
       "Number of deployments is incorrect.
-       Expected: {{ num_deployments }}.
+       Expected: {{ num_deployments }}
        Actual {{ ros_num_deployments }}"
-  when: num_deployments is defined and {{ num_deployments | int }} != {{ ros_num_deployments | int }}
+  when:
+    - num_deployments is defined
+    - num_deployments | int != ros_num_deployments | int
 
 - name: Fail if deployment does not exist
   fail:
@@ -53,7 +37,10 @@
 
 - name:  Fail if deployment {{ deployment }} values are incorrect
   fail:
-    msg: "{{ item.key }} is incorrect or does not exist."
+    msg: |
+      "'{{ item.key }}' is incorrect or does not exist.
+       Expected: {{ item.key }} == {{ item.value }}
+       Actual: {{ item.key }} == {{ ros_json['deployments'][deployment][item.key] }}"
   when: ros_json['deployments'][deployment][item.key] is undefined or
         ros_json['deployments'][deployment][item.key] != item.value
   with_dict: "{{ expected }}"

--- a/roles/rpm_ostree_status_verify/tasks/rpm_ostree_status.yml
+++ b/roles/rpm_ostree_status_verify/tasks/rpm_ostree_status.yml
@@ -1,0 +1,1 @@
+../../rpm_ostree_status/tasks/main.yml

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -226,7 +226,8 @@
       register: attempted_install
       failed_when: attempted_install.rc != 1
 
-    - include: 'roles/rpm_ostree_status/tasks/main.yml'
+    - include_role:
+        name: rpm_ostree_status
 
     - name: Fail if current deployment has unlocked not set to none
       fail:
@@ -247,7 +248,8 @@
     - name: Unlock system
       command: ostree admin unlock
 
-    - include: 'roles/rpm_ostree_status/tasks/main.yml'
+    - include_role:
+        name: rpm_ostree_status
 
     - name: Verify rpm_ostree status is unlocked and set to hotfix
       fail:
@@ -290,7 +292,8 @@
     - name: Unlock system with hotfix
       command: ostree admin unlock --hotfix
 
-    - include: 'roles/rpm_ostree_status/tasks/main.yml'
+    - include_role:
+        name: rpm_ostree_status
 
     - name: Verify rpm_ostree status has unlocked set to hotfix
       fail:

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -276,7 +276,8 @@
         msg: "Error message is incorrect"
       when: "'Deployment is already in unlocked state: development' not in double_unlock.stderr"
 
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
 - name: Ostree Admin Unlock - Hotfix Unlock Twice - Error Message
   hosts: all
@@ -303,7 +304,7 @@
     - name: Fail if non booted deployment does not have same commit id as booted
       fail:
         msg: "Deployments have different commit_IDs"
-      when: ros_not_booted['checksum'] !=  ros_booted['checksum']
+      when: ros_not_booted['checksum'] != ros_booted['checksum']
 
     - name: Run unlock twice (system is already unlocked)
       command: ostree admin unlock

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -230,7 +230,7 @@
 
     - name: Fail if current deployment has unlocked not set to none
       fail:
-        when: "deployment unlocked not set to none"
+       msg: "Booted deployment does not have 'unlocked' not set to none"
       when: "'none' not in ros_booted['unlocked']"
 
 - name: Ostree Admin Unlock - Unlock Twice - Error Message
@@ -251,7 +251,7 @@
 
     - name: Verify rpm_ostree status is unlocked and set to hotfix
       fail:
-        msg: "Booted deployment does not have unlocked set to hotfix"
+        msg: "Booted deployment does not have 'unlocked' set to hotfix"
       when: "'development' not in ros_booted['unlocked']"
 
     - name: Run unlock twice (system is already unlocked)

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -54,8 +54,8 @@
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current version and refspec
       set_fact:
-         head_version: "{{ ros_booted['version'] }}"
-         refspec: "{{ ros_booted['origin'] }}"
+        head_version: "{{ ros_booted['version'] }}"
+        refspec: "{{ ros_booted['origin'] }}"
 
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
@@ -66,10 +66,14 @@
 
     - name: Get HEAD-1 version
       shell: ostree show $(ostree rev-parse {{ refspec }}^) --print-metadata-key version | tr -d \'
-      register: hmo_version
+      register: ostree_show
+
+    - name: Set HEAD-1 fact
+      set_fact:
+        hmo_version: "{{ ostree_show.stdout }}"
 
     - name: Deploy HEAD-1
-      command: rpm-ostree deploy {{ hmo_version.stdout }}
+      command: rpm-ostree deploy {{ hmo_version }}
       register: ros_deploy
       retries: 5
       delay: 60
@@ -86,7 +90,7 @@
         num_deployments: 2
         expected:
           booted: true
-          version: "{{ hmo_version.stdout }}"
+          version: "{{ hmo_version }}"
 
     # rollback to head
     - include_role:
@@ -141,8 +145,8 @@
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
       set_fact:
-         head_csum: "{{ ros_booted['checksum'] }}"
-         refspec: "{{ ros_booted['origin'] }}"
+        head_csum: "{{ ros_booted['checksum'] }}"
+        refspec: "{{ ros_booted['origin'] }}"
 
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
@@ -153,10 +157,14 @@
 
     - name: Get HEAD-1 checksum
       shell: ostree rev-parse {{ refspec }}^
-      register: hmo_csum
+      register: orp
+
+    - name: Set HEAD-1 fact
+      set_fact:
+        hmo_csum: "{{ orp.stdout }}"
 
     - name: Deploy HEAD-1
-      command: rpm-ostree deploy {{ hmo_csum.stdout }}
+      command: rpm-ostree deploy {{ hmo_csum }}
       register: ros_deploy
       retries: 5
       delay: 60
@@ -173,7 +181,7 @@
         deployment: 0
         expected:
           booted: true
-          checksum: "{{ hmo_csum.stdout }}"
+          checksum: "{{ hmo_csum }}"
 
     - name: Rollback to HEAD
       include_role:
@@ -228,8 +236,8 @@
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
       set_fact:
-         head_csum: "{{ ros_booted['checksum'] }}"
-         refspec: "{{ ros_booted['origin'] }}"
+        head_csum: "{{ ros_booted['checksum'] }}"
+        refspec: "{{ ros_booted['origin'] }}"
 
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
@@ -240,10 +248,14 @@
 
     - name: Get HEAD-1 checksum
       command: ostree rev-parse {{ refspec }}^
-      register: hmo_csum
+      register: orp
+
+    - name: Set HEAD-1 fact
+      set_fact:
+        hmo_csum: "{{ orp.stdout }}"
 
     - name: Deploy version HEAD-1
-      command: rpm-ostree deploy {{ hmo_csum.stdout }}
+      command: rpm-ostree deploy {{ hmo_csum }}
       register: ros_deploy
       retries: 5
       delay: 60
@@ -257,7 +269,7 @@
         deployment: 0
         expected:
           booted: false
-          checksum: "{{ hmo_csum.stdout }}"
+          checksum: "{{ hmo_csum }}"
 
     # verify current deployment info
     - include_role:
@@ -413,8 +425,23 @@
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
       set_fact:
-         head_csum: "{{ ros_booted['checksum'] }}"
-         refspec: "{{ ros_booted['origin'] }}"
+        head_csum: "{{ ros_booted['checksum'] }}"
+        refspec: "{{ ros_booted['origin'] }}"
+
+    - name: Pull last two commits
+      command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
+      register: osp
+      retries: 5
+      delay: 60
+      until: osp|success
+
+    - name: Get HEAD-1 checksum
+      command: ostree rev-parse {{ refspec }}^
+      register: orp
+
+    - name: Set HEAD-1 fact
+      set_fact:
+        hmo_csum: "{{ orp.stdout }}"
 
     - name: Set origin file
       command: ostree admin --print-current-dir
@@ -498,19 +525,8 @@
     - include_role:
         name: rpm_ostree_status
 
-    - name: Pull last two commits
-      command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
-      register: osp
-      retries: 5
-      delay: 60
-      until: osp|success
-
-    - name: Get HEAD-1 checksum
-      command: ostree rev-parse {{ refspec }}^
-      register: hmo_csum
-
     - name: Deploy HEAD-1
-      command: rpm-ostree deploy {{ hmo_csum.stdout }} --uninstall {{ g_pkg }}
+      command: rpm-ostree deploy {{ hmo_csum }} --uninstall {{ g_pkg }}
       register: ros_deploy
       retries: 5
       delay: 60
@@ -533,7 +549,7 @@
         deployment: 0
         expected:
           booted: true
-          checksum: "{{ hmo_csum.stdout }}"
+          checksum: "{{ hmo_csum }}"
 
     # rpm-ostree upgrade
     - include_role:

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -91,7 +91,6 @@
     # reboot
     - include: ../../common/ans_reboot.yml
 
-    # verify version after rolling back
     - include: roles/rpm_ostree_status_verify/tasks/main.yml
       deployment: 0
       num_deployments: 2

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -51,26 +51,28 @@
     - include_role:
         name: rpm_ostree_status
 
-    # the rpm_ostree_status above sets the ros_booted variable used below
-    - name: Set current version and refspec
-      set_fact:
-        head_version: "{{ ros_booted['version'] }}"
-        refspec: "{{ ros_booted['origin'] }}"
-
-    - name: Pull last two commits
-      command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
+    # It's possible that the test could be run against a commit that is older
+    # that what HEAD is on the remote.  So let's just get all the commit
+    # metadata to be safe.
+    - name: Pull all the commit data
+      command: ostree pull --commit-metadata-only --depth=-1 {{ ros_booted['origin'] }}
       register: osp
       retries: 5
       delay: 60
       until: osp|success
 
-    - name: Get HEAD-1 version
-      shell: ostree show $(ostree rev-parse {{ refspec }}^) --print-metadata-key version | tr -d \'
+    # Use the parent of the deployed commit as HEAD-1, in case the remote
+    # is updated during the test.
+    - name: Get parent of deployed commit
+      shell: ostree show $(ostree rev-parse {{ ros_booted['checksum'] }}^) --print-metadata-key version | tr -d \'
       register: ostree_show
 
-    - name: Set HEAD-1 fact
+    # the rpm_ostree_status above sets the ros_booted variable used below
+    - name: Set current version and refspec
       set_fact:
+        head_version: "{{ ros_booted['version'] }}"
         hmo_version: "{{ ostree_show.stdout }}"
+        refspec: "{{ ros_booted['origin'] }}"
 
     - name: Deploy HEAD-1
       command: rpm-ostree deploy {{ hmo_version }}
@@ -80,7 +82,8 @@
       until: ros_deploy|success
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify version in deployment 0
     - include_role:
@@ -97,7 +100,8 @@
         name: rpm_ostree_rollback
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     - include_role:
         name: rpm_ostree_status_verify
@@ -142,26 +146,18 @@
     - include_role:
         name: rpm_ostree_status
 
+    # Get the parent of the deployed commit, which we will use as HEAD-1
+    # in case the remote gets updated while testing
+    - name: Get parent of deployed commit
+      command: ostree rev-parse {{ ros_booted['checksum'] }}^
+      register: orp
+
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
       set_fact:
         head_csum: "{{ ros_booted['checksum'] }}"
-        refspec: "{{ ros_booted['origin'] }}"
-
-    - name: Pull last two commits
-      command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
-      register: osp
-      retries: 5
-      delay: 60
-      until: osp|success
-
-    - name: Get HEAD-1 checksum
-      shell: ostree rev-parse {{ refspec }}^
-      register: orp
-
-    - name: Set HEAD-1 fact
-      set_fact:
         hmo_csum: "{{ orp.stdout }}"
+        refspec: "{{ ros_booted['origin'] }}"
 
     - name: Deploy HEAD-1
       command: rpm-ostree deploy {{ hmo_csum }}
@@ -171,7 +167,8 @@
       until: ros_deploy|success
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify booted checksum
     - include_role:
@@ -188,7 +185,8 @@
         name: rpm_ostree_rollback
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify HEAD checksum is booted
     - include_role:
@@ -233,28 +231,20 @@
     - include_role:
         name: rpm_ostree_status
 
+    # Get the parent of the deployed commit, which we will use as HEAD-1
+    # in case the remote gets updated while testing
+    - name: Get parent of deployed commit
+      command: ostree rev-parse {{ ros_booted['checksum'] }}^
+      register: orp
+
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
       set_fact:
         head_csum: "{{ ros_booted['checksum'] }}"
+        hmo_csum: "{{ orp.stdout }}"
         refspec: "{{ ros_booted['origin'] }}"
 
-    - name: Pull last two commits
-      command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
-      register: osp
-      retries: 5
-      delay: 60
-      until: osp|success
-
-    - name: Get HEAD-1 checksum
-      command: ostree rev-parse {{ refspec }}^
-      register: orp
-
-    - name: Set HEAD-1 fact
-      set_fact:
-        hmo_csum: "{{ orp.stdout }}"
-
-    - name: Deploy version HEAD-1
+    - name: Deploy HEAD-1 checksum
       command: rpm-ostree deploy {{ hmo_csum }}
       register: ros_deploy
       retries: 5
@@ -356,7 +346,8 @@
         name: rpm_ostree_upgrade
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify upgrade info
     - include_role:
@@ -377,7 +368,8 @@
       until: ros_rebase|success
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify rebase back to original refspec
     - include_role:
@@ -422,26 +414,18 @@
     - include_role:
         name: rpm_ostree_status
 
+    # Get the parent of the deployed commit, which we will use as HEAD-1
+    # in case the remote gets updated while testing
+    - name: Get parent of deployed commit
+      command: ostree rev-parse {{ ros_booted['checksum'] }}^
+      register: orp
+
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
       set_fact:
         head_csum: "{{ ros_booted['checksum'] }}"
-        refspec: "{{ ros_booted['origin'] }}"
-
-    - name: Pull last two commits
-      command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
-      register: osp
-      retries: 5
-      delay: 60
-      until: osp|success
-
-    - name: Get HEAD-1 checksum
-      command: ostree rev-parse {{ refspec }}^
-      register: orp
-
-    - name: Set HEAD-1 fact
-      set_fact:
         hmo_csum: "{{ orp.stdout }}"
+        refspec: "{{ ros_booted['origin'] }}"
 
     - name: Set origin file
       command: ostree admin --print-current-dir
@@ -481,7 +465,8 @@
       until: ros_upgrade|success
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify upgrade info
     - include_role:
@@ -503,7 +488,8 @@
       command: rpm-ostree rebase {{ refspec }} {{ head_csum }}
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify rebase info
     - include_role:
@@ -533,7 +519,8 @@
       until: ros_deploy|success
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify package is no longer installed
     - include_role:
@@ -551,12 +538,17 @@
           booted: true
           checksum: "{{ hmo_csum }}"
 
-    # rpm-ostree upgrade
-    - include_role:
-        name: rpm_ostree_upgrade
+    # Deploy back to original commit
+    - name: Deploy original commit
+      command: rpm-ostree deploy {{ head_csum }}
+      register: rosd_head
+      retries: 5
+      delay: 60
+      until: rosd_head|success
 
     # reboot
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     # verify package is still not installed
     - include_role:
@@ -617,7 +609,8 @@
     - name: Enable initramfs
       command: rpm-ostree initramfs --enable --arg="-I" --arg="/etc/rpmostree-file"
 
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     - include_role:
         name: rpm_ostree_status_verify
@@ -666,7 +659,8 @@
     - name: Disable initramfs
       command: rpm-ostree initramfs --disable
 
-    - include: ../../common/ans_reboot.yml
+    - include_role:
+        name: reboot
 
     - name: Get bootloader entry
       shell: grep ^initrd /boot/loader/entries/ostree-{{ osname }}-0.conf | sed -e 's,initrd ,/boot/,'

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -48,7 +48,8 @@
     - vars.yml
 
   tasks:
-    - include: roles/rpm_ostree_status/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_status
 
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current version and refspec
@@ -78,34 +79,41 @@
     - include: ../../common/ans_reboot.yml
 
     # verify version in deployment 0
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      deployment: 0
-      num_deployments: 2
-      expected:
-        booted: true
-        version: "{{ hmo_version.stdout }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        deployment: 0
+        num_deployments: 2
+        expected:
+          booted: true
+          version: "{{ hmo_version.stdout }}"
 
     # rollback to head
-    - include: roles/rpm_ostree_rollback/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_rollback
 
     # reboot
     - include: ../../common/ans_reboot.yml
 
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      deployment: 0
-      num_deployments: 2
-      expected:
-        version: "{{ head_version }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        deployment: 0
+        num_deployments: 2
+        expected:
+          version: "{{ head_version }}"
 
     - name: Cleanup deployments
       command: rpm-ostree cleanup -r
 
     # verify cleanup
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      deployment: 0
-      num_deployments: 1
-      expected:
-        version: "{{ head_version }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        deployment: 0
+        num_deployments: 1
+        expected:
+          version: "{{ head_version }}"
 
 
 #####################################################################################
@@ -127,7 +135,8 @@
     - vars.yml
 
   tasks:
-    - include: roles/rpm_ostree_status/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_status
 
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
@@ -157,36 +166,43 @@
     - include: ../../common/ans_reboot.yml
 
     # verify booted checksum
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: true
-        checksum: "{{ hmo_csum.stdout }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: true
+          checksum: "{{ hmo_csum.stdout }}"
 
-    - name: Rollback to head
-      include: roles/rpm_ostree_rollback/tasks/main.yml
+    - name: Rollback to HEAD
+      include_role:
+        name: rpm_ostree_rollback
 
     # reboot
     - include: ../../common/ans_reboot.yml
 
-    # verify head checksum is booted
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: true
-        checksum: "{{ head_csum }}"
+    # verify HEAD checksum is booted
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: true
+          checksum: "{{ head_csum }}"
 
     - name: Cleanup rollback
       command: rpm-ostree cleanup -r
 
     # verify rollback cleanup
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 1
-      deployment: 0
-      expected:
-        checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 1
+        deployment: 0
+        expected:
+          checksum: "{{ head_csum }}"
 
 #####################################################################################
 #
@@ -206,7 +222,8 @@
     - vars.yml
 
   tasks:
-    - include: roles/rpm_ostree_status/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_status
 
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
@@ -233,31 +250,37 @@
       until: ros_deploy|success
 
     # verify pending deployment info
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: false
-        checksum: "{{ hmo_csum.stdout }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: false
+          checksum: "{{ hmo_csum.stdout }}"
 
     # verify current deployment info
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 1
-      expected:
-        booted: true
-        checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 1
+        expected:
+          booted: true
+          checksum: "{{ head_csum }}"
 
     - name: Delete pending deployment
       command: rpm-ostree cleanup -p
 
     # verify origin deployment is still there and not deleted
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 1
-      deployment: 0
-      expected:
-        booted: true
-        checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 1
+        deployment: 0
+        expected:
+          booted: true
+          checksum: "{{ head_csum }}"
 
 #####################################################################################
 #
@@ -277,7 +300,8 @@
     - vars.yml
 
   tasks:
-    - include: roles/rpm_ostree_status/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_status
 
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
@@ -316,19 +340,22 @@
         - ansible_distribution_major_version == '26'
 
     # rpm-ostree upgrade
-    - include: roles/rpm_ostree_upgrade/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_upgrade
 
     # reboot
     - include: ../../common/ans_reboot.yml
 
     # verify upgrade info
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        checksum: "{{ new_commit.stdout }}"
-        version: "test"
-        origin: "local-branch"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          checksum: "{{ new_commit.stdout }}"
+          version: "test"
+          origin: "local-branch"
 
     - name: Rebase back to original deployment
       command: rpm-ostree rebase {{ refspec }} {{ head_csum }}
@@ -341,21 +368,25 @@
     - include: ../../common/ans_reboot.yml
 
     # verify rebase back to original refspec
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          checksum: "{{ head_csum }}"
 
     - name: Cleanup
       command: rpm-ostree cleanup -rpmb
 
     # verify cleanup
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 1
-      deployment: 0
-      expected:
-        checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 1
+        deployment: 0
+        expected:
+          checksum: "{{ head_csum }}"
 
 
 #####################################################################################
@@ -376,7 +407,8 @@
     - vars.yml
 
   tasks:
-    - include: roles/rpm_ostree_status/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_status
 
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
@@ -425,15 +457,18 @@
     - include: ../../common/ans_reboot.yml
 
     # verify upgrade info
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: true
-        base-checksum: "{{ new_commit.stdout }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: true
+          base-checksum: "{{ new_commit.stdout }}"
 
     # verify installation of {{ g_pkg }}
-    - include: roles/rpm_ostree_install_verify/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_install_verify
       vars:
         package: "{{ g_pkg }}"
 
@@ -444,20 +479,24 @@
     - include: ../../common/ans_reboot.yml
 
     # verify rebase info
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: true
-        base-checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: true
+          base-checksum: "{{ head_csum }}"
 
     # verify package is still layered
-    - include: roles/rpm_ostree_install_verify/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_install_verify
       vars:
         package: "{{ g_pkg }}"
 
     # refresh rpm-ostree status variables
-    - include: roles/rpm_ostree_status/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_status
 
     - name: Pull last two commits
       command: ostree pull --commit-metadata-only --depth=1 {{ refspec }}
@@ -481,46 +520,55 @@
     - include: ../../common/ans_reboot.yml
 
     # verify package is no longer installed
-    - include: roles/rpm_ostree_uninstall_verify/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_uninstall_verify
       vars:
         package: "{{ g_pkg }}"
 
     # verify deploy with uninstallation info
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: true
-        checksum: "{{ hmo_csum.stdout }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: true
+          checksum: "{{ hmo_csum.stdout }}"
 
     # rpm-ostree upgrade
-    - include: roles/rpm_ostree_upgrade/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_upgrade
 
     # reboot
     - include: ../../common/ans_reboot.yml
 
     # verify package is still not installed
-    - include: roles/rpm_ostree_uninstall_verify/tasks/main.yml
+    - include_role:
+        name: rpm_ostree_uninstall_verify
       vars:
         package: "{{ g_pkg }}"
 
     # verify upgrade info
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: true
-        checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: true
+          checksum: "{{ head_csum }}"
 
     - name: Cleanup
       command: rpm-ostree cleanup -rpmb
 
     # verify cleanup
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 1
-      deployment: 0
-      expected:
-        checksum: "{{ head_csum }}"
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 1
+        deployment: 0
+        expected:
+          checksum: "{{ head_csum }}"
 
 #####################################################################################
 #
@@ -555,12 +603,14 @@
 
     - include: ../../common/ans_reboot.yml
 
-    - include: roles/rpm_ostree_status_verify/tasks/main.yml
-      num_deployments: 2
-      deployment: 0
-      expected:
-        booted: true
-        regenerate-initramfs: true
+    - include_role:
+        name: rpm_ostree_status_verify
+      vars:
+        num_deployments: 2
+        deployment: 0
+        expected:
+          booted: true
+          regenerate-initramfs: true
 
     - name: Fail if initramfs does not have two arguments
       fail:


### PR DESCRIPTION
This attempts to streamline the `rpm_ostree_status` role by employing
the `json_query` filter.  We can query the `deployments` from the
output of `rpm-ostree status --json` for the correct deployment which
is booted or not booted.  In the case of a single deployment, we
default to setting the `ros_not_booted` to false.

The `rpm_ostree_status_verify` has been converted to use the
json_query filter as well.  In this role, the `rpm_ostree_status` is
symlinked into the directory, so it can be included directly.  This
was done because we want to have that role run every time the 'verify'
role is called.  (I tried to use the meta dependencies, but it would
only run once per playbook if the 'verify' role was called multiple
times)

I also snuck it a little fix to the `admin-unlock` test that I noticed
while checking to see if the all the tests still worked.

Closes #230