### PR TITLE
tree-wide: correct use of Jinja2 templating in when: statements

### DIFF
--- a/docs/howto_contribute.md
+++ b/docs/howto_contribute.md
@@ -79,7 +79,7 @@ operation is successful.
 - name: Verify Docker image was built
   command: docker images
   register: docker_images
-  failed_when: "'{{ image_name }}' not in docker_images.stdout"
+  failed_when: image_name not in docker_images.stdout
 ```
 
 This role is very flexible as it allows users the ability to define the

--- a/roles/atomic_images_delete_all/tasks/main.yml
+++ b/roles/atomic_images_delete_all/tasks/main.yml
@@ -11,4 +11,4 @@
 - name: Verify no images exist
   command: atomic images list -q
   register: ail
-  failed_when: "{{ ail.stdout_lines | length }} > 0"
+  failed_when: ail.stdout_lines|length > 0

--- a/roles/atomic_pull/tasks/main.yml
+++ b/roles/atomic_pull/tasks/main.yml
@@ -15,4 +15,4 @@
 - name: Verify image exists
   command: atomic images list
   register: ail
-  failed_when: "'{{ image }}' not in ail.stdout"
+  failed_when: image not in ail.stdout

--- a/roles/docker_build_httpd/tasks/main.yml
+++ b/roles/docker_build_httpd/tasks/main.yml
@@ -59,4 +59,4 @@
 - name: Fail if httpd image not present
   fail:
     msg: "The {{ g_httpd_name }} image is not present"
-  when: "'{{ g_httpd_name }}' not in build_images.stdout"
+  when: g_httpd_name not in build_images.stdout

--- a/roles/docker_pull_base_image/tasks/main.yml
+++ b/roles/docker_pull_base_image/tasks/main.yml
@@ -20,4 +20,4 @@
 - name: Fail if base image is missing
   fail:
     msg: "The base image named {{ g_osname }} is missing"
-  when: "'{{ g_osname }}' not in docker_images.stdout"
+  when: g_osname not in docker_images.stdout

--- a/roles/docker_remove_all/tasks/main.yml
+++ b/roles/docker_remove_all/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Fail if any containers persist
   fail:
     msg: "All containers were not removed successfully"
-  when: "{{ docker_ps.stdout|length }} != 0"
+  when: docker_ps.stdout|length != 0
 
 - name: Remove all images
   shell: docker rmi -f $(docker images -aq)
@@ -25,4 +25,4 @@
 - name: Fail if any images persist
   fail:
     msg: "All images were not removed successfully"
-  when: "{{ docker_images.stdout|length }} != 0"
+  when: docker_images.stdout|length != 0

--- a/roles/docker_rm_httpd_container/tasks/main.yml
+++ b/roles/docker_rm_httpd_container/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Fail if httpd container is not present
   fail:
     msg: "The {{ g_httpd_name }} container is not present"
-  when: "'{{ g_httpd_name }}' not in ps_before.stdout"
+  when: g_httpd_name not in ps_before.stdout
 
 - name: Remove the httpd container
   command: "docker rm {{ g_httpd_name }}"
@@ -30,4 +30,4 @@
 - name: Fail if httpd container is present
   fail:
     msg: "The {{ g_httpd_name }} container is still present"
-  when: "'{{ g_httpd_name }}' in ps_after.stdout"
+  when: g_httpd_name in ps_after.stdout

--- a/roles/docker_rmi_httpd_image/tasks/main.yml
+++ b/roles/docker_rmi_httpd_image/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Fail if the httpd image is not present
   fail:
     msg: "The {{ g_httpd_name }} container is not present"
-  when: "'{{ g_httpd_name }}' not in images_before.stdout"
+  when: g_httpd_name not in images_before.stdout
 
 - name: Remove the httpd container
   command: "docker rmi {{ g_httpd_name }}"
@@ -30,4 +30,4 @@
 - name: Fail if the httpd image is present
   fail:
     msg: "The {{ g_httpd_name }} image was not removed"
-  when: "'{{ g_httpd_name }}' in images_after.stdout"
+  when: g_httpd_name in images_after.stdout

--- a/roles/docker_run_httpd/tasks/main.yml
+++ b/roles/docker_run_httpd/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Fail if httpd image is missing
   fail:
     msg: "httpd image is not present"
-  when: "'{{ g_httpd_name }}' not in images.stdout"
+  when: g_httpd_name not in images.stdout
 
 - name: Run httpd container
   command: "docker run -d -p 80:80 --name {{ g_httpd_name }} {{ g_httpd_name }}"
@@ -30,7 +30,7 @@
 - name: Check for httpd container
   fail:
     msg: "The {{ g_httpd_name }} container is not running"
-  when: "'{{ g_httpd_name }}' not in ps_run.stdout"
+  when: g_httpd_name not in ps_run.stdout
 
 - name: Verify port 80 is open
   wait_for:
@@ -54,7 +54,7 @@
 - name: Fail if httpd container is still running
   fail:
     msg: "The {{ g_httpd_name }} container is still running"
-  when: "'{{ g_httpd_name }}' in ps_stop.stdout"
+  when: g_httpd_name in ps_stop.stdout
 
 - name: Start httpd container
   command: "docker start {{ g_httpd_name }}"
@@ -66,7 +66,7 @@
 - name: Fail if httpd container is not running
   fail:
     msg: "The {{ g_httpd_name }} container is not running"
-  when: "'{{ g_httpd_name }}' not in ps_start.stdout"
+  when: g_httpd_name not in ps_start.stdout
 
 - name: Stop httpd container
   command: "docker stop {{ g_httpd_name }}"
@@ -78,4 +78,4 @@
 - name: Fail if httpd container is still running
   fail:
     msg: "The {{ g_httpd_name }} container is still running"
-  when: "'{{ g_httpd_name }}' in ps_stop.stdout"
+  when: g_httpd_name in ps_stop.stdout

--- a/roles/docker_storage_verify/tasks/main.yml
+++ b/roles/docker_storage_verify/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Check Docker storage driver
   shell: "docker info | grep -oP '(?<=Storage Driver: ).*'"
   register: storage_driver
-  failed_when: "'{{ storage_driver.stdout }}' != '{{ driver }}'"
+  failed_when: storage_driver.stdout != driver
 
 - name: Check for F25 Docker mount
   command: findmnt /var/lib/docker/devicemapper

--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -29,7 +29,7 @@
   - name: pull kubernetes api-server, controller-mgr, scheduler
     command: docker pull {{ item }}
     register: pull
-    failed_when: "'{{ item }}' not in pull.stdout"
+    failed_when: item not in pull.stdout
     with_items:
       - "{{ kube_apiserver }}"
       - "{{ kube_controller_manager }}"

--- a/roles/rpm_ostree_install_verify/tasks/main.yml
+++ b/roles/rpm_ostree_install_verify/tasks/main.yml
@@ -51,7 +51,7 @@
 - name: Fail if {{ roiv_package_name }} is not in rpm-ostree status output
   fail:
     msg: "{{ roiv_package_name }} not in rpm-ostree status output"
-  when: "'{{ roiv_package_name }}' not in installed_pkgs"
+  when: roiv_package_name not in installed_pkgs
 
 - name: Check for {{ roiv_binary_name }} binary
   command: command -v {{ roiv_binary_name }}

--- a/roles/rpm_ostree_uninstall_verify/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall_verify/tasks/main.yml
@@ -59,7 +59,7 @@
 - name: Fail if {{ rouv_package_name }} is in rpm-ostree status output
   fail:
     msg: "{{ rouv_package_name }} in rpm-ostree status output"
-  when: "'{{ rouv_package_name }}' in installed_pkgs"
+  when: rouv_package_name in installed_pkgs
 
 - name: Fail if binary for {{ rouv_binary_name }} is installed
   command: command -v {{ rouv_binary_name }}

--- a/roles/rpmdb_verify/tasks/main.yml
+++ b/roles/rpmdb_verify/tasks/main.yml
@@ -8,4 +8,4 @@
 - name: Fail if the RPM database is broken
   fail:
     msg: "The RPM database is not usable"
-  when: "{{ rpmdb.stdout | int }} <= 0 or rpmdb.rc != 0"
+  when: rpmdb.stdout|int <= 0 or rpmdb.rc != 0

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -96,7 +96,7 @@
 - name: Fail if a file/dir is found with 'default_t' label
   fail:
     msg: "The file {{ item.item }} had an SELinux label of 'default_t'"
-  when: "{{ item.stdout | length }} != 0"
+  when: item.stdout|length != 0
   with_items: "{{ find_default_t.results }}"
 
 - name: Look for files/dir with 'unlabeled_t' label
@@ -107,5 +107,5 @@
 - name: Fail if a file is found with the 'unlabeled_t' label
   fail:
     msg: "The file {{ item.item }} had an SELinux label of 'unlabeled_t'"
-  when: "{{ item.stdout | length }} != 0"
+  when: item.stdout|length != 0
   with_items: "{{ find_file_t.results }}"

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -241,12 +241,12 @@
     - name: Fail if {{ g_pkg2 }} is in rpm-ostree status output for pending packages
       fail:
         msg: "{{ g_pkg2 }} in rpm-ostree status output"
-      when: "'{{ g_pkg2 }}' in pending_pkgs"
+      when: g_pkg2 in pending_pkgs
 
     - name: Fail if {{ g_pkg1 }} is not in rpm-ostree status output for pending packages
       fail:
         msg: "{{ g_pkg1 }} not in rpm-ostree status output"
-      when: "'{{ g_pkg1 }}' not in pending_pkgs"
+      when: g_pkg1 not in pending_pkgs
 
     - name: Fail if {{ g_pkg1 }} is installed
       command: command -v {{ g_pkg1 }}
@@ -376,7 +376,7 @@
     - name: Fail if {{ g_deployed_pkg }} is not in requested packages
       fail:
         msg: "{{ g_deployed_pkg }} not found in rpm-ostree status output"
-      when: "'{{ g_deployed_pkg }}' not in req_pkgs"
+      when: g_deployed_pkg not in req_pkgs
 
 - name: Package Layering - Installing non-root ownership package
   hosts: all

--- a/tests/pkg-layering/verify_package_deployed.yml
+++ b/tests/pkg-layering/verify_package_deployed.yml
@@ -1,3 +1,4 @@
+# vim: set ft=ansible:
 ---
 - name: Fail when package is undefined
   fail:
@@ -25,7 +26,7 @@
 - name: Fail if {{ package }} is not in rpm-ostree status output
   fail:
     msg: "{{ package }} not in rpm-ostree status output"
-  when: "'{{ package }}' not in installed_pkgs"
+  when: package not in installed_pkgs
 
 - name: Verify {{ package }} is installed
   command: command -v {{ package }}

--- a/tests/pkg-layering/verify_package_not_deployed.yml
+++ b/tests/pkg-layering/verify_package_not_deployed.yml
@@ -1,3 +1,4 @@
+# vim: set ft=ansible:
 ---
 - name: Fail when package is undefined
   fail:
@@ -25,7 +26,7 @@
 - name: Fail if {{ package }} is in rpm-ostree status output
   fail:
     msg: "{{ package }} in rpm-ostree status output"
-  when: "'{{ package }}' in installed_pkgs"
+  when: package in installed_pkgs
 
 - name: Fail if {{ package }} is installed
   command: command -v {{ package }}

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -628,7 +628,7 @@
     - name: Fail if initramfs does not have two arguments
       fail:
         msg: "Incorrect number of arguments.  Expected: 2.  Actual: {{ ros_booted['initramfs-args'] | length }}"
-      when: "{{ ros_booted['initramfs-args'] | length }} != 2"
+      when: ros_booted['initramfs-args']|length != 2
 
     - name: Fail if first initramfs argument is not set
       fail:


### PR DESCRIPTION
I've observed warnings thrown by Ansible about using Jinja2 templating
in `when:` and `failed_when:` statements like this:

```
   when: "'{{ foo }}' in bar.stdout"
```

The correct way to write this is like so:

```
   when: foo in bar.stdout
```

This change corrects (most) of the instances of this to the correct
format.