### PR TITLE
Improve error messages in roles

### DIFF
--- a/roles/atomic_host_status_verify/tasks/main.yml
+++ b/roles/atomic_host_status_verify/tasks/main.yml
@@ -19,5 +19,8 @@
 
 - name: Fail if output is not identical
   fail:
-    msg="The output of atomic host status and rpm-ostree status are not the same"
+    msg: |
+      The output of atomic host status and rpm-ostree status are not the same.
+      atomic host status: {{ ahs.stdout }}
+      rpm-ostree status: {{ ros.stdout }}
   when: ahs.stdout != ros.stdout

--- a/roles/atomic_images_list_verify/tasks/main.yml
+++ b/roles/atomic_images_list_verify/tasks/main.yml
@@ -53,7 +53,9 @@
 
 - name: Fail if values are incorrect
   fail:
-    msg: "Got {{ item.key }}:{{ ailv_match[item.key]}}.  Expected {{ item.key }}:{{ item.value }}"
+    msg: |
+      Expected: {{ item.key }}:{{ item.value }}
+      Actual: {{ item.key }}:{{ ailv_match[item.key]}}
   when: ailv_match[item.key] is undefined or
         item.value != ailv_match[item.key]
   with_dict: "{{ ailv_expected }}"

--- a/roles/atomic_pull_verify/tasks/main.yml
+++ b/roles/atomic_pull_verify/tasks/main.yml
@@ -22,5 +22,7 @@
 
 - name: Fail if busybox is not in atomic images output
   fail:
-    msg="busybox is not in atomic images output"
+    msg: |
+      Expected: busybox is not in atomic images output
+      Actual: {{ aio.stdout }}
   when: "'busybox' not in aio.stdout"

--- a/roles/atomic_run_verify/tasks/main.yml
+++ b/roles/atomic_run_verify/tasks/main.yml
@@ -9,7 +9,7 @@
 #
 - name: Fail if container is undefined
   fail:
-    msg="No container specified"
+    msg: "No container specified"
   when: container is undefined
 
 - name: atomic run {{ container }}
@@ -21,5 +21,7 @@
 
 - name: Fail if container is not running
   fail:
-    msg="Container is not Up or Created in docker ps -a output"
+    msg: |
+      Expected: Container is Up or Created in docker ps -a output
+      Actual: {{ dps.stdout }}
   when: (dps.stdout.find("Up") == -1 and dps.stdout.find("Created") == -1)

--- a/roles/atomic_scan_verify/tasks/main.yml
+++ b/roles/atomic_scan_verify/tasks/main.yml
@@ -27,7 +27,7 @@
 
 - name: Check installation of openscap
   fail:
-    msg="Atomic install was unsuccessful"
+    msg: "Atomic install was unsuccessful"
   when: "'Installation complete' not in result.stdout"
 
   # Use 'docker pull' for now; maybe switch to 'atomic pull' once all the
@@ -45,7 +45,7 @@
 
 - name: Catch atomic scan failures
   fail:
-    msg="Atomic scan failed"
+    msg: "Atomic scan failed"
   when: "'Files associated' not in atomic_output.stdout"
 
 - name: Get scanner result directory
@@ -59,5 +59,5 @@
 
 - name: Fail if result directory does not exist
   fail:
-    msg="Scanner result directory does not exist."
+    msg: "Scanner result directory does not exist."
   when: scan_dir.stat.exists == False

--- a/roles/atomic_stop_verify/tasks/main.yml
+++ b/roles/atomic_stop_verify/tasks/main.yml
@@ -11,7 +11,7 @@
 #
 - name: Fail if container is undefined
   fail:
-    msg="No container specified"
+    msg: "No container specified"
   when: container is undefined
 
 - name: atomic stop {{ container }}
@@ -23,5 +23,7 @@
 
 - name: Fail if {{ container }} status is not exited
   fail:
-    msg="Container is not Up or Created in docker ps -a output"
+    msg: |
+      Expected: Container has exited status
+      Actual: {{ dps.stdout }}
   when: dps.stdout.find("Exited") == -1

--- a/roles/atomic_system_install_verify/tasks/main.yml
+++ b/roles/atomic_system_install_verify/tasks/main.yml
@@ -15,5 +15,7 @@
 
 - name: Fail if image is not in list output
   fail:
-    msg: "{{ image }} is not in list output"
+    msg: |
+      Expected: {{ image }} is in atomic containers list output
+      Actual: {{ acl_output.stdout }}
   when: image not in acl_output.stdout

