### PR TITLE
Add test for livefs

### DIFF
--- a/roles/rpm_ostree_install_verify/tasks/main.yml
+++ b/roles/rpm_ostree_install_verify/tasks/main.yml
@@ -9,6 +9,7 @@
 # Parameter:
 #   roiv_package_name - name of a single package
 #   roiv_binary_name - name of binary to check for (optional)
+#   roiv_status_check - boolean - optionally check the rpm-ostree status for package
 #
 # Requirements:
 #  This role must be run after the reboot following rpm-ostree install of a package
@@ -29,29 +30,17 @@
 - name: Setup binary fact
   set_fact:
     roiv_binary_name: "{{ roiv_binary_name if roiv_binary_name is defined else roiv_package_name }}"
+    roiv_status_check: "{{ roiv_status_check | default(true) }}"
 
-- name: Get rpm-ostree status --json output
-  command: rpm-ostree status --json
-  register: installed
+- include_role:
+    name: rpm_ostree_status
 
-- name: Convert rpm-ostree status output to jinja2 json
-  set_fact:
-    installed_json: "{{ installed.stdout | from_json }}"
-
-- name: Set packages when deployment 0 is booted
-  set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][0]['packages'] }}"
-  when: installed_json['deployments'][0]['packages'] is defined and installed_json['deployments'][0]['booted']
-
-- name: Set packages when deployment 1 is booted
-  set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][1]['packages'] }}"
-  when: installed_json['deployments'][1]['packages'] is defined and installed_json['deployments'][1]['booted']
-
-- name: Fail if {{ roiv_package_name }} is not in rpm-ostree status output
+# ros_booted is pulled from the rpm_ostree_status role above
+- name: Fail if {{ roiv_package_name }} is not in list of installed packages
   fail:
-    msg: "{{ roiv_package_name }} not in rpm-ostree status output"
-  when: roiv_package_name not in installed_pkgs
+    msg: "{{ roiv_package_name }} is not in rpm-ostree status output"
+  when: roiv_package_name not in ros_booted['packages'] and
+        roiv_status_check
 
 - name: Check for {{ roiv_binary_name }} binary
   command: command -v {{ roiv_binary_name }}

--- a/roles/rpm_ostree_livefs/meta/main.yml
+++ b/roles/rpm_ostree_livefs/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_ostree_livefs/tasks/main.yml
+++ b/roles/rpm_ostree_livefs/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# vim: set ft=ansible:
+#
+- name: Enable livefs
+  command: rpm-ostree ex livefs
+  register: ros_lfs
+
+# Regex to find all the sha256 checksums in the output
+- name: Get commits
+  set_fact:
+    commits: "{{ ros_lfs.stdout|regex_findall('[A-Fa-f0-9]{64}') }}"
+
+# Note: There was an instance where there were three checksums in the message
+# so just grab the last two.
+- name: Get base and livefs commits
+  set_fact:
+    rol_base_commit: "{{ commits[-2] }}"
+    rol_livefs_commit: "{{ commits[-1] }}"
+

--- a/roles/rpm_ostree_rollback/meta/main.yml
+++ b/roles/rpm_ostree_rollback/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_ostree_uninstall_verify/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall_verify/tasks/main.yml
@@ -9,7 +9,7 @@
 # Parameter:
 #   rouv_package_name - the name of a single package
 #   rouv_binary_name - the name of a binary (optional)
-#
+#   rouv_status_check - boolean -check the rpm-ostree output for the package (optional)
 # Requirements:
 #  This role must be run after the reboot following rpm-ostree install of a package
 #
@@ -29,37 +29,17 @@
 - name: Setup binary fact
   set_fact:
     rouv_binary_name: "{{ rouv_binary_name if rouv_binary_name is defined else rouv_package_name }}"
+    rouv_status_check: "{{ rouv_status_check | default(true) }}"
 
-- name: Get rpm-ostree status --json output
-  command: rpm-ostree status --json
-  register: installed
+- include_role:
+    name: rpm_ostree_status
 
-- name: Convert rpm-ostree status output to jinja2 json
-  set_fact:
-    installed_json: "{{ installed.stdout | from_json }}"
-
-# This is a hack for packages being displayed in rpm-ostree v2017.3 that should
-# be fixed in v2017.4.  Once all streams are at v2017.4 we can fix this.  See
-# https://github.com/projectatomic/rpm-ostree/pull/670
-- name: Set packages when deployment 0 is booted
-  set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][0]['packages'] if installed_json['deployments'][0]['packages'] is defined else {} }}"
-  when: installed_json['deployments'][0]['booted']
-
-- name: Set packages when deployment 1 is booted
-  set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][1]['packages'] if installed_json['deployments'][1]['packages'] is defined else {} }}"
-  when:  installed_json['deployments'][1]['booted']
-
-- name: Fail if packages not found in rpm-ostree status output
+# ros_booted is pulled from rpm_ostree_status role above
+- name: Fail if package is in rpm-ostree booted deployment
   fail:
