### PR TITLE
roles: print matching lines from journal

### DIFF
--- a/roles/journal_fatal_msgs/meta/main.yml
+++ b/roles/journal_fatal_msgs/meta/main.yml
@@ -9,14 +9,17 @@ dependencies:
   - role: journal_search
     search_string: 'avc:  denied'
     fail_if_found: true
+    extra_args: '_TRANSPORT=audit'
 
   # check for kernel Oops
   - role: journal_search
     search_string: Oops
     fail_if_found: true
+    extra_args: '_TRANSPORT=kernel'
 
   # check for unmapped SELinux contexts
   # see https://bugzilla.redhat.com/show_bug.cgi?id=1465650#c8
   - role: journal_search
     search_string: unmapped
     fail_if_found: true
+    extra_args: '_TRANSPORT=kernel'

--- a/roles/journal_search/tasks/main.yml
+++ b/roles/journal_search/tasks/main.yml
@@ -6,6 +6,7 @@
 #
 # Parameters:
 #   search_string (string) - string to search the journal for
+#   extra_args (string) - free form string to pass to 'journalctl' (optional)
 #   fail_if_found (bool) - cause the role to fail if the string is found (optional)
 #
 - name: Fail if the 'search_string' is undefined
@@ -13,51 +14,50 @@
     msg: "The variable 'search_string' is undefined"
   when: search_string is undefined
 
-- name: Setup "fail_if_found" variable
+- name: Setup "fail_if_found" and "extra_args" variable
   set_fact:
     fif: "{{ fail_if_found | default(false) | bool }}"
+    ea: "{{ extra_args | default('') }}"
 
-#
-# We hide the stdout of this task, since the journal could be 1000s of lines
-# This method is used because if we did something like:
-#
-#  'journalctl -b | grep foo'
-#
-# ...that command itself would show up in the journal because of how Ansible
-# executes commands on the host.
-#
-- name: Grab the journal
-  command: journalctl -b --no-pager
+# The command has to built up by pieces in order to handle the possibility of
+# extra args that might be passed in to the 'journalctl' command.
+- name: Build command pieces
+  set_fact:
+    journal_cmd: "{{ 'journalctl -b --no-pager ' + ea if ea|length > 0 else 'journalctl -b --no-pager' }}"
+    grep_cmd: "{{ 'grep ' + search_string|quote }}"
+
+# An inverse 'grep' is used to filter our some of the journal entries that
+# can be created when using Ansible
+- name: Build full command
+  set_fact:
+    full_cmd: "{{ journal_cmd + ' | ' + grep_cmd + ' | grep -v ansible-command' }}"
+
+# The 'full_cmd' variable is not quoted when passed to the 'shell:' module
+# because doing so causes the module to return 'No such file or directory'
+# This is not the safest thing to do, but let's allow it for now.
+- name: Search the journal for the string
+  shell: "{{ full_cmd }}"
   register: j
-  no_log: true
+  failed_when: j.rc > 1
 
 - name: Set the found_string fact
   set_fact:
-    found_string: "{{ j.stdout | search(search_string) }}"
+    found_string: "{{ j.rc == 0 }}"
 
-- name: Search for string in the journal
+- name: Fail if the string was not found in the journal
   fail:
     msg: "Unable to find string '{{ search_string }}' in the journal"
   when:
     - not fif
     - not found_string
 
-# We scrape the journal manually after the fact because the contents of the
-# 'shell:' command below will end up in the journal when it is run on the
-# host under test.  Since the test should fail and abort any other plays
-# in the playbook, it should be safe to pollute the journal like this.
-#
-# Additionally, this is not in a 'block:' statement because apparently you
-# can't include a 'fail:' statement inside a block.  ¯\_(ツ)_/¯
-- name: Grep the journal again for matching strings
-  shell: "journalctl -b | grep {{ search_string | quote }}"
-  when:
-    - fif
-    - found_string
-
 - name: Fail if the string was found in the journal
   fail:
-    msg: "Found the string '{{ search_string }}' in the journal"
+    msg: |
+      Found the string '{{ search_string }}' in the journal
+
+      Matching entries:
+      {{ j.stdout }}
   when:
     - fif
     - found_string

--- a/roles/journal_search/tasks/main.yml
+++ b/roles/journal_search/tasks/main.yml
@@ -31,16 +31,33 @@
   register: j
   no_log: true
 
+- name: Set the found_string fact
+  set_fact:
+    found_string: "{{ j.stdout | search(search_string) }}"
+
 - name: Search for string in the journal
   fail:
     msg: "Unable to find string '{{ search_string }}' in the journal"
   when:
     - not fif
-    - search_string not in j.stdout
+    - not found_string
+
+# We scrape the journal manually after the fact because the contents of the
+# 'shell:' command below will end up in the journal when it is run on the
+# host under test.  Since the test should fail and abort any other plays
+# in the playbook, it should be safe to pollute the journal like this.
+#
+# Additionally, this is not in a 'block:' statement because apparently you
+# can't include a 'fail:' statement inside a block.  ¯\_(ツ)_/¯
+- name: Grep the journal again for matching strings
+  shell: "journalctl -b | grep {{ search_string | quote }}"
+  when:
+    - fif
+    - found_string
 
 - name: Fail if the string was found in the journal
   fail:
     msg: "Found the string '{{ search_string }}' in the journal"
   when:
     - fif
-    - search_string in j.stdout
+    - found_string


### PR DESCRIPTION
Previously, when the `journal_search` role would fail, it would only
print a message saying that the matching line had been found.  This is
only partially useful if you want to see the actual matching line in
the test output.

This changes the `journal_search` role to crudely print the matching
lines by way of running a `grep` against the output of `journalctl`
after a match has been found.  The reason for doing this operation
after the match has been found is because the command `journal | grep
<string>` may end up in the journal if it is run with elevated
privileges via Ansible (i.e. using `sudo`)

Closes #253