--- a/roles/docker_latest_setup/tasks/main.yml
+++ b/roles/docker_latest_setup/tasks/main.yml
@@ -35,7 +35,12 @@
 
 - name: Fail if docker version is not the same as docker-latest
   fail:
-    msg: "Docker is not docker latest"
+    msg: |
+      Docker is not docker latest
+      Expected: docker version and docker latest version to be the same
+      Result:
+        Docker Version: {{ docker_ver.stdout }}
+        Docker Latest: {{ dockerl_ver.stdout }}
   when: docker_ver.stdout != dockerl_ver.stdout
 
 

--- a/roles/docker_pull_base_image/tasks/main.yml
+++ b/roles/docker_pull_base_image/tasks/main.yml
@@ -19,5 +19,7 @@
 
 - name: Fail if base image is missing
   fail:
-    msg: "The base image named {{ g_osname }} is missing"
+    msg: |
+      The base image named {{ g_osname }} is missing
+      Actual: {{ docker_images.stdout }}
   when: g_osname not in docker_images.stdout

--- a/roles/docker_rm_httpd_container/tasks/main.yml
+++ b/roles/docker_rm_httpd_container/tasks/main.yml
@@ -17,7 +17,9 @@
 
 - name: Fail if httpd container is not present
   fail:
-    msg: "The {{ g_httpd_name }} container is not present"
+    msg: |
+      Expected: {{ g_httpd_name }} container is present in docker ps
+      Actual: {{ ps_before.stdout }}
   when: g_httpd_name not in ps_before.stdout
 
 - name: Remove the httpd container
@@ -29,5 +31,8 @@
 
 - name: Fail if httpd container is present
   fail:
-    msg: "The {{ g_httpd_name }} container is still present"
+    msg: |
+      The {{ g_httpd_name }} container is still present
+      Expected: {{ g_httpd_name }} is missing from docker ps -a
+      Actual: {{ ps_after.stdout }}
   when: g_httpd_name in ps_after.stdout

--- a/roles/docker_rmi_httpd_image/tasks/main.yml
+++ b/roles/docker_rmi_httpd_image/tasks/main.yml
@@ -17,7 +17,9 @@
 
 - name: Fail if the httpd image is not present
   fail:
-    msg: "The {{ g_httpd_name }} container is not present"
+    msg: |
+      Expected: {{ g_httpd_name }} container is in docker images
+      Actual: docker images {{ images_before.stdout }}
   when: g_httpd_name not in images_before.stdout
 
 - name: Remove the httpd container
@@ -29,5 +31,7 @@
 
 - name: Fail if the httpd image is present
   fail:
-    msg: "The {{ g_httpd_name }} image was not removed"
+    msg: |
+      Expected: {{ g_httpd_name }} is removed from docker images
+      Actual: docker images: {{ images_after.stdout }}
   when: g_httpd_name in images_after.stdout

--- a/roles/docker_run_httpd/tasks/main.yml
+++ b/roles/docker_run_httpd/tasks/main.yml
@@ -17,7 +17,9 @@
 
 - name: Fail if httpd image is missing
   fail:
-    msg: "httpd image is not present"
+    msg: |
+      Expected: {{ g_httpd_name }} in docker images output
+      Actual: {{ images.stdout }}
   when: g_httpd_name not in images.stdout
 
 - name: Run httpd container
@@ -29,7 +31,9 @@
 
 - name: Check for httpd container
   fail:
-    msg: "The {{ g_httpd_name }} container is not running"
+    msg: |
+      Expected: {{ g_httpd_name }} is running
+      Actual: {{ ps_run.stdout }}
   when: g_httpd_name not in ps_run.stdout
 
 - name: Verify port 80 is open
@@ -53,7 +57,9 @@
 
 - name: Fail if httpd container is still running
   fail:
-    msg: "The {{ g_httpd_name }} container is still running"
+    msg: |
+      Expected: {{ g_httpd_name }} is not running.
+      Actual: {{ ps_stop.stdout }}
   when: g_httpd_name in ps_stop.stdout
 
 - name: Start httpd container
@@ -65,7 +71,9 @@
 
 - name: Fail if httpd container is not running
   fail:
-    msg: "The {{ g_httpd_name }} container is not running"
+    msg: |
+      Expected: {{ g_httpd_name }} container is running
+      Actual: {{ ps_start.stdout }}
   when: g_httpd_name not in ps_start.stdout
 
 - name: Stop httpd container