-    msg: "Packages not found in rpm-ostree status output"
-  when: installed_pkgs is undefined
-
-- name: Fail if {{ rouv_package_name }} is in rpm-ostree status output
-  fail:
-    msg: "{{ rouv_package_name }} in rpm-ostree status output"
-  when: rouv_package_name in installed_pkgs
+    msg: "{{ rouv_package_name }} is in rpm-ostree status output when it shouldn't be"
+  when: rouv_package_name in ros_booted['packages'] and
+        rouv_status_check
 
 - name: Fail if binary for {{ rouv_binary_name }} is installed
   command: command -v {{ rouv_binary_name }}

--- a/tests/rpm-ostree/README.md
+++ b/tests/rpm-ostree/README.md
@@ -10,6 +10,7 @@ Core Functionality
   - rpm-ostree status
   - rpm-ostree upgrade
   - rpm-ostree reload
+  - rpm-ostree ex livefs
   - rpm-ostree initramfs
 
 To be Covered

--- a/tests/rpm-ostree/info.txt
+++ b/tests/rpm-ostree/info.txt
@@ -6,6 +6,7 @@ Test Coverage:
 * rpm-ostree status
 * rpm-ostree upgrade
 * rpm-ostree reload
+* rpm-ostree ex livefs
 * rpm-ostree initramfs
 
 Not Covered:

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -604,78 +604,69 @@
     - role: rpm_ostree_cleanup_all
 
     - role: rpm_ostree_install
-      vars:
-        roi_packages: "{{ pkg_name }}"
-        roi_reboot: false
+      roi_packages: "{{ pkg_name }}"
+      roi_reboot: false
 
     - role: rpm_ostree_livefs
 
     - role: rpm_ostree_install_verify
-      vars:
-        roiv_package_name: "{{ pkg_name }}"
-        roiv_status_check: false
+      roiv_package_name: "{{ pkg_name }}"
+      roiv_status_check: false
 
     # rol_base_commit and rol_livefs_commit come from the rpm_ostree_livefs role
     # deployment information
     - role: rpm_ostree_status_verify
-      vars:
-        num_deployments: 3
-        deployment: 1
-        expected:
-          booted: true
-          checksum: "{{ rol_base_commit }}"
-          live-replaced: "{{ rol_livefs_commit }}"
+      num_deployments: 3
+      deployment: 1
+      expected:
+        booted: true
+        checksum: "{{ rol_base_commit }}"
+        live-replaced: "{{ rol_livefs_commit }}"
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 0
-        expected:
-          booted: false
-          checksum: "{{ rol_livefs_commit }}"
-          packages:
-            - "{{ pkg_name }}"
+      deployment: 0
+      expected:
+        booted: false
+        checksum: "{{ rol_livefs_commit }}"
+        packages:
+          - "{{ pkg_name }}"
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 2
-        expected:
-          booted: false
-          checksum: "{{ rol_base_commit }}"
-          packages: []
+      deployment: 2
+      expected:
+        booted: false
+        checksum: "{{ rol_base_commit }}"
+        packages: []
 
     # Reboot and check that the deployment is now a typical package layered deployment
     - role: reboot
 
     - role: rpm_ostree_install_verify
-      vars:
-        roiv_package_name: "{{ pkg_name }}"
-        roiv_status_check: false
+      roiv_package_name: "{{ pkg_name }}"
+      roiv_status_check: false
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 0
-        expected:
-          booted: true
-          base-checksum: "{{ rol_base_commit }}"
-          checksum: "{{ rol_livefs_commit }}"
-          packages:
-            - "{{ pkg_name }}"
+      deployment: 0
+      expected:
+        booted: true
+        base-checksum: "{{ rol_base_commit }}"
+        checksum: "{{ rol_livefs_commit }}"
+        packages:
+          - "{{ pkg_name }}"
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 1
-        expected:
-          booted: false
-          checksum: "{{ rol_base_commit }}"
-          live-replaced: "{{ rol_livefs_commit }}"
+      deployment: 1
+      expected:
+        booted: false
+        checksum: "{{ rol_base_commit }}"
+        live-replaced: "{{ rol_livefs_commit }}"
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 2
-        expected:
-          booted: false
-          checksum: "{{ rol_base_commit }}"
-          packages: []
+      deployment: 2
+      expected:
+        booted: false
+        checksum: "{{ rol_base_commit }}"
+        packages: []
 
     # Rollback twice to get to the original deployment
     - role: rpm_ostree_rollback
@@ -687,35 +678,31 @@
     - role: reboot
 
     - role: rpm_ostree_uninstall_verify
