### PR TITLE
Increase likelihood that roles run more than once with allow_duplicates

### DIFF
--- a/roles/ansible_version_check/meta/main.yml
+++ b/roles/ansible_version_check/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_host_check/meta/main.yml
+++ b/roles/atomic_host_check/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_host_status_verify/meta/main.yml
+++ b/roles/atomic_host_status_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_images_delete_all/meta/main.yml
+++ b/roles/atomic_images_delete_all/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_installation_verify/meta/main.yml
+++ b/roles/atomic_installation_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_pull_verify/meta/main.yml
+++ b/roles/atomic_pull_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_run_verify/meta/main.yml
+++ b/roles/atomic_run_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_scan/meta/main.yml
+++ b/roles/atomic_scan/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_scan_verify/meta/main.yml
+++ b/roles/atomic_scan_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_stop_verify/meta/main.yml
+++ b/roles/atomic_stop_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_system_install/meta/main.yml
+++ b/roles/atomic_system_install/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_system_install_verify/meta/main.yml
+++ b/roles/atomic_system_install_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_system_uninstall/meta/main.yml
+++ b/roles/atomic_system_uninstall/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_system_uninstall_verify/meta/main.yml
+++ b/roles/atomic_system_uninstall_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/booted_deployment_set_fact/meta/main.yml
+++ b/roles/booted_deployment_set_fact/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/command/meta/main.yml
+++ b/roles/command/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/command_privilege_verify/meta/main.yml
+++ b/roles/command_privilege_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_build_httpd/meta/main.yml
+++ b/roles/docker_build_httpd/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_build_tag_push/meta/main.yml
+++ b/roles/docker_build_tag_push/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_latest_setup/meta/main.yml
+++ b/roles/docker_latest_setup/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_private_registry/meta/main.yml
+++ b/roles/docker_private_registry/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_pull_base_image/meta/main.yml
+++ b/roles/docker_pull_base_image/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_pull_run_remove/meta/main.yml
+++ b/roles/docker_pull_run_remove/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_remove_all/meta/main.yml
+++ b/roles/docker_remove_all/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_rm_httpd_container/meta/main.yml
+++ b/roles/docker_rm_httpd_container/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_rmi_httpd_image/meta/main.yml
+++ b/roles/docker_rmi_httpd_image/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_run_httpd/meta/main.yml
+++ b/roles/docker_run_httpd/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_storage_verify/meta/main.yml
+++ b/roles/docker_storage_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_version_check/meta/main.yml
+++ b/roles/docker_version_check/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/epel_rpm_url/meta/main.yml
+++ b/roles/epel_rpm_url/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/etc_modify/meta/main.yml
+++ b/roles/etc_modify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/etc_verify_changes/meta/main.yml
+++ b/roles/etc_verify_changes/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/etcd_sys_container_install/meta/main.yml
+++ b/roles/etcd_sys_container_install/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/handler_notify_on_failure/meta/main.yml
+++ b/roles/handler_notify_on_failure/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/httpd_start/meta/main.yml
+++ b/roles/httpd_start/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/journal_search/meta/main.yml
+++ b/roles/journal_search/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/k8_cluster_services_rc_setup/meta/main.yml
+++ b/roles/k8_cluster_services_rc_setup/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/k8_remove_all/meta/main.yml
+++ b/roles/k8_remove_all/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/kubernetes_setup/meta/main.yml
+++ b/roles/kubernetes_setup/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/load_variables/meta/main.yml
+++ b/roles/load_variables/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/local_branch_commit/meta/main.yml
+++ b/roles/local_branch_commit/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/local_branch_setup/meta/main.yml
+++ b/roles/local_branch_setup/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/machine_id_compare/meta/main.yml
+++ b/roles/machine_id_compare/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/origin_file_modify/meta/main.yml
+++ b/roles/origin_file_modify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/osname_set_fact/meta/main.yml
+++ b/roles/osname_set_fact/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/ostree_admin_unlock/meta/main.yml
+++ b/roles/ostree_admin_unlock/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/ostree_admin_unlock_hotfix/meta/main.yml
+++ b/roles/ostree_admin_unlock_hotfix/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/overlayfs_verify_missing/meta/main.yml
+++ b/roles/overlayfs_verify_missing/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/overlayfs_verify_present/meta/main.yml
+++ b/roles/overlayfs_verify_present/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/package_verify_missing/meta/main.yml
+++ b/roles/package_verify_missing/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/package_verify_present/meta/main.yml
+++ b/roles/package_verify_present/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/redhat_subscription/meta/main.yml
+++ b/roles/redhat_subscription/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/redhat_unsubscribe/meta/main.yml
+++ b/roles/redhat_unsubscribe/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_install/meta/main.yml
+++ b/roles/rpm_install/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_ostree_cleanup_all/meta/main.yml
+++ b/roles/rpm_ostree_cleanup_all/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_ostree_rebase/meta/main.yml
+++ b/roles/rpm_ostree_rebase/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_ostree_upgrade/meta/main.yml
+++ b/roles/rpm_ostree_upgrade/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpm_uninstall/meta/main.yml
+++ b/roles/rpm_uninstall/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/rpmdb_verify/meta/main.yml
+++ b/roles/rpmdb_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/runc_version_check/meta/main.yml
+++ b/roles/runc_version_check/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/selinux_boolean/meta/main.yml
+++ b/roles/selinux_boolean/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/selinux_boolean_verify/meta/main.yml
+++ b/roles/selinux_boolean_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/selinux_verify/meta/main.yml
+++ b/roles/selinux_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/semanage_fcontext_mod/meta/main.yml
+++ b/roles/semanage_fcontext_mod/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/semanage_fcontext_verify/meta/main.yml
+++ b/roles/semanage_fcontext_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/tmp_check_perms/meta/main.yml
+++ b/roles/tmp_check_perms/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/url_verify/meta/main.yml
+++ b/roles/url_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/user_add/meta/main.yml
+++ b/roles/user_add/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/user_verify_missing/meta/main.yml
+++ b/roles/user_verify_missing/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/user_verify_present/meta/main.yml
+++ b/roles/user_verify_present/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/var_add_files/meta/main.yml
+++ b/roles/var_add_files/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/var_files_present/meta/main.yml
+++ b/roles/var_files_present/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true


### PR DESCRIPTION
There were a few instances while running atomic host tests where
where a role was not being run a second time (Ansible's default
behavior).  This commit addes meta/main.yml for each role with
allow_duplicates set to true to increase the likelihood that the
role will run when it is subsequently called.

check_mode: no is also another method and can be used if this doesn't
work.