### PR TITLE
Use virtualenv for PAPR

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -8,9 +8,12 @@ cluster:
 context: fedora/26/atomic
 
 packages:
-  - ansible
+  - python-virtualenv
+  - python-pip
   - git
-  - python2-jmespath
+  - gcc
+  - redhat-rpm-config
+  - libselinux-python
 
 tests:
   - ./.test_director
@@ -23,7 +26,7 @@ cluster:
     - name: testnode
       distro: fedora/27/atomic
   container:
-    image: registry.fedoraproject.org/fedora:27
+    image: registry.fedoraproject.org/fedora:26
 
 context: fedora/27/atomic
 
@@ -35,7 +38,7 @@ cluster:
     - name: testnode
       distro: centos/7/atomic
   container:
-      image: registry.centos.org/centos/centos:7
+      image: registry.fedoraproject.org/fedora:26
 
 context: centos/7/atomic
 
@@ -47,6 +50,6 @@ cluster:
     - name: testnode
       distro: centos/7/atomic/continuous
   container:
-      image: registry.centos.org/centos/centos:7
+      image: registry.fedoraproject.org/fedora:26
 
 context: centos/7/atomic/continuous

--- a/.test_director
+++ b/.test_director
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -xeuo pipefail
 
+VIRTUAL_ENV_DISABLE_PROMPT=1
+
+if [ ! -d venv ]; then
+    virtualenv --system-site-packages venv
+fi
+
+source venv/bin/activate
+
+pip install -r requirements.txt
+
+ansible --version
+
 NEW_TESTS=( $(git diff --name-only $(git merge-base origin/master HEAD) | grep 'tests/.*/main.yml' || true) )
 
 # no new tests found, just run improved sanity test


### PR DESCRIPTION
Resolves issue #262.  The latest version of Ansible was being installed
by PAPR but A-H-T currently supports 2.2.x.  Use virtualenv to install
the supported version of Ansible for A-H-T.