@@ -77,5 +85,7 @@
 
 - name: Fail if httpd container is still running
   fail:
-    msg: "The {{ g_httpd_name }} container is still running"
+    msg: |
+      Expected: {{ g_httpd_name }} is stopped
+      Actual: {{ ps_stop.stdout }}
   when: g_httpd_name in ps_stop.stdout

--- a/roles/docker_version_check/tasks/main.yml
+++ b/roles/docker_version_check/tasks/main.yml
@@ -12,5 +12,8 @@
 
 - name: Check if minimum version is met
   fail:
-    msg: "Docker version too old: {{ actual_docker_version.stdout }} < {{ docker_version }}"
+    msg: |
+      Docker version too old.
+      Expected Version: {{ docker_version }}
+      Actual Version: {{ actual_docker_version.stdout }}
   when: actual_docker_version.stdout | version_compare(docker_version, '<')

--- a/roles/etc_verify_changes/tasks/main.yml
+++ b/roles/etc_verify_changes/tasks/main.yml
@@ -16,15 +16,24 @@
 
 - name: Fail if the file is not owned by root
   fail:
-    msg: "The epel.repo file is not owned by root"
+    msg: |
+      The epel.repo file is not owned by root
+      Expected: UID = 0
+      Actual: UID = {{ epel.stat.uid }}
   when: epel.stat.uid != 0
 
 - name: Fail if the group on the file is not root
   fail:
-    msg: "The epel.repo file does not have the right group"
+    msg: |
+      The epel.repo file does not have the right group
+      Expected: GID = 0
+      Actual: GID = {{ epel.stat.gid }}
   when: epel.stat.gid != 0
 
 - name: Fail if the permssions on the file are not correct
   fail:
-    msg: "The epel.repo file does not have the right permissions"
+    msg: |
+      The epel.repo file does not have the right permissions
+      Expected: Permissions = 0644
+      Actual: Permissions = {{ epel.stat.mode }}
   when: epel.stat.mode != "0644"

--- a/roles/ostree_admin_unlock/tasks/main.yml
+++ b/roles/ostree_admin_unlock/tasks/main.yml
@@ -11,5 +11,7 @@
 
 - name: Fail if unlocked is not set to development
   fail:
-    msg: "Unlocked is not set to development"
+    msg: |
+      Unlocked is not set to development.
+      Actual: {{ ros_booted['unlocked'] }}
   when: "'development' not in ros_booted['unlocked']"

--- a/roles/rpm_ostree_install_verify/tasks/main.yml
+++ b/roles/rpm_ostree_install_verify/tasks/main.yml
@@ -38,7 +38,9 @@
 # ros_booted is pulled from the rpm_ostree_status role above
 - name: Fail if {{ roiv_package_name }} is not in list of installed packages
   fail:
-    msg: "{{ roiv_package_name }} is not in rpm-ostree status output"
+    msg: |
+      {{ roiv_package_name }} is not in rpm-ostree status output
+      Result: {{ ros_booted['packages'] }}
   when: roiv_package_name not in ros_booted['packages'] and
         roiv_status_check
 

--- a/roles/rpm_ostree_uninstall_verify/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall_verify/tasks/main.yml
@@ -37,7 +37,9 @@
 # ros_booted is pulled from rpm_ostree_status role above
 - name: Fail if package is in rpm-ostree booted deployment
   fail:
-    msg: "{{ rouv_package_name }} is in rpm-ostree status output when it shouldn't be"
+    msg: |
+      Expected: {{ rouv_package_name }} is not booted deployment packages
+      Actual: Booted deployment packages: {{ ros_booted['packages'] }}
   when: rouv_package_name in ros_booted['packages'] and
         rouv_status_check
 

--- a/roles/rpm_signature_verify/tasks/main.yml
+++ b/roles/rpm_signature_verify/tasks/main.yml
@@ -52,11 +52,17 @@
 
     - name: Fail if GPG key is not found
       fail:
-        msg: "RPMs not signed with appropriate GPG key"
+        msg: |
+          RPMs not signed with appropriate GPG key.
+          Expected: {{ rsv_gpg_key }}
+          Result: {{ rsv_rpm_sig.stdout }}
       when: rsv_gpg_key not in rsv_rpm_sig.stdout
 
     - name: Fail if more than one GPG key found
       fail:
-        msg: "Multiple GPG keys found"
+        msg: |
+          Multiple GPG keys found!
+          Expected: {{ rsv_gpg_key }}
+          Result: {{ rsv_rpm_sig.stdout }}
       when: rsv_rpm_sig.stdout|length > 17
   when: rsv_rpm_sig_supported

