### PR TITLE
i-s-t: use diff RPM for 'rpm_install' on Fedora

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -211,14 +211,29 @@
 
     - role: rpm_install
       rpm_url: "{{ g_rpm_url }}"
+      when: ansible_distribution != 'Fedora'
       tags:
         - rpm_install
+
+    - role: rpm_install
+      rpm_url: "{{ g_rpm_url_fedora }}"
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - rpm_install_fedora
 
     - role: package_verify_present
       rpm_name: "{{ g_rpm_name }}"
       check_binary: false
+      when: ansible_distribution != 'Fedora'
       tags:
         - package_verify_present
+
+    - role: package_verify_present
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      check_binary: false
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - package_verify_present_fedora
 
     # Check that /tmp has the proper permissions
     - role: tmp_check_perms
@@ -524,8 +539,15 @@
     # Verify admin unlocked package is removed after upgrade
     - role: package_verify_missing
       rpm_name: "{{ g_rpm_name }}"
+      when: ansible_distribution != 'Fedora'
       tags:
         - package_verify_missing
+
+    - role: package_verify_missing
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - package_verify_missing_fedora
 
     # Check that /tmp is properly setup again
     - role: tmp_check_perms

--- a/tests/improved-sanity-test/vars/common.yml
+++ b/tests/improved-sanity-test/vars/common.yml
@@ -8,7 +8,9 @@ g_dir2: 'qe2'
 g_hostname: 'myhostname'
 g_pkg: "wget"
 g_rpm_url: 'https://download.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm'
+g_rpm_url_fedora: 'https://kojipkgs.fedoraproject.org//packages/ltrace/0.7.91/22.fc26/x86_64/ltrace-0.7.91-22.fc26.x86_64.rpm'
 g_rpm_name: 'epel-release'
+g_rpm_name_fedora: 'ltrace'
 g_seboolean: "virt_use_nfs"
 # These variables are used by the 'semanage_fcontext_mod' and
 # 'semanage_fcontext_verify' roles.  The values were pulled from

--- a/tests/improved-sanity-test/vars/common.yml
+++ b/tests/improved-sanity-test/vars/common.yml
@@ -8,7 +8,7 @@ g_dir2: 'qe2'
 g_hostname: 'myhostname'
 g_pkg: "wget"
 g_rpm_url: 'https://download.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm'
-g_rpm_url_fedora: 'https://kojipkgs.fedoraproject.org//packages/ltrace/0.7.91/22.fc26/x86_64/ltrace-0.7.91-22.fc26.x86_64.rpm'
+g_rpm_url_fedora: 'https://kojipkgs.fedoraproject.org/packages/ltrace/0.7.91/22.fc26/x86_64/ltrace-0.7.91-22.fc26.x86_64.rpm'
 g_rpm_name: 'epel-release'
 g_rpm_name_fedora: 'ltrace'
 g_seboolean: "virt_use_nfs"


### PR DESCRIPTION
Previously, we were getting away with using `epel-release` as a
generic RPM duing the `rpm_install` role in the i-s-t.  But the latest
version of the RPM now has a `Conflicts: fedora-release` and thus we
can't install it on Fedora-based AH systems anymore.

This change conditionalizes the RPM we use during the `rpm_install`
role.  On Fedora, I chose the current stable version of `ltrace` and
stuck with `epel-release` for everything else.