### PR TITLE
docker-build-httpd:  set MTU equal to default interface

### DIFF
--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -39,6 +39,17 @@
       when: (rhel_base_images is undefined or rhel_image_names is undefined) and
             ansible_distribution == "RedHat"
 
+    - name: Set MTU on docker daemon
+      lineinfile:
+        path: /etc/sysconfig/docker-network
+        regexp: "^DOCKER_NETWORK_OPTIONS"
+        line: "DOCKER_NETWORK_OPTIONS='--mtu={{ ansible_default_ipv4['mtu'] }}'"
+
+    - name: Restart docker daemon
+      service:
+        name: docker
+        state: restarted
+
   roles:
     # This playbook requires Ansible 2.2 and an Atomic Host
     - role: ansible_version_check
@@ -138,6 +149,18 @@
 
   tags:
     - docker_build_cleanup
+
+  pre_tasks:
+    - name: Set MTU on docker daemon
+      lineinfile:
+        path: /etc/sysconfig/docker-network
+        regexp: "^DOCKER_NETWORK_OPTIONS"
+        line: "DOCKER_NETWORK_OPTIONS="
+
+    - name: Restart docker daemon
+      service:
+        name: docker
+        state: restarted
 
   roles:
     - role: docker_remove_all

--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -39,6 +39,10 @@
       when: (rhel_base_images is undefined or rhel_image_names is undefined) and
             ansible_distribution == "RedHat"
 
+    # Determining the right MTU for Docker interfaces running on OpenStack
+    # can be tricky:
+    #  - https://bugzilla.redhat.com/show_bug.cgi?id=1475460
+    #  - https://bugzilla.redhat.com/show_bug.cgi?id=1357116
     - name: Set MTU on docker daemon
       lineinfile:
         dest: /etc/sysconfig/docker-network

--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -41,7 +41,7 @@
 
     - name: Set MTU on docker daemon
       lineinfile:
-        path: /etc/sysconfig/docker-network
+        dest: /etc/sysconfig/docker-network
         regexp: "^DOCKER_NETWORK_OPTIONS"
         line: "DOCKER_NETWORK_OPTIONS='--mtu={{ ansible_default_ipv4['mtu'] }}'"
 
@@ -153,7 +153,7 @@
   pre_tasks:
     - name: Set MTU on docker daemon
       lineinfile:
-        path: /etc/sysconfig/docker-network
+        dest: /etc/sysconfig/docker-network
         regexp: "^DOCKER_NETWORK_OPTIONS"
         line: "DOCKER_NETWORK_OPTIONS="
 


### PR DESCRIPTION
When running an OpenStack environment, the host under test might end
up with an MTU that doesn't jive with the Docker daemon (usually when
the MTU is lower than 1500).  This can lead to network issues when
doing `docker build`.  So we'll just set the MTU for the Docker
daemon to the same.