### PR TITLE
selinux_verify: update the files/procs to check for CAHC

### DIFF
--- a/roles/selinux_verify/vars/centosdev-7.yml
+++ b/roles/selinux_verify/vars/centosdev-7.yml
@@ -1,19 +1,21 @@
 ---
 distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-shim', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-shim-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-ctr-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/dockerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/dockerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/dockerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-latest-storage-setup', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/container-storage-setup', value: 'system_u:object_r:bin_t:s0' }
-  - { key: '/usr/libexec/docker/docker-containerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-containerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/libexec/docker/docker-containerd-shim-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-containerd-shim-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/libexec/docker/docker-ctr-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-ctr-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/libexec/docker/docker-init-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-init-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-lvm-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-novolume-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
@@ -24,4 +26,3 @@ distro_files:
 
 distro_procs:
   - { key: 'docker', value: 'system_u:system_r:container_runtime_t:s0' }
-  - { key: 'docker-containerd', value: 'system_u:system_r:container_runtime_t:s0' }


### PR DESCRIPTION
We had to revert the version of `docker` on CAHC to an older version
being served up by CentOS-extras, which neccessitated the need to
update the files and processes we check for incorrect SELinux labels.

Related:  CentOS/sig-atomic-buildscripts#308