### PR TITLE
admin-unlock: use different RPM on Fedora

### DIFF
--- a/roles/epel_rpm_url/tasks/main.yml
+++ b/roles/epel_rpm_url/tasks/main.yml
@@ -21,14 +21,14 @@
 
 - name: Set EPEL base url
   set_fact:
-    epel_base: "https://download.fedoraproject.org/pub/epel/7/x86_64"
+    epel_base: "https://download.fedoraproject.org/pub/epel/7/x86_64/Packages/"
 
 - name: Get subdir url
   set_fact:
     epel_subdir: "{{ epel_base }}/{{ rpm_name[0] }}"
 
 - name: Scrape HTML for package name
-  shell: curl -LsSk {{ epel_subdir }}/ | sed -n 's/.*"\({{ rpm_name }}.*.rpm\)\".*/\1/p'
+  shell: curl -LsSk {{ epel_subdir }}/ | sed -n 's|.*\"\({{ rpm_name | quote}}.*.rpm\)\".*|\1|p'
   register: epel_output
   retries: 5
   delay: 60

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -58,7 +58,9 @@
       fail:
         msg: "Required variables are not defined.  Check vars.yml file."
       when: g_rpm_url is undefined or
+            g_rpm_url_fedora is undefined or
             g_rpm_name is undefined or
+            g_rpm_name_fedora is undefined or
             g_rpm_name_2 is undefined
 
   roles:
@@ -92,27 +94,63 @@
 
     - role: rpm_install
       rpm_url: "{{ g_rpm_url }}"
+      when: ansible_distribution != 'Fedora'
+
+    - role: rpm_install
+      rpm_url: "{{ g_rpm_url_fedora }}"
+      when: ansible_distribution == 'Fedora'
 
     - role: package_verify_present
       rpm_name: "{{ g_rpm_name }}"
       check_binary: false
+      when: ansible_distribution != 'Fedora'
+
+    - role: package_verify_present
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      check_binary: false
+      when: ansible_distribution == 'Fedora'
 
     - role: rpm_uninstall
       rpm_name: "{{ g_rpm_name }}"
+      when: ansible_distribution != 'Fedora'
+
+    - role: rpm_uninstall
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      when: ansible_distribution == 'Fedora'
 
     - role: package_verify_missing
       rpm_name: "{{ g_rpm_name }}"
+      when: ansible_distribution != 'Fedora'
+
+    - role: package_verify_missing
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      when: ansible_distribution == 'Fedora'
 
     - role: rpm_install
       rpm_url: "{{ g_rpm_url }}"
+      when: ansible_distribution != 'Fedora'
       tags:
         - second_install
+
+    - role: rpm_install
+      rpm_url: "{{ g_rpm_url_fedora }}"
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - second_install_fedora
 
     - role: package_verify_present
       rpm_name: "{{ g_rpm_name }}"
       check_binary: false
+      when: ansible_distribution != 'Fedora'
       tags:
         - second_verify_present
+
+    - role: package_verify_present
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      check_binary: false
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - second_verify_present_fedora
 
     - role: reboot
 
@@ -120,8 +158,16 @@
 
     - role: package_verify_missing
       rpm_name: "{{ g_rpm_name }}"
+      when: ansible_distribution != 'Fedora'
       tags:
         - second_verify_missing
+
+    - role: package_verify_missing
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - second_verify_missing_fedora
+
 
 - name: Ostree Admin Unlock - Hotfix - Add/Remove Package Persistence
   hosts: all
@@ -140,27 +186,63 @@
 
     - role: rpm_install
       rpm_url: "{{ g_rpm_url }}"
+      when: ansible_distribution != 'Fedora'
+
+    - role: rpm_install
+      rpm_url: "{{ g_rpm_url_fedora }}"
+      when: ansible_distribution == 'Fedora'
 
     - role: package_verify_present
       rpm_name: "{{ g_rpm_name }}"
       check_binary: false
+      when: ansible_distribution != 'Fedora'
+
+    - role: package_verify_present
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      check_binary: false
+      when: ansible_distribution == 'Fedora'
 
     - role: rpm_uninstall
       rpm_name: "{{ g_rpm_name }}"
+      when: ansible_distribution != 'Fedora'
+
+    - role: rpm_uninstall
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      when: ansible_distribution == 'Fedora'
 
     - role: package_verify_missing
       rpm_name: "{{ g_rpm_name }}"
+      when: ansible_distribution != 'Fedora'
+
+    - role: package_verify_missing
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      when: ansible_distribution == 'Fedora'
 
     - role: rpm_install
       rpm_url: "{{ g_rpm_url }}"
+      when: ansible_distribution != 'Fedora'
       tags:
         - second_install
+
+    - role: rpm_install
+      rpm_url: "{{ g_rpm_url_fedora }}"
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - second_install_fedora
 
     - role: package_verify_present
       rpm_name: "{{ g_rpm_name }}"
       check_binary: false
+      when: ansible_distribution != 'Fedora'
       tags:
         - second_verify_present
+
+    - role: package_verify_present
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      check_binary: false
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - second_verify_present_fedora
 
     - role: reboot
 
@@ -169,8 +251,16 @@
     - role: package_verify_present
       rpm_name: "{{ g_rpm_name }}"
       check_binary: false
+      when: ansible_distribution != 'Fedora'
       tags:
         - third_verify_present
+
+    - role: package_verify_present
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      check_binary: false
+      when: ansible_distribution == 'Fedora'
+      tags:
+        - third_verify_present_fedora
 
     - role: epel_rpm_url
       rpm_name: "{{ g_rpm_name_2 }}"
@@ -204,6 +294,11 @@
 
     - role: package_verify_missing
       rpm_name: "{{ g_rpm_name }}"
+      when: ansible_distribution != 'Fedora'
+
+    - role: package_verify_missing
+      rpm_name: "{{ g_rpm_name_fedora }}"
+      when: ansible_distribution == 'Fedora'
 
     - role: package_verify_missing
       rpm_name: "{{ g_rpm_name_2 }}"

--- a/tests/admin-unlock/vars.yml
+++ b/tests/admin-unlock/vars.yml
@@ -1,4 +1,6 @@
 ---
 g_rpm_url: 'https://download.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm'
+g_rpm_url_fedora: 'https://kojipkgs.fedoraproject.org/packages/ltrace/0.7.91/22.fc26/x86_64/ltrace-0.7.91-22.fc26.x86_64.rpm'
 g_rpm_name: 'epel-release'
+g_rpm_name_fedora: 'ltrace'
 g_rpm_name_2: 'fpaste'


### PR DESCRIPTION
In #271, the RPM used during the sanity test of `ostree admin unlock`
was changed for the Fedora case.  We make the same changes here in the
more comprehesive test of the `ostree admin unlock` functionality.

As part of this, the base EPEL URL is updated (who knew it chagned?!)
and the `sed` regex was updated to be a little cleaner.