--- a/roles/runc_version_check/tasks/main.yml
+++ b/roles/runc_version_check/tasks/main.yml
@@ -12,5 +12,8 @@
 
 - name: Check if minimum version is met
   fail:
-    msg: "Runc version too old: {{ actual_runc_version.stdout }} < {{ runc_version }}"
+    msg:
+      Runc version too old.
+      Expected Version: {{ runc_version }}
+      Actual Version: {{ actual_runc_version.stdout }}
   when: actual_runc_version.stdout | version_compare(runc_version, '<')

--- a/roles/semanage_fcontext_verify/tasks/main.yml
+++ b/roles/semanage_fcontext_verify/tasks/main.yml
@@ -11,5 +11,7 @@
 
 - name: Fail if the context does not match what is expected
   fail:
-    msg: "The SELinux context does not match what was expected"
+    msg: |
+      Expected: SELinux fcontext: {{ test_context }}
+      Actual: SELinux fcontext: {{ fcontext.stdout }}
   when: test_context not in fcontext.stdout

--- a/roles/tmp_check_perms/tasks/main.yml
+++ b/roles/tmp_check_perms/tasks/main.yml
@@ -11,5 +11,14 @@
 
 - name: Fail if something on /tmp is fishy
   fail:
-    msg: "Permissions or ownership on /tmp is incorrect"
+    msg: |
+      Permissions or ownership on /tmp is incorrect
+      Expected:
+        Mode: 0777
+        Group: root
+        Owner: root
+      Actual:
+        Mode: {{ s.stat.mode }}
+        Group: {{ s.stat.gr_name }}
+        Owner: {{ s.stat.pw_name }}
   when: s.stat.mode != "0777" or s.stat.gr_name != "root" or s.stat.pw_name != "root"

--- a/roles/var_files_present/tasks/main.yml
+++ b/roles/var_files_present/tasks/main.yml
@@ -27,17 +27,26 @@
 
 - name: Fail if directory not owned by root
   fail:
-    msg: "/var/{{ vfp_dirname }} is not owned by root"
+    msg: |
+      /var/{{ vfp_dirname }} is not owned by root
+      Expected:  UID = 0
+      Actual: UID = {{ var_dir.stat.uid }}
   when: var_dir.stat.uid != 0
 
 - name: Fail if the group of the owner of the directory is not root
   fail:
-    msg: "/var/{{ vfp_dirname }} does not have the right GID"
+    msg: |
+      /var/{{ vfp_dirname }} does not have the right GID
+      Expected: GID = 0
+      Actual: GID = {{ var_dir.stat.gid }}
   when: var_dir.stat.gid != 0
 
 - name: Fail if permissions are incorrect on the directory
   fail:
-    msg: "/var/{{ vfp_dirname }} does not have the correct permissions"
+    msg: |
+      /var/{{ vfp_dirname }} does not have the correct permissions
+      Expected: Mode = 0755
+      Actual: Mode = {{ var_dir.stat.mode }}
   when: var_dir.stat.mode != "0755"
 
 - name: Check for correct SELinux type
@@ -52,17 +61,26 @@
 
 - name: Fail if the owner of the file is not root
   fail:
-    msg: "The added file is not owned by root"
+    msg: |
+      The added file is not owned by root
+      Expected: UID = 0
+      Actual: UID = {{ added_file.stat.uid }}
   when: added_file.stat.uid != 0
 
 - name: Fail if the group on the file is not root
   fail:
-    msg: "The group on the added file is not root"
+    msg: |
+      The group on the added file is not root
+      Expected: UID = 0
+      Actual: UID = {{ added_file.stat.uid }}
   when: added_file.stat.uid != 0
 
 - name: Fail if the permissions are incorrect on the file
   fail:
-    msg: "The permissions on the added file are incorrect"
+    msg: |
+      The permissions on the added file are incorrect
+      Expected: Mode = 0644
+      Actual: Mode = {{ added_file.stat.mode }}
   when: added_file.stat.mode != "0644"
 
 - name: Check for correct SELinux type


### PR DESCRIPTION
Sometimes its not easy to figure out why a test failed based on
the error message.  Digging into the code to find the failure
comparison that caused the failure is required.

Lets make the error messages more detailed when comparisons are
made so triaging failures is easier.

Note: This commit is only improving the error messages in the roles.