### PR TITLE
tests: handle 'atomic install --system' on old versions

### DIFF
--- a/roles/atomic_system_install/tasks/main.yml
+++ b/roles/atomic_system_install/tasks/main.yml
@@ -9,8 +9,27 @@
     msg: "Image is undefined"
   when: image is undefined
 
+- name: Determine version of atomic
+  command: rpm -q --queryformat '%{VERSION}' atomic
+  register: rpmq
+
+- name: Setup atomic_version fact
+  set_fact:
+    atomic_version:  "{{ rpmq.stdout }}"
+
+# The behavior changed with this commit:
+# https://github.com/projectatomic/atomic/commit/b5f07baa6c54c2bc74079797b80a109a8d10873a
+- name: Setup atomic install command (pre v1.19.1)
+  set_fact:
+    atomic_install_cmd: "atomic install --system --system-package no "
+
+- name: Setup atomic install command (post v1.19.1)
+  set_fact:
+    atomic_install_cmd: "atomic install --system "
+  when: atomic_version | version_compare('1.19.1', '>=')
+
 - name: Install system container
-  command: atomic install --system {{ image }}
+  command: {{ atomic_install_cmd }} {{ image }}
   register: ais
   retries: 5
   delay: 60

--- a/roles/atomic_system_install/tasks/main.yml
+++ b/roles/atomic_system_install/tasks/main.yml
@@ -29,7 +29,7 @@
   when: atomic_version | version_compare('1.19.1', '>=')
 
 - name: Install system container
-  command: {{ atomic_install_cmd }} {{ image }}
+  command: "{{ atomic_install_cmd }} {{ image }}"
   register: ais
   retries: 5
   delay: 60

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -390,6 +390,26 @@
   vars_files:
     - vars.yml
 
+  pre_tasks:
+    - name: Determine version of atomic
+      command: rpm -q --queryformat '%{VERSION}' atomic
+      register: rpmq
+
+    - name: Setup atomic_version fact
+      set_fact:
+        atomic_version:  "{{ rpmq.stdout }}"
+
+    # The behavior changed with this commit:
+    # https://github.com/projectatomic/atomic/commit/b5f07baa6c54c2bc74079797b80a109a8d10873a
+    - name: Setup atomic install command (pre v1.19.1)
+      set_fact:
+        atomic_install_cmd: "atomic install --system --system-package no "
+
+    - name: Setup atomic install command (post v1.19.1)
+      set_fact:
+        atomic_install_cmd: "atomic install --system "
+      when: atomic_version | version_compare('1.19.1', '>=')
+
   tasks:
     - name: Check for etcd rpm
       command: rpm -q etcd
@@ -417,8 +437,7 @@
 
     - name: Install etcd
       command: >
-        atomic install
-        --system
+        {{ atomic_install_cmd }}
         --name=etcd
         {{ etcd_image }}
       register: ai_etcd
@@ -445,9 +464,8 @@
         set /atomic.io/network/config '{"Network":"172.17.0.0/16"}'
 
     - name: Install flannel
-      command:
-        atomic install
-        --system
+      command: >
+        {{ atomic_install_cmd }}
         --name=flannel
         {{ flannel_image }}
       register: ai_flannel


### PR DESCRIPTION
Well, we're still using `fedora/26/atomic` in our CI checks and the
version of `atomic` there is friggin old.  How old?  So old that it
will try to land an RPM on the host when you do an 'atomic install
--system' by default.

This tries to work around this problem by doing a version check and
altering how the `atomic install` command is used depending on the
version detected.