### PR TITLE
WIP:  use 'jq' to filter out noisy keys from JSON output

### DIFF
--- a/roles/install_jq/defaults/main.yml
+++ b/roles/install_jq/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+jq_path: /usr/local/bin/jq
+jq_url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64

--- a/roles/install_jq/meta/main.yml
+++ b/roles/install_jq/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/install_jq/tasks/main.yml
+++ b/roles/install_jq/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# vim: set ft=ansible:
+#
+- name: Test if 'jq' is installed
+  command: command -v jq
+  register: jq_installed
+  ignore_errors: true
+  become: false
+
+- when: jq_installed.rc == 1
+  block:
+    - name: Install 'jq' if it is not installed
+      command: "curl -L -o {{ jq_path }} {{ jq_url }}"
+
+    - name: Set executable bit
+      command: "chmod +x {{ jq_path }}"

--- a/roles/rpm_ostree_status/meta/main.yml
+++ b/roles/rpm_ostree_status/meta/main.yml
@@ -1,2 +1,5 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: install_jq

--- a/roles/rpm_ostree_status/tasks/main.yml
+++ b/roles/rpm_ostree_status/tasks/main.yml
@@ -5,8 +5,12 @@
 #  rpm-ostree status --json output.  If no second deployment exists,
 #  ros_not_booted will be set to false
 #
+# Newer versions of 'rpm-ostree' include the RPM DB pacakge list in the
+# commit metadata.  This causes hundreds of pkg entries to be included
+# in the JSON output.  We can exclude this from the output by piping to
+# 'jq' and removing the noisy keys.
 - name: Get rpm-ostree status output
-  command: rpm-ostree status --json
+  shell: rpm-ostree status --json | {{ jq_path }} 'del(.deployments[]["layered-commit-meta"]["rpmostree.rpmdb.pkglist"], .deployments[]["base-commit-meta"]["rpmostree.rpmdb.pkglist"])'
   register: ros
 
 - name: Convert to JSON
@@ -26,4 +30,3 @@
   set_fact:
     ros_not_booted: "{{ item | default(false) }}"
   with_items: "{{ ros_json | json_query('deployments[?!booted]') }}"
-


### PR DESCRIPTION
In the newer versions of `rpm-ostree`, the RPM DB package list is
included in the commit metadata.  This causes the output of
`rpm-ostree status --json` to be very noisy when run via Ansible (i.e.
100s of package key/values are now in the output).

This attempts to work around the noise by running the output through
`jq` and deleting the offending keys.

Part of this included creating a new role to land `jq` on the host, if it was not already there.