### PR TITLE
Move subscription-manager auto-attach parameter in subscription file

### DIFF
--- a/roles/redhat_subscription/files/subscription_data.csv.sample
+++ b/roles/redhat_subscription/files/subscription_data.csv.sample
@@ -2,4 +2,4 @@ baseurl,https://cdn.redhat.com
 serverurl,subscription.rhn.redhat.com:443/subscription
 username,username@example.com
 password,yourPa$sW0rd
-extra,--force
+extra,--auto-attach --force

--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -45,7 +45,7 @@
 
   - name: Register with subscription-manager
     command: >
-      subscription-manager register --auto-attach --force
+      subscription-manager register
       --baseurl="{{ lookup('csvfile', 'baseurl file={} delimiter=,'.format(subscription_file)) }}"
       --serverurl="{{ lookup('csvfile', 'serverurl file={} delimiter=,'.format(subscription_file)) }}"
       --username="$USERNAME"


### PR DESCRIPTION
subscription_data.csv.sample got an extra parameter.
We can use this extra parameter to subscribe with activationkey for example.

    extra,--activationkey='...' --org='...'

If we do so, roles/redhat_subscription/tasks/main.yml:46 raise an error:

    "Error: Activation keys cannot be used with --auto-attach."

Move --auto-attach in subscription file sample.
Remove --force because extra param is already set

This PR fixes #249