### PR TITLE
roles/bdsf: prepend 'ansible_host' to archive file

### DIFF
--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -39,11 +39,11 @@
 - block:
   - name: Remove existing archive file
     local_action:
-      file path="{{ playbook_dir }}/bdsf_archive.yml" state=absent
+      file path="{{ playbook_dir }}/{{ ansible_host }}_bdsf_archive.yml" state=absent
     become: false
 
   - name: Archive refspec and checksum
     local_action:
-      template src=bdsf_archive.j2 dest="{{ playbook_dir }}/bdsf_archive.yml"
+      template src=bdsf_archive.j2 dest="{{ playbook_dir }}/{{ ansible_host }}_bdsf_archive.yml"
     become: false
   when: bdsf_archive

--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Set archive value
   set_fact:
     bdsf_archive: "{{ archive | default('false') }}"
+    bdsf_ansible_host: "{{ ansible_host }}"
 
 - name: Get rpm-ostree status output
   command: rpm-ostree status --json
@@ -39,11 +40,11 @@
 - block:
   - name: Remove existing archive file
     local_action:
-      file path="{{ playbook_dir }}/{{ ansible_host }}_bdsf_archive.yml" state=absent
+      file path="{{ playbook_dir }}/{{ bdsf_ansible_host }}_bdsf_archive.yml" state=absent
     become: false
 
   - name: Archive refspec and checksum
     local_action:
-      template src=bdsf_archive.j2 dest="{{ playbook_dir }}/{{ ansible_host }}_bdsf_archive.yml"
+      template src=bdsf_archive.j2 dest="{{ playbook_dir }}/{{ bdsf_ansible_host }}_bdsf_archive.yml"
     become: false
   when: bdsf_archive

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -744,7 +744,7 @@
 
     # load in the YAML files with archived deployment info
     - role: load_variables
-      filename: "{{ playbook_dir}}/bdsf_archive.yml"
+      filename: "{{ playbook_dir}}/{{ ansible_host }}_bdsf_archive.yml"
       tags:
         - load_variables
 


### PR DESCRIPTION
If you ran a long test that used the `booted_deployment_set_fact` role
across multiple hosts in parallel, any archive file that was created
by the test would be clobbered by the last execution that completed.
This creates a problem when you are trying to read that file and
expecting it to have certain values.

To avoid this, the archive file is created with the value of
`ansible_host` prepended to the file name.  This keeps the file unique
to the host under test and should avoid any clobbering that may have
happened.

Closes #258