### PR TITLE
add 'atomic_install_version_check' role

### DIFF
--- a/roles/atomic_install_version_check/meta/main.yml
+++ b/roles/atomic_install_version_check/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/atomic_install_version_check/tasks/main.yml
+++ b/roles/atomic_install_version_check/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# vim: set ft=ansible:
+#
+- name: Determine version of atomic
+  command: rpm -q --queryformat '%{VERSION}' atomic
+  register: rpmq
+
+- name: Setup atomic_version fact
+  set_fact:
+    aivc_atomic_version:  "{{ rpmq.stdout }}"
+
+# The behavior changed with this commit:
+# https://github.com/projectatomic/atomic/commit/b5f07baa6c54c2bc74079797b80a109a8d10873a
+- name: Setup atomic install command (pre v1.19.1)
+  set_fact:
+    aivc_atomic_install_cmd: "atomic install --system --system-package no "
+
+- name: Setup atomic install command (post v1.19.1)
+  set_fact:
+    aivc_atomic_install_cmd: "atomic install --system "
+  when: aivc_atomic_version | version_compare('1.19.1', '>=')
+

--- a/roles/atomic_system_install/meta/main.yml
+++ b/roles/atomic_system_install/meta/main.yml
@@ -1,2 +1,5 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: atomic_install_version_check

--- a/roles/atomic_system_install/tasks/main.yml
+++ b/roles/atomic_system_install/tasks/main.yml
@@ -9,27 +9,10 @@
     msg: "Image is undefined"
   when: image is undefined
 
-- name: Determine version of atomic
-  command: rpm -q --queryformat '%{VERSION}' atomic
-  register: rpmq
-
-- name: Setup atomic_version fact
-  set_fact:
-    atomic_version:  "{{ rpmq.stdout }}"
-
-# The behavior changed with this commit:
-# https://github.com/projectatomic/atomic/commit/b5f07baa6c54c2bc74079797b80a109a8d10873a
-- name: Setup atomic install command (pre v1.19.1)
-  set_fact:
-    atomic_install_cmd: "atomic install --system --system-package no "
-
-- name: Setup atomic install command (post v1.19.1)
-  set_fact:
-    atomic_install_cmd: "atomic install --system "
-  when: atomic_version | version_compare('1.19.1', '>=')
-
+# The `aivc_atomic_install_cmd` is set by the required role:
+# `atomic_install_version_check`
 - name: Install system container
-  command: "{{ atomic_install_cmd }} {{ image }}"
+  command: "{{ aivc_atomic_install_cmd }} {{ image }}"
   register: ais
   retries: 5
   delay: 60

--- a/roles/etcd_sys_container_install/meta/main.yml
+++ b/roles/etcd_sys_container_install/meta/main.yml
@@ -1,2 +1,5 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: atomic_install_version_check

--- a/roles/etcd_sys_container_install/tasks/main.yml
+++ b/roles/etcd_sys_container_install/tasks/main.yml
@@ -10,7 +10,6 @@
 #     verifying the set and get of the key.  This is useful since etcd
 #     keys are preserved even after uninstalling the system container
 #
-
 - name: Set facts
   set_fact:
     etcd_image: 'registry.access.redhat.com/rhel7/etcd'
@@ -23,10 +22,11 @@
     etcd_name: 'etcd'
   when: ansible_distribution != 'RedHat'
 
+# The `aivc_atomic_install_cmd` is set by the required role:
+# `atomic_install_version_check`
 - name: Install etcd
   command: >
-    atomic install
-    --system
+    {{ aivc_atomic_install_cmd }}
     --name=etcd
     {{ etcd_image }}
   register: ai_etcd

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -391,24 +391,9 @@
     - vars.yml
 
   pre_tasks:
-    - name: Determine version of atomic
-      command: rpm -q --queryformat '%{VERSION}' atomic
-      register: rpmq
-
-    - name: Setup atomic_version fact
-      set_fact:
-        atomic_version:  "{{ rpmq.stdout }}"
-
-    # The behavior changed with this commit:
-    # https://github.com/projectatomic/atomic/commit/b5f07baa6c54c2bc74079797b80a109a8d10873a
-    - name: Setup atomic install command (pre v1.19.1)
-      set_fact:
-        atomic_install_cmd: "atomic install --system --system-package no "
-
-    - name: Setup atomic install command (post v1.19.1)
-      set_fact:
-        atomic_install_cmd: "atomic install --system "
-      when: atomic_version | version_compare('1.19.1', '>=')
+    - name: Check the version of 'atomic'
+      include_role:
+        name: atomic_install_version_check
 
   tasks:
     - name: Check for etcd rpm
@@ -435,9 +420,11 @@
         enabled: no
       when: rpm_etcd.rc == 0
 
+    # The `aivc_atomic_install_cmd` is set by the required role:
+    # `atomic_install_version_check`
     - name: Install etcd
       command: >
-        {{ atomic_install_cmd }}
+        {{ aivc_atomic_install_cmd }}
         --name=etcd
         {{ etcd_image }}
       register: ai_etcd
@@ -465,7 +452,7 @@
 
     - name: Install flannel
       command: >
-        {{ atomic_install_cmd }}
+        {{ aivc_atomic_install_cmd }}
         --name=flannel
         {{ flannel_image }}
       register: ai_flannel

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -450,6 +450,8 @@
         runc exec etcd etcdctl
         set /atomic.io/network/config '{"Network":"172.17.0.0/16"}'
 
+    # The `aivc_atomic_install_cmd` is set by the required role:
+    # `atomic_install_version_check`
     - name: Install flannel
       command: >
         {{ aivc_atomic_install_cmd }}


### PR DESCRIPTION
I was about to add a 3rd copy of the same code to detect which version
of `atomic` we are using when we run the tests.  But I came to my
senses and added a new role that handles all that.

The `atomic_install_version_check` role does a version check and sets
up a variable to use `atomic install`.  This is a follow-on (and
improvement, IMO) to #284.