### PR TITLE
Gather version information for common packages

### DIFF
--- a/roles/atomic_host_set_facts/meta/main.yml
+++ b/roles/atomic_host_set_facts/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_host_set_facts/tasks/main.yml
+++ b/roles/atomic_host_set_facts/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# vim: set ft=ansible:
+#
+# This role creates a dictionary named atomic_host that contains the versions
+# of common packages contained in atomic host.
+#
+- name: Get atomic version
+  command: rpm -q --queryformat '%{VERSION}' atomic
+  register: ahsf_av
+
+- name: Get docker version
+  command: rpm -q --queryformat '%{VERSION}' docker
+  register: ahsf_dv
+
+- name: Get rpm-ostree version
+  command: rpm -q --queryformat '%{VERSION}' rpm-ostree-client
+  register: ahsf_rov
+
+- name: Get skopeo version
+  command: rpm -q --queryformat '%{VERSION}' skopeo
+  register: ahsf_sv
+
+- name: Get ostree version
+  command: rpm -q --queryformat '%{VERSION}' ostree
+  register: ahsf_ov
+
+- name: Set facts for version
+  set_fact:
+    atomic_host:
+      atomic:
+        version: "{{ ahsf_av.stdout }}"
+      docker:
+        version: "{{ ahsf_dv.stdout }}"
+      rpm-ostree:
+        version: "{{ ahsf_rov.stdout }}"
+      skopeo:
+        version: "{{ ahsf_sv.stdout }}"
+      ostree:
+        version: "{{ ahsf_ov.stdout }}"


### PR DESCRIPTION
The goal of atomic host tests is to run across the latest released
and development streams of Atomic Host (Fedora, RHEL, CentOS). Some
of these streams are slower to get newer packages and causes breakage
in the test due to missing/broken functionality.  We have dealing
with these by getting the version of the package as needed and
conditionally performing actions based on the version.

This PR aims to simplify this process by centralizing the gathering
of about the atomic host in one role and making the information
available through a dictionary.  Currently, there is only version
information about common packages, but anything can be added to the
dictionary.  It is pretty much like the setup module in Ansible but
specifically for Atomic Host.