### PR TITLE
tests/rpm-ostree: don't try to 'rpm-ostree reload' on F26

### DIFF
--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -303,6 +303,17 @@
 
     - name: rpm-ostree reload
       command: rpm-ostree reload
+      when:
+        - ansible_distribution != 'Fedora'
+        - ansible_distribution_major_version != '26'
+
+    - name: restart rpm-ostreed
+      service:
+        name: rpm-ostreed
+        state: restarted
+      when:
+        - ansible_distribution == 'Fedora'
+        - ansible_distribution_major_version == '26'
 
     # rpm-ostree upgrade
     - include: roles/rpm_ostree_upgrade/tasks/main.yml
@@ -390,6 +401,17 @@
 
     - name: rpm-ostree reload
       command: rpm-ostree reload
+      when:
+        - ansible_distribution != 'Fedora'
+        - ansible_distribution_major_version != '26'
+
+    - name: restart rpm-ostreed
+      service:
+        name: rpm-ostreed
+        state: restarted
+      when:
+        - ansible_distribution == 'Fedora'
+        - ansible_distribution_major_version == '26'
 
     - name: Upgrade
       command: rpm-ostree upgrade --install {{ g_pkg }}

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -301,6 +301,7 @@
       command: ostree commit -b local-branch --tree=ref=local-branch --add-metadata-string version=test
       register: new_commit
 
+    # TODO: revert this conditional once F26 picks up rpm-ostree 2017.9
     - name: rpm-ostree reload
       command: rpm-ostree reload
       when:
@@ -399,6 +400,7 @@
       command: ostree commit -b local-branch --tree=ref=local-branch --add-metadata-string version=test
       register: new_commit
 
+    # TODO: revert this conditional once F26 picks up rpm-ostree 2017.9
     - name: rpm-ostree reload
       command: rpm-ostree reload
       when:


### PR DESCRIPTION
I had hoped that the latest two week release of F26 (26.141) would
have picked up the version of `rpm-ostree` (2017.9) which included a
fix for projectatomic/rpm-ostree#976, but that version was stuck in
Bodhi purgatory waiting for karma and missed the compose.  :rage:

Because that issue is impacting some of our PR testing, this change
temporarily switches to restarting the `rpm-ostreed` service for the
F26 case.  Once the *next* two-week compose is released, we will
should revert this change.