### PR TITLE
roles:  use new regexp method to append kube options

### DIFF
--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -26,11 +26,31 @@
       - controller-mgr-pod.json
       - scheduler-pod.json
 
+  # Thank you based Google gods
+  # https://groups.google.com/d/msg/ansible-project/JvHfchsgRaU/Vw_CzBbvadgJ
+  #
+  # Shoddy explanation of regexp:
+  #   - open of capture group 1: matched by (
+  #   - <startofline>: matched by ^
+  #   - the string "KUBELET_ARGS=": matched literally (double quote is escaped)
+  #   - any characters after above string: matched by .*
+  #   - close of capture group 1: matched by )
+  #   - the closing " char: matched by \"
+  #   - any spaces/tabs: matched by \s*
+  #   - <endofline>: matched by $
+  #
+  # The capture group 1 is referred to as \1 in the 'line:' statement and
+  # will be used as the begining of the line to be inserted into the file.
+  # Thus, any exiting values to KUBELET_ARGS are preserved and the two
+  # new options (--register-node and --pod-manifest-path) are cleanly
+  # appended.
   - name: add kubelet args
-    replace:
-      dest=/etc/kubernetes/kubelet
-      regexp='^KUBELET_ARGS=\"\"'
-      replace='KUBELET_ARGS=\"--register-node=true --config=/etc/kubernetes/manifests/\"'
+    lineinfile:
+      dest: /etc/kubernetes/kubelet
+      backup: true
+      backrefs: true
+      regexp: '(^KUBELET_ARGS=\".*)\"\s*$'
+      line: '\1 --register-node=true --pod-manifest-path=/etc/kubernetes/manifests/"'
 
   - name: stop docker, etcd, kube-proxy, kubelet
     service:


### PR DESCRIPTION
The previous approach to adding required options to the `KUBELET_ARGS`
did not take into account that there could be default options passed
in as args.  This changes uses the `lineinfile` module and its regexp
capabilities to match the `KUBELET_ARGS` line in the file and append
the options we want to the existing line.

Additionally, the `--config` flag for the kubelet was marked as
'Deprecated' way back in Aug 2016[0] and then completely removed in Jan
2017[1].  The replacement option is `--pod-manifest-path`.

[0] https://github.com/kubernetes/kubernetes/commit/e43ccdbf2c0b69bfa19108a4d82894962c108016
[1] https://github.com/kubernetes/kubernetes/commit/bec6635ccc05b1f02c9971ec9bf529faac0b9ca1