### PR TITLE
system-containers: disable etcd/flanneld if rpms are installed

### DIFF
--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -391,6 +391,30 @@
     - vars.yml
 
   tasks:
+    - name: Check for etcd rpm
+      command: rpm -q etcd
+      register: rpm_etcd
+      ignore_errors: true
+
+    - name: Check for flannel rpm
+      command: rpm -q flannel
+      register: rpm_flannel
+      ignore_errors: true
+
+    - name: Stop flanneld server if flannel rpm present
+      service:
+        name: flanneld
+        state: stopped
+        enabled: no
+      when: rpm_flannel.rc == 0
+
+    - name: Stop etcd service if etcd rpm present
+      service:
+        name: etcd
+        state: stopped
+        enabled: no
+      when: rpm_etcd.rc == 0
+
     - name: Install etcd
       command: >
         atomic install


### PR DESCRIPTION
On certain flavors of Atomic Host, we still ship the `etcd` and
`flannel` RPMs on the host.  This causes a minor conflict when we
install those services from system containers.  Notably, the existing
services can be running and attempts to `runc exec` into the
containers will fail because they haven't been started yet.

So we check for the presence of the RPMs and proactively disable/stop
the services before trying to use the system containers.