### PR TITLE
roles: adjust retries on 'redhat_subscription' and 'redhat_unsubscribe'

### DIFF
--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -55,9 +55,9 @@
       USERNAME: "{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
       PASSWORD: "{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"
     register: result
-    until: result.rc == 0
-    retries: 3
-    delay: 5
+    until: result|success
+    retries: 5
+    delay: 60
 
   - name: disable all repos
     command: subscription-manager repos --disable=*

--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -61,6 +61,10 @@
 
   - name: disable all repos
     command: subscription-manager repos --disable=*
+    register: result
+    until: result|success
+    retries: 5
+    delay: 60
 
   - name: enable server, optional, and extras repos
     command: >
@@ -68,6 +72,10 @@
       --enable rhel-7-server-rpms
       --enable rhel-7-server-optional-rpms
       --enable rhel-7-server-extras-rpms
+    register: result
+    until: result|success
+    retries: 5
+    delay: 60
 
   - name: Mask and stop rhsmcertd
     shell: >

--- a/roles/redhat_unsubscribe/tasks/main.yml
+++ b/roles/redhat_unsubscribe/tasks/main.yml
@@ -22,6 +22,9 @@
   failed_when:
     - subman_remove.rc != 0
     - subman_remove.rc != 70
+  until: subman_remove|success
+  retries: 5
+  delay: 60
 
 - name: Unregister from remote service
   command: subscription-manager unregister

--- a/roles/redhat_unsubscribe/tasks/main.yml
+++ b/roles/redhat_unsubscribe/tasks/main.yml
@@ -25,6 +25,10 @@
 
 - name: Unregister from remote service
   command: subscription-manager unregister
+  register: result
+  until: result|success
+  retries: 5
+  delay: 60
 
 - name: Insert 'unconfigured-state' field
   lineinfile:


### PR DESCRIPTION
Our internal jobs hit some network timeouts while doing an
'unsubscribe' with `subscription-manager`.  We already had some
retries for `redhat_subscription`, but were lacking them on the
`redhat_unsubscribe`.  This change implements the retries for
'unsubscribe' and bumps up the retries on 'subscription'