### PR TITLE
stop using Fedora 25 images in roles/tests

### DIFF
--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Set cockpit container name for Fedora/CentOS
   set_fact:
-    cockpit_cname: "registry.fedoraproject.org/f25/cockpit"
+    cockpit_cname: "registry.fedoraproject.org/f26/cockpit"
   when: "'CentOS' in ansible_distribution or ansible_distribution == 'Fedora'"
 
 - name: Install cockpit container with tag

--- a/roles/etcd_sys_container_install/tasks/main.yml
+++ b/roles/etcd_sys_container_install/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Set facts
   set_fact:
-    etcd_image: 'registry.fedoraproject.org/f25/etcd'
+    etcd_image: 'registry.fedoraproject.org/f26/etcd'
     etcd_name: 'etcd'
   when: ansible_distribution != 'RedHat'
 

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -53,9 +53,9 @@
 
     - name: Set facts
       set_fact:
-        etcd_image: 'registry.fedoraproject.org/f25/etcd'
+        etcd_image: 'registry.fedoraproject.org/f26/etcd'
         etcd_name: 'etcd'
-        flannel_image: 'registry.fedoraproject.org/f25/flannel'
+        flannel_image: 'registry.fedoraproject.org/f26/flannel'
         flannel_name: 'flannel'
       when: ansible_distribution != 'RedHat'
 


### PR DESCRIPTION
Fedora 25 will be EOL shortly, so let's bump up to Fedora 26.  (I
would use Fedora 27, but not all of the old images got rebuilt, AFAIK)