-      vars:
-        rouv_package_name: "{{ pkg_name }}"
-        rouv_status_check: false
+      rouv_package_name: "{{ pkg_name }}"
+      rouv_status_check: false
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 0
-        expected:
-          booted: true
-          checksum: "{{ rol_base_commit }}"
-          packages: []
+      deployment: 0
+      expected:
+        booted: true
+        checksum: "{{ rol_base_commit }}"
+        packages: []
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 1
-        expected:
-          booted: false
-          checksum: "{{ rol_base_commit }}"
-          live-replaced: "{{ rol_livefs_commit }}"
+      deployment: 1
+      expected:
+        booted: false
+        checksum: "{{ rol_base_commit }}"
+        live-replaced: "{{ rol_livefs_commit }}"
 
     - role: rpm_ostree_status_verify
-      vars:
-        deployment: 2
-        expected:
-          booted: false
-          base-checksum: "{{ rol_base_commit }}"
-          checksum: "{{ rol_livefs_commit }}"
-          packages:
-            - "{{ pkg_name }}"
+      deployment: 2
+      expected:
+        booted: false
+        base-checksum: "{{ rol_base_commit }}"
+        checksum: "{{ rol_livefs_commit }}"
+        packages:
+          - "{{ pkg_name }}"
 
     - role: rpm_ostree_cleanup_all
 

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -584,6 +584,143 @@
 
 #####################################################################################
 #
+# rpm-ostree livefs
+#   - simple test for test livefs
+#
+#####################################################################################
+- name: rpm-ostree livefs
+  hosts: all
+  become: yes
+
+  tags:
+    - livefs
+
+  pre_tasks:
+    - name: Set pkg name
+      set_fact:
+        pkg_name: "wget"
+
+  roles:
+    - role: rpm_ostree_cleanup_all
+
+    - role: rpm_ostree_install
+      vars:
+        roi_packages: "{{ pkg_name }}"
+        roi_reboot: false
+
+    - role: rpm_ostree_livefs
+
+    - role: rpm_ostree_install_verify
+      vars:
+        roiv_package_name: "{{ pkg_name }}"
+        roiv_status_check: false
+
+    # rol_base_commit and rol_livefs_commit come from the rpm_ostree_livefs role
+    # deployment information
+    - role: rpm_ostree_status_verify
+      vars:
+        num_deployments: 3
+        deployment: 1
+        expected:
+          booted: true
+          checksum: "{{ rol_base_commit }}"
+          live-replaced: "{{ rol_livefs_commit }}"
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 0
+        expected:
+          booted: false
+          checksum: "{{ rol_livefs_commit }}"
+          packages:
+            - "{{ pkg_name }}"
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 2
+        expected:
+          booted: false
+          checksum: "{{ rol_base_commit }}"
+          packages: []
+
+    # Reboot and check that the deployment is now a typical package layered deployment
+    - role: reboot
+
+    - role: rpm_ostree_install_verify
+      vars:
+        roiv_package_name: "{{ pkg_name }}"
+        roiv_status_check: false
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 0
+        expected:
+          booted: true
+          base-checksum: "{{ rol_base_commit }}"
+          checksum: "{{ rol_livefs_commit }}"
+          packages:
+            - "{{ pkg_name }}"
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 1
+        expected:
+          booted: false
+          checksum: "{{ rol_base_commit }}"
+          live-replaced: "{{ rol_livefs_commit }}"
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 2
+        expected:
+          booted: false
+          checksum: "{{ rol_base_commit }}"
+          packages: []
+
+    # Rollback twice to get to the original deployment
+    - role: rpm_ostree_rollback
+
+    - role: rpm_ostree_rollback
+
+    # Reboot and verify that the system is back to the original deployment without livefs
+    # or layered packages
+    - role: reboot
+
+    - role: rpm_ostree_uninstall_verify
+      vars:
+        rouv_package_name: "{{ pkg_name }}"
+        rouv_status_check: false
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 0
+        expected:
+          booted: true
+          checksum: "{{ rol_base_commit }}"
+          packages: []
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 1
+        expected:
+          booted: false
+          checksum: "{{ rol_base_commit }}"
+          live-replaced: "{{ rol_livefs_commit }}"
+
+    - role: rpm_ostree_status_verify
+      vars:
+        deployment: 2
+        expected:
+          booted: false
+          base-checksum: "{{ rol_base_commit }}"
+          checksum: "{{ rol_livefs_commit }}"
+          packages:
+            - "{{ pkg_name }}"
+
+    - role: rpm_ostree_cleanup_all
+
+#####################################################################################
+#
 # rpm-ostree initramfs
 #   - test client side initramfs
 #


### PR DESCRIPTION
This commit adds a simple livefs test using package layering as the
change in the filesystem.

The rpm_ostree_install_verify and rpm_ostree_uninstall_verify roles
needed an option to skip the rpm-ostree status since the output is
changed with the livefs implementation. The roles were also cleaned
up and now uses the new variables from the rpm_ostree_status role.