### PR TITLE
papr: changes related to f27 release

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -3,7 +3,7 @@ cluster:
     - name: testnode
       distro: fedora/26/atomic
   container:
-    image: registry.fedoraproject.org/fedora:25
+    image: registry.fedoraproject.org/fedora:27
 
 context: fedora/26/atomic
 
@@ -21,9 +21,21 @@ inherit: true
 cluster:
   hosts:
     - name: testnode
+      distro: fedora/27/atomic
+  container:
+    image: registry.fedoraproject.org/fedora:27
+
+context: fedora/27/atomic
+
+---
+inherit: true
+
+cluster:
+  hosts:
+    - name: testnode
       distro: centos/7/atomic
   container:
-    image: registry.fedoraproject.org/fedora:25
+    image: registry.fedoraproject.org/fedora:27
 
 context: centos/7/atomic
 
@@ -35,6 +47,6 @@ cluster:
     - name: testnode
       distro: centos/7/atomic/continuous
   container:
-    image: registry.fedoraproject.org/fedora:25
+    image: registry.fedoraproject.org/fedora:27
 
 context: centos/7/atomic/continuous

--- a/.papr.yml
+++ b/.papr.yml
@@ -3,7 +3,7 @@ cluster:
     - name: testnode
       distro: fedora/26/atomic
   container:
-    image: registry.fedoraproject.org/fedora:27
+    image: registry.fedoraproject.org/fedora:26
 
 context: fedora/26/atomic
 
@@ -35,7 +35,7 @@ cluster:
     - name: testnode
       distro: centos/7/atomic
   container:
-    image: registry.fedoraproject.org/fedora:27
+      image: registry.centos.org/centos/centos:7
 
 context: centos/7/atomic
 
@@ -47,6 +47,6 @@ cluster:
     - name: testnode
       distro: centos/7/atomic/continuous
   container:
-    image: registry.fedoraproject.org/fedora:27
+      image: registry.centos.org/centos/centos:7
 
 context: centos/7/atomic/continuous


### PR DESCRIPTION
F27 has been released, so let's enable our CI on that image and switch
the containers to F27, too.