### PR TITLE
selinux_verify:  update files/procs for latest 7.4 content

### DIFF
--- a/roles/selinux_verify/vars/centosdev-7.yml
+++ b/roles/selinux_verify/vars/centosdev-7.yml
@@ -1,25 +1,22 @@
 ---
 distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-containerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-containerd-shim', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-containerd-shim-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-ctr-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/dockerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/dockerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/dockerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-latest-storage-setup', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-storage-setup', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/container-storage-setup', value: 'system_u:object_r:bin_t:s0' }
+  - { key: '/usr/libexec/docker/docker-containerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-containerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-containerd-shim-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-containerd-shim-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-ctr-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-ctr-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-init-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-init-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-lvm-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-novolume-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-
   - { key: '/usr/libexec/docker/docker-proxy-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-proxy-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-runc-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
@@ -27,3 +24,4 @@ distro_files:
 
 distro_procs:
   - { key: 'docker', value: 'system_u:system_r:container_runtime_t:s0' }
+  - { key: 'docker-containerd', value: 'system_u:system_r:container_runtime_t:s0' }


### PR DESCRIPTION
The CAHC stream started picking up RPMs from the CentOS 7.4 release,
which resulted in a few changes to the list of files and processes we
want to check.