### PR TITLE
papr: install rsync

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -14,6 +14,7 @@ packages:
   - gcc
   - redhat-rpm-config
   - libselinux-python
+  - rsync
 
 tests:
   - ./.test_director


### PR DESCRIPTION
We need `rsync` to be present on the host/container running the
Ansible tests.