### PR TITLE
Comply to YAML spec where possible

### DIFF
--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -45,7 +45,7 @@
 
 - name: Ostree Admin Unlock - Setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - setup
@@ -78,7 +78,7 @@
 
 - name: Ostree Admin Unlock - Add/Remove Package - Non-persistence
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - unlock_add_remove_package_non_persistence
@@ -126,7 +126,7 @@
 
 - name: Ostree Admin Unlock - Hotfix - Add/Remove Package Persistence
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - hotfix_add_remove_package_persistence
@@ -188,7 +188,7 @@
 
 - name: Ostree Admin Unlock - Hotfix - Rollback
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - hotfix_rollback
@@ -213,7 +213,7 @@
 
 - name: Ostree Admin Unlock - No Install Without Unlock
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cannot_install_without_unlock
@@ -235,14 +235,15 @@
 
     - name: Fail if current deployment has unlocked not set to none
       fail:
-       msg: |
-         Expected: booted deployment has unlocked set to none
-         Actual: booted deployment unlocked is set to {{ ros_booted['unlocked'] }}
+        msg: |
+          Expected: booted deployment has unlocked set to none
+          Actual: booted deployment unlocked is set to
+                  {{ ros_booted['unlocked'] }}
       when: "'none' not in ros_booted['unlocked']"
 
 - name: Ostree Admin Unlock - Unlock Twice - Error Message
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - unlock_twice_error_message
@@ -261,7 +262,8 @@
       fail:
         msg: |
           Expected: booted deployment has unlocked set to hotfix
-          Actual: booted deployment unlocked is set to {{ ros_booted['unlocked'] }}
+          Actual: booted deployment unlocked is set to
+                  {{ ros_booted['unlocked'] }}
       when: "'development' not in ros_booted['unlocked']"
 
     - name: Run unlock twice (system is already unlocked)
@@ -275,7 +277,8 @@
           Expected: Error message should indicated the deployment is already in
                     the unlocked state: development
           Actual: {{ double_unlock.stderr }}
-      when: "'Deployment is already in unlocked state: development' not in double_unlock.stderr"
+      when:
+        - "'Deployment is already in unlocked state: development' not in double_unlock.stderr"
 
     - name: Run unlock hotfix (system is already locked)
       command: ostree admin unlock --hotfix
@@ -288,14 +291,15 @@
           Expected: Error message should indicate the deployment is already in
                     the unlocked state: development
           Actual: {{ double_unlock.stderr }}
-      when: "'Deployment is already in unlocked state: development' not in double_unlock.stderr"
+      when:
+        - "'Deployment is already in unlocked state: development' not in double_unlock.stderr"
 
     - include_role:
         name: reboot
 
 - name: Ostree Admin Unlock - Hotfix Unlock Twice - Error Message
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - hotfix_unlock_twice_error_message
@@ -337,7 +341,8 @@
           Expected: Error message should indicated deployment is already in
                     unlocked state: hotfix
           Actual: {{ double_unlock.stderr }}
-      when: "'Deployment is already in unlocked state: hotfix' not in double_unlock.stderr"
+      when:
+        - "'Deployment is already in unlocked state: hotfix' not in double_unlock.stderr"
 
     - name: Run unlock hotfix (system is already locked)
       command: ostree admin unlock --hotfix
@@ -350,12 +355,13 @@
           Expected: Error message should indicated deployment is already in
                     unlocked state: hotfix
           Actual: {{ double_unlock.stderr }}
-      when: "'Deployment is already in unlocked state: hotfix' not in double_unlock.stderr"
+      when:
+        - "'Deployment is already in unlocked state: hotfix' not in double_unlock.stderr"
 
 
 - name: Ostree Admin Unlock - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -45,7 +45,7 @@
 
 - name: Ostree Admin Unlock - Setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - setup
@@ -78,7 +78,7 @@
 
 - name: Ostree Admin Unlock - Add/Remove Package - Non-persistence
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - unlock_add_remove_package_non_persistence
@@ -126,7 +126,7 @@
 
 - name: Ostree Admin Unlock - Hotfix - Add/Remove Package Persistence
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - hotfix_add_remove_package_persistence
@@ -188,7 +188,7 @@
 
 - name: Ostree Admin Unlock - Hotfix - Rollback
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - hotfix_rollback
@@ -213,7 +213,7 @@
 
 - name: Ostree Admin Unlock - No Install Without Unlock
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cannot_install_without_unlock
@@ -243,7 +243,7 @@
 
 - name: Ostree Admin Unlock - Unlock Twice - Error Message
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - unlock_twice_error_message
@@ -299,7 +299,7 @@
 
 - name: Ostree Admin Unlock - Hotfix Unlock Twice - Error Message
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - hotfix_unlock_twice_error_message
@@ -361,7 +361,7 @@
 
 - name: Ostree Admin Unlock - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -287,8 +287,8 @@
     - name: Set image name
       set_fact:
         fq_name: "docker.io/busybox"
-        digest: >
-          "sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912"
+        digest:
+          sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912
 
   roles:
     - name: atomic_pull

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -3,7 +3,7 @@
 #
 - name: Atomic - Setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - setup
@@ -24,7 +24,7 @@
 
 - name: Atomic Fully Qualified Name
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - fq_name
@@ -89,7 +89,7 @@
 
 - name: Atomic Short Name
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - shortname
@@ -161,7 +161,7 @@
 
 - name: Atomic fully qualified container name
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - fq_name_name
@@ -231,7 +231,7 @@
 
 - name: Atomic Pull With Tags
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - pull_tags
@@ -278,7 +278,7 @@
 
 - name: Atomic Pull By Digest
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - pull_digest_simple
@@ -287,7 +287,8 @@
     - name: Set image name
       set_fact:
         fq_name: "docker.io/busybox"
-        digest: "sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912"
+        digest: >
+          "sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912"
 
   roles:
     - name: atomic_pull
@@ -309,7 +310,7 @@
 
 - name: Atomic Pull Storage
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - pull_storage
@@ -362,7 +363,7 @@
 
 - name: Atomic Images Update
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - images_update
@@ -421,7 +422,7 @@
       expected_values:
         repo: "{{ local_name }}"
         tag: "latest"
-      expect_missing: True
+      expect_missing: true
 
     # Pull the image from the private registry
     - role: atomic_pull

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -3,7 +3,7 @@
 #
 - name: Atomic - Setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - setup
@@ -24,7 +24,7 @@
 
 - name: Atomic Fully Qualified Name
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - fq_name
@@ -89,7 +89,7 @@
 
 - name: Atomic Short Name
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - shortname
@@ -161,7 +161,7 @@
 
 - name: Atomic fully qualified container name
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - fq_name_name
@@ -231,7 +231,7 @@
 
 - name: Atomic Pull With Tags
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - pull_tags
@@ -278,7 +278,7 @@
 
 - name: Atomic Pull By Digest
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - pull_digest_simple
@@ -310,7 +310,7 @@
 
 - name: Atomic Pull Storage
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - pull_storage
@@ -363,7 +363,7 @@
 
 - name: Atomic Images Update
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - images_update

--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -19,7 +19,7 @@
 #
 - name: Docker build httpd - setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - docker_build_setup
@@ -84,7 +84,7 @@
       synchronize:
         src: files/
         dest: "{{ working_dir }}/"
-        recursive: "yes"
+        recursive: true
 
     - name: Pull all the upstream base images
       command: "docker pull {{ item }}"
@@ -106,7 +106,7 @@
 
 - name: Docker build httpd - test
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - docker_build_test
@@ -158,7 +158,7 @@
 
 - name: Docker build httpd - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - docker_build_cleanup

--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -19,7 +19,7 @@
 #
 - name: Docker build httpd - setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - docker_build_setup
@@ -30,12 +30,16 @@
   pre_tasks:
     - name: Fail if variables are not defined
       fail:
-        msg: "Required variables are not defined.  Please check tests/docker-build-httpd/vars.yml."
+        msg: |
+          Required variables are not defined.
+          Please check tests/docker-build-httpd/vars.yml.
       when: base_images is undefined or image_names is undefined
 
     - name: Fail if RHEL variables are not defined
       fail:
-        msg: "Required RHEL variables are not defined.  Please check tests/docker-build-httpd/vars.yml"
+        msg: |
+          Required RHEL variables are not defined.
+          Please check tests/docker-build-httpd/vars.yml
       when: (rhel_base_images is undefined or rhel_image_names is undefined) and
             ansible_distribution == "RedHat"
 
@@ -80,7 +84,7 @@
       synchronize:
         src: files/
         dest: "{{ working_dir }}/"
-        recursive: yes
+        recursive: "yes"
 
     - name: Pull all the upstream base images
       command: "docker pull {{ item }}"
@@ -102,7 +106,7 @@
 
 - name: Docker build httpd - test
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - docker_build_test
@@ -113,24 +117,29 @@
   pre_tasks:
     - name: Fail if variables are not defined
       fail:
-        msg: "Required variables are not defined.  Please check tests/docker-build-httpd/vars.yml."
+        msg: |
+          Required variables are not defined.
+          Please check tests/docker-build-httpd/vars.yml.
       when: base_images is undefined or image_names is undefined
 
     - name: Fail if RHEL variables are not defined
       fail:
-        msg: "Required RHEL variables are not defined.  Please check tests/docker-build-httpd/vars.yml"
-      when: (rhel_base_images is undefined or rhel_image_names is undefined) and
-            ansible_distribution == "RedHat"
+        msg: |
+          Required RHEL variables are not defined.
+          Please check tests/docker-build-httpd/vars.yml
+      when:
+        - (rhel_base_images is undefined or rhel_image_names is undefined)
+        - ansible_distribution == "RedHat"
   tasks:
-      # I would have used a 'block' of 'roles' here, but that is not
-      # compatible with the 'with_items' loop control, so I stuck all
-      # the tasks into a single role file and used an 'include:'
-      # statement on that file.
-      #
-      # Added the ability to skip broken images with the 'cli_skipped_images'
-      # variable.  This can be set via the CLI like so:
-      # ansible-playbook -e "cli_skipped_images=busybox_httpd,debian_httpd"
-      #
+    # I would have used a 'block' of 'roles' here, but that is not
+    # compatible with the 'with_items' loop control, so I stuck all
+    # the tasks into a single role file and used an 'include:'
+    # statement on that file.
+    #
+    # Added the ability to skip broken images with the 'cli_skipped_images'
+    # variable.  This can be set via the CLI like so:
+    # ansible-playbook -e "cli_skipped_images=busybox_httpd,debian_httpd"
+    #
     - include: tasks/build_run_remove.yml
       vars:
         base_dir: "{{ working_dir }}"
@@ -149,7 +158,7 @@
 
 - name: Docker build httpd - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - docker_build_cleanup

--- a/tests/docker-swarm/main.yml
+++ b/tests/docker-swarm/main.yml
@@ -14,7 +14,7 @@
 
 - name: Docker Swarm - Setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - setup
@@ -64,7 +64,7 @@
 
 - name: Docker Swarm - Basic Functional Test
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - basic
@@ -82,7 +82,7 @@
         msg: |
           Expected: Swarm is not set to active
           Actual: {{ di.stdout }}
-      when:  "'Swarm: active' in di.stdout"
+      when: "'Swarm: active' in di.stdout"
 
     - name: Initialize docker swarm
       command: docker swarm init --advertise-addr 127.0.0.1
@@ -182,7 +182,8 @@
     - name: Fail if {{ g_service_name }} is still in docker service ls output
       fail:
         msg: |
-          Expected: {{ g_service_name }} should not be in docker service ls output
+          Expected: {{ g_service_name }} should not be in docker service ls
+                    output
           Actual: {{ dsls.stdout }}
       when: g_service_name in dsls.stdout
 
@@ -202,7 +203,7 @@
 
 - name: Docker Swarm - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup

--- a/tests/docker-swarm/main.yml
+++ b/tests/docker-swarm/main.yml
@@ -14,7 +14,7 @@
 
 - name: Docker Swarm - Setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - setup
@@ -64,7 +64,7 @@
 
 - name: Docker Swarm - Basic Functional Test
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - basic
@@ -203,7 +203,7 @@
 
 - name: Docker Swarm - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup

--- a/tests/docker/main.yml
+++ b/tests/docker/main.yml
@@ -22,7 +22,7 @@
 
 - name: Docker - Setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - setup
@@ -60,7 +60,7 @@
 
 - name: Docker - Functional Tests
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - functional
@@ -104,7 +104,7 @@
 
 - name: Docker - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup
@@ -132,7 +132,7 @@
         - name: Re-enable docker
           service:
             name: docker
-            enabled: "yes"
+            enabled: true
             state: started
       when: g_docker_latest
 

--- a/tests/docker/main.yml
+++ b/tests/docker/main.yml
@@ -22,7 +22,7 @@
 
 - name: Docker - Setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - setup
@@ -60,7 +60,7 @@
 
 - name: Docker - Functional Tests
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - functional
@@ -104,7 +104,7 @@
 
 - name: Docker - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup
@@ -114,26 +114,26 @@
 
   pre_tasks:
     - block:
-      - name: Stop and disable docker-latest
-        service:
-          name: docker-latest
-          enabled: no
-          state: stopped
+        - name: Stop and disable docker-latest
+          service:
+            name: docker-latest
+            enabled: "no"
+            state: stopped
 
-      - name: Revert docker-latest binary
-        blockinfile:
-          dest: /etc/sysconfig/docker
-          block: |
-            #DOCKERBINARY=/usr/bin/docker-latest
-            #DOCKERDBINARY=/usr/bin/dockerd-latest
-            #DOCKER_CONTAINERD_BINARY=/usr/bin/docker-containerd-latest
-            #DOCKER_CONTAINERD_SHIM_BINARY=/usr/bin/docker-containerd-shim-latest
+        - name: Revert docker-latest binary
+          blockinfile:
+            dest: /etc/sysconfig/docker
+            block: |
+              #DOCKERBINARY=/usr/bin/docker-latest
+              #DOCKERDBINARY=/usr/bin/dockerd-latest
+              #DOCKER_CONTAINERD_BINARY=/usr/bin/docker-containerd-latest
+              #DOCKER_CONTAINERD_SHIM_BINARY=/usr/bin/docker-containerd-shim-latest
 
-      - name: Re-enable docker
-        service:
-          name: docker
-          enabled: yes
-          state: started
+        - name: Re-enable docker
+          service:
+            name: docker
+            enabled: "yes"
+            state: started
       when: g_docker_latest
 
   roles:

--- a/tests/images_cve_scanner/main.yml
+++ b/tests/images_cve_scanner/main.yml
@@ -16,7 +16,7 @@
 #
 - name: Prepare container images for scanning
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - images_cve_scanner
@@ -44,7 +44,7 @@
         result_list: []
 
     - include_role:
-        allow_duplicates: "yes"
+        allow_duplicates: true
         vars:
           image: "{{ item }}'"
         name: container_image_scanner
@@ -63,7 +63,7 @@
 
 - name: Image scanning - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup

--- a/tests/images_cve_scanner/main.yml
+++ b/tests/images_cve_scanner/main.yml
@@ -16,7 +16,7 @@
 #
 - name: Prepare container images for scanning
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - images_cve_scanner
@@ -44,13 +44,13 @@
         result_list: []
 
     - include_role:
-        allow_duplicates: yes
+        allow_duplicates: "yes"
         vars:
           image: "{{ item }}'"
         name: container_image_scanner
       with_items: "{{ image_name_list }}"
       register: sot
-      ignore_errors: True
+      ignore_errors: true
       loop_control:
         loop_var: image
 
@@ -63,7 +63,7 @@
 
 - name: Image scanning - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -28,7 +28,7 @@
 #
 - name: Improved Sanity Test - Pre-Upgrade
   hosts: all
-  become: "yes"
+  become: true
   force_handlers: true
 
   tags:
@@ -77,7 +77,7 @@
     # The 'archive' option will drop a YAML file into the playbook directory
     # with the value of the original checksum, refspec, and remote
     - role: booted_deployment_set_fact
-      archive: "yes"
+      archive: true
       tags:
         - booted_deployment_set_fact
 
@@ -359,7 +359,7 @@
       version: test2
       tags:
         - local_branch_commit
-      check_mode: "no"
+      check_mode: false
 
     # TEST
     # Verify installation of etcd system container works
@@ -371,7 +371,7 @@
     - role: rpm_ostree_upgrade
       tags:
         - rpm_ostree_upgrade
-      check_mode: "no"
+      check_mode: false
 
     # Before we reboot, check the journal for anything that blew up
     - role: journal_fatal_msgs
@@ -389,7 +389,7 @@
 
 - name: Improved Sanity Test - Post-Upgrade
   hosts: all
-  become: "yes"
+  become: true
   force_handlers: true
 
   tags:
@@ -411,18 +411,18 @@
       handler_name: h_get_journal
       tags:
         - handler_notify_on_failure
-      check_mode: "no"
+      check_mode: false
 
     - role: atomic_host_check
       tags:
         - atomic_host_check
 
-    # Setup facts again. (Need to use the 'check_mode: no' option to ensure the
+    # Setup facts again. (Need to use the 'check_mode: false' option to ensure the
     # role runs again)
     - role: osname_set_fact
       tags:
         - osname_set_fact
-      check_mode: "no"
+      check_mode: false
 
     # Before we do any additional actions, let's check the journal to see if
     # anything blew up after reboot
@@ -518,7 +518,7 @@
       tags:
         - etcd_sys_container_install
         - cloud_image
-      check_mode: "no"
+      check_mode: false
 
     # Uninstall etcd system container
     - role: atomic_system_uninstall
@@ -526,7 +526,7 @@
       tags:
         - atomic_system_uninstall
         - cloud_image
-      check_mode: "no"
+      check_mode: false
 
     # Verify etcd system container uninstall
     - role: atomic_system_uninstall_verify
@@ -724,7 +724,7 @@
 
 - name: Improved Sanity Test - Post-Rollback
   hosts: all
-  become: "yes"
+  become: true
   force_handlers: true
 
   tags:
@@ -747,7 +747,7 @@
       handler_name: h_get_journal
       tags:
         - handler_notify_on_failure
-      check_mode: "no"
+      check_mode: false
 
     # Ensure the host(s) are indeed Atomic Host(s)
     - role: atomic_host_check

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -18,7 +18,7 @@
 #
 - name: k8-cluster
   hosts: all
-  become: "yes"
+  become: true
 
   roles:
     # This playbook requires Ansible 2.2 and an Atomic Host
@@ -60,7 +60,7 @@
 
 - name: Kubernetes Cluster - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -18,7 +18,7 @@
 #
 - name: k8-cluster
   hosts: all
-  become: yes
+  become: "yes"
 
   roles:
     # This playbook requires Ansible 2.2 and an Atomic Host
@@ -60,7 +60,7 @@
 
 - name: Kubernetes Cluster - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup

--- a/tests/openshift-ansible-test/main.yml
+++ b/tests/openshift-ansible-test/main.yml
@@ -16,12 +16,17 @@
         # instance.  This can be done via the inventory file or on the command
         # line, like so:
         #
-        # $ ansible-playbook -i inventory -e cli_oo_host=10.0.36.120 tests/openshift-ansible-testing/main.yml
+        # $ ansible-playbook -i inventory -e cli_oo_host=10.0.36.120 \
+        #   tests/openshift-ansible-testing/main.yml
         #
         oo_host: "{{ cli_oo_host | default(ansible_default_ipv4.address) }}"
         oo_release: "{{ cli_oo_release | default('1.5.1') }}"
-        oo_py_interpreter: "{{ '-e ansible_python_interpreter=/usr/bin/python3' if ansible_distribution == 'Fedora' else '' }}"
-        oo_skip_memory_check: "{{ '-e openshift_disable_check=memory_availability' if ansible_memtotal_mb|int < 8192 else '' }}"
+        oo_py_interpreter: >
+          "{{ '-e ansible_python_interpreter=/usr/bin/python3'
+          if ansible_distribution == 'Fedora' else '' }}"
+        oo_skip_memory_check: >
+          "{{ '-e openshift_disable_check=memory_availability'
+          if ansible_memtotal_mb|int < 8192 else '' }}"
 
     - name: Make temp directory of holding
       command: mktemp -d
@@ -42,7 +47,9 @@
       delegate_to: localhost
 
     - name: Run the openshift-ansible playbook
-      command: "ansible-playbook -i cluster-inventory playbooks/byo/config.yml {{ oo_py_interpreter }} {{ oo_skip_memory_check }}"
+      command: >
+        ansible-playbook -i cluster-inventory playbooks/byo/config.yml
+        {{ oo_py_interpreter }} {{ oo_skip_memory_check }}"
       args:
         chdir: "{{ mktemp.stdout }}"
       delegate_to: localhost
@@ -52,12 +59,15 @@
         port: 8443
         delay: 60
 
-      # this may not be required
+    # this may not be required
     - name: Add admin user to cluster-admin role
-      command: /usr/local/bin/oadm policy add-cluster-role-to-user cluster-admin admin
+      command: >
+        /usr/local/bin/oadm policy add-cluster-role-to-user cluster-admin admin
 
     - name: Login to the cluster
-      command: "/usr/local/bin/oc login -u admin -p OriginAdmin https://{{ oo_public_host }}:8443"
+      command: >
+        /usr/local/bin/oc login -u admin -p OriginAdmin
+        https://{{ oo_public_host }}:8443
 
       # this is kind of a hack; sometimes need to wait (5m) for the pods
     - name: Verify pods are running

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -244,18 +244,18 @@
     - name: Set packages when deployment 0 is not booted
       set_fact:
         pending_pkgs: "{{ pending_json['deployments'][0]['packages'] }}"
-      when: >
-        pending_json['deployments'][0] is defined
-        and not pending_json['deployments'][0]['booted']
+      when:
+        - pending_json['deployments'][0] is defined
+        - not pending_json['deployments'][0]['booted']
 
     - name: Set packages when deployment 1 is not booted
       set_fact:
         pending_pkgs: "{{ pending_json['deployments'][1]['packages'] }}"
-      when: >
-        pending_json['deployments'][1] is defined
-        and not pending_json['deployments'][1]['booted']
+      when:
+        - pending_json['deployments'][1] is defined
+        - not pending_json['deployments'][1]['booted']
 
-    - name: Fail if {{ g_pkg2 }} is in  pending packages
+    - name: Fail if {{ g_pkg2 }} is in pending packages
       fail:
         msg: |
           Expected: "{{ g_pkg2 }} should not be in rpm-ostree status output

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -43,7 +43,7 @@
 
 - name: Package Layering Tests - Setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - setup
@@ -79,7 +79,7 @@
 
 - name: Package Layering - Single package install and uninstall test
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - single_pkg_install_uninstall
@@ -112,7 +112,7 @@
 
 - name: Package Layering - Multiple package install and uninstall test
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - multi_pkg_install_uninstall
@@ -153,7 +153,7 @@
 
 - name: Package Layering - Reboot flag test
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - reboot_flag
@@ -180,7 +180,7 @@
 
 - name: Package Layering - Dry run tests
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - dry_run
@@ -206,7 +206,7 @@
 
 - name: Package Layering - Dry run does not affect installed packages tests
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - dry_run_interaction
@@ -276,7 +276,7 @@
 
 - name: Package Layering - install package from EPEL repo test
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - alternate_repo_install
@@ -297,8 +297,8 @@
         mirrorlist: >
           https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
         failovermethod: priority
-        gpgcheck: "yes"
-        enabled: "yes"
+        gpgcheck: true
+        enabled: true
         gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 
     - name: Install {{ g_epel_pkg }} from EPEL
@@ -316,7 +316,7 @@
 
 - name: Package Layering - Negative test - Uninstalling non-existent package
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - uninstall_invalid_pkg
@@ -341,7 +341,7 @@
 
 - name: Package Layering - Negative Test - Installing non-existent package
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - install_invalid_pkg
@@ -366,7 +366,7 @@
 
 - name: Package Layering - Installing existing package
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - install_existing_pkg
@@ -417,7 +417,7 @@
 
 - name: Package Layering - Installing non-root ownership package
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - install_nonroot_pkg
@@ -452,7 +452,7 @@
 
 - name: Package Layering - Negative - Install already layered package
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - install_previously_layered
@@ -468,7 +468,7 @@
 
 - name: Package Layering - Negative Test - Installing insufficient privileges
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - install_unprivileged
@@ -486,7 +486,7 @@
 
 - name: Package Layering - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -18,23 +18,32 @@
 #   - Verify multiple rpm packages can be layered through rpm-ostree install
 #   - Verify rpm packages can be removed through rpm-ostree uninstall
 #   - Verify multiple rpm packages can be removed through rpm-ostree uninstall
-#   - Verify rpm-ostree status output displays "Package: <pkg1> <pkg2>.." when packages are layered
-#   - Verify the -r / --reboot flag reboots the host after rpm-ostree install or rpm-ostree uninstall
-#   - Verify the -n / --dry-run flag does not perform the package add/remove function and displays a summary of packages to be installed
-#   - Verify a dry-run of rpm-ostree install|uninstall does not affect an existing package that has been layered, but not rebooted.
-#   - Verify that after additional repos are enabled (i.e. EPEL), rpm-ostree install|uninstall can be successfully used for packages in those repos.
+#   - Verify rpm-ostree status output displays "Package: <pkg1> <pkg2>.." when
+#     packages are layered
+#   - Verify the -r / --reboot flag reboots the host after rpm-ostree install
+#     or rpm-ostree uninstall
+#   - Verify the -n / --dry-run flag does not perform the package add/remove
+#     function and displays a summary of packages to be installed
+#   - Verify a dry-run of rpm-ostree install|uninstall does not affect an
+#     existing package that has been layered, but not rebooted.
+#   - Verify that after additional repos are enabled (i.e. EPEL), rpm-ostree
+#     install|uninstall can be successfully used for packages in those repos.
 #
 # Negative Testing
 #   - Verify correct error is displayed removing a package that does not exist
-#   - Verify correct error is displayed when adding a package that does not exists in the repo
-#   - Verify correct error message is displayed when adding a package that is already in the deployment
-#   - Verify packages which have files with non-root ownership cannot be installed
-#   - Verify that install/uninstall operations cannot be performed by unprivileged users
+#   - Verify correct error is displayed when adding a package that does not
+#     exists in the repo
+#   - Verify correct error message is displayed when adding a package that is
+#     already in the deployment
+#   - Verify packages which have files with non-root ownership cannot be
+#     installed
+#   - Verify that install/uninstall operations cannot be performed by
+#     unprivileged users
 #
 
 - name: Package Layering Tests - Setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - setup
@@ -70,7 +79,7 @@
 
 - name: Package Layering - Single package install and uninstall test
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - single_pkg_install_uninstall
@@ -103,7 +112,7 @@
 
 - name: Package Layering - Multiple package install and uninstall test
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - multi_pkg_install_uninstall
@@ -144,7 +153,7 @@
 
 - name: Package Layering - Reboot flag test
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - reboot_flag
@@ -171,7 +180,7 @@
 
 - name: Package Layering - Dry run tests
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - dry_run
@@ -197,7 +206,7 @@
 
 - name: Package Layering - Dry run does not affect installed packages tests
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - dry_run_interaction
@@ -235,21 +244,25 @@
     - name: Set packages when deployment 0 is not booted
       set_fact:
         pending_pkgs: "{{ pending_json['deployments'][0]['packages'] }}"
-      when: pending_json['deployments'][0] is defined and not pending_json['deployments'][0]['booted']
+      when: >
+        pending_json['deployments'][0] is defined
+        and not pending_json['deployments'][0]['booted']
 
     - name: Set packages when deployment 1 is not booted
       set_fact:
         pending_pkgs: "{{ pending_json['deployments'][1]['packages'] }}"
-      when: pending_json['deployments'][1] is defined and not pending_json['deployments'][1]['booted']
+      when: >
+        pending_json['deployments'][1] is defined
+        and not pending_json['deployments'][1]['booted']
 
-    - name: Fail if {{ g_pkg2 }} is in rpm-ostree status output for pending packages
+    - name: Fail if {{ g_pkg2 }} is in  pending packages
       fail:
         msg: |
           Expected: "{{ g_pkg2 }} should not be in rpm-ostree status output
           Actual: {{ pending_pkgs }}
       when: g_pkg2 in pending_pkgs
 
-    - name: Fail if {{ g_pkg1 }} is not in rpm-ostree status output for pending packages
+    - name: Fail if {{ g_pkg1 }} is not in pending packages
       fail:
         msg: |
           Expected: {{ g_pkg1 }}  in rpm-ostree status output
@@ -263,7 +276,7 @@
 
 - name: Package Layering - install package from EPEL repo test
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - alternate_repo_install
@@ -281,10 +294,11 @@
       yum_repository:
         name: epel
         description: Extra Packages for Enterprise Linux 7 - $basearch
-        mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+        mirrorlist: >
+          https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
         failovermethod: priority
-        gpgcheck: yes
-        enabled: yes
+        gpgcheck: "yes"
+        enabled: "yes"
         gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 
     - name: Install {{ g_epel_pkg }} from EPEL
@@ -302,7 +316,7 @@
 
 - name: Package Layering - Negative test - Uninstalling non-existent package
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - uninstall_invalid_pkg
@@ -327,7 +341,7 @@
 
 - name: Package Layering - Negative Test - Installing non-existent package
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - install_invalid_pkg
@@ -344,15 +358,15 @@
     - name: Fail if error not expected
       fail:
         msg: |
-          Expected: No package is contained in the rpm-ostree install output when
-                    attempting to install an invalid package
+          Expected: No package is contained in the rpm-ostree install output
+                    when attempting to install an invalid package
           Actual: {{ nonexist.stderr }}
       when: "'No package' not in nonexist.stderr"
 
 
 - name: Package Layering - Installing existing package
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - install_existing_pkg
@@ -374,18 +388,25 @@
       set_fact:
         req_json: "{{ req.stdout | from_json }}"
 
-    # This is a hack for requested-packages being displayed in rpm-ostree v2017.3 that should
-    # be fixed in v2017.4.  Once all streams are at v2017.4 we can fix this.  See
-    # https://github.com/projectatomic/rpm-ostree/pull/670
+    # This is a hack for requested-packages being displayed in rpm-ostree
+    # v2017.3 that should be fixed in v2017.4.  Fix this once  all streams
+    # are at v2017.4.
+    # See https://github.com/projectatomic/rpm-ostree/pull/670
     - name: Set packages when deployment 0 is booted
       set_fact:
-        req_pkgs: "{{ req_json['deployments'][0]['requested-packages'] if req_json['deployments'][0]['requested-packages'] is defined else {} }}"
+        req_pkgs: >
+           "{{ req_json['deployments'][0]['requested-packages']
+           if req_json['deployments'][0]['requested-packages'] is defined
+           else {} }}"
       when: req_json['deployments'][0]['booted']
 
     - name: Set packages when deployment 1 is booted
       set_fact:
-        req_pkgs: "{{ req_json['deployments'][1]['requested-packages'] if req_json['deployments'][1]['requested-packages'] is defined else {} }}"
-      when:  req_json['deployments'][1]['booted']
+        req_pkgs: >
+          "{{ req_json['deployments'][1]['requested-packages']
+          if req_json['deployments'][1]['requested-packages'] is defined
+          else {} }}"
+      when: req_json['deployments'][1]['booted']
 
     - name: Fail if {{ g_deployed_pkg }} is not in requested packages
       fail:
@@ -396,7 +417,7 @@
 
 - name: Package Layering - Installing non-root ownership package
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - install_nonroot_pkg
@@ -431,7 +452,7 @@
 
 - name: Package Layering - Negative - Install already layered package
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - install_previously_layered
@@ -440,14 +461,14 @@
     - vars.yml
 
   tasks:
-     - name: Install already layered package
-       command: rpm-ostree install {{ g_pkg1 }}
-       register: ros_install
-       failed_when: ros_install.rc == 0
+    - name: Install already layered package
+      command: rpm-ostree install {{ g_pkg1 }}
+      register: ros_install
+      failed_when: ros_install.rc == 0
 
-- name: Package Layering - Negative Test - Installing without sufficient privileges
+- name: Package Layering - Negative Test - Installing insufficient privileges
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - install_unprivileged
@@ -465,7 +486,7 @@
 
 - name: Package Layering - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup
@@ -475,7 +496,8 @@
 
   pre_tasks:
     - name: Uninstall all packages
-      command: rpm-ostree uninstall {{ g_pkg1 }} {{ g_epel_pkg }} {{ g_deployed_pkg }}
+      command: >
+        rpm-ostree uninstall {{ g_pkg1 }} {{ g_epel_pkg }} {{ g_deployed_pkg }}
 
     - include: '../../common/ans_reboot.yml'
 

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -7,7 +7,7 @@
 #
 - name: rpm-ostree - Setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - setup
@@ -39,7 +39,7 @@
 
 - name: rpm-ostree - deploy by version
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - deploy_version
@@ -137,7 +137,7 @@
 
 - name: rpm-ostree - deploy by commit
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - deploy_commit
@@ -222,7 +222,7 @@
 
 - name: rpm-ostree - cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup_pending
@@ -296,7 +296,7 @@
 
 - name: rpm-ostree - upgrade and rebase
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - upgrade_rebase
@@ -409,7 +409,7 @@
 
 - name: rpm-ostree - upgrade and rebase + install and uninstall
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - upgrade_rebase_install_uninstall
@@ -601,7 +601,7 @@
 #####################################################################################
 - name: rpm-ostree livefs
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - livefs
@@ -727,7 +727,7 @@
 
 - name: rpm-ostree - client side initramfs
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - initramfs

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -7,7 +7,7 @@
 #
 - name: rpm-ostree - Setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - setup
@@ -39,7 +39,7 @@
 
 - name: rpm-ostree - deploy by version
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - deploy_version
@@ -55,7 +55,8 @@
     # that what HEAD is on the remote.  So let's just get all the commit
     # metadata to be safe.
     - name: Pull all the commit data
-      command: ostree pull --commit-metadata-only --depth=-1 {{ ros_booted['origin'] }}
+      command: >
+        ostree pull --commit-metadata-only --depth=-1 {{ ros_booted['origin'] }}
       register: osp
       retries: 5
       delay: 60
@@ -64,7 +65,9 @@
     # Use the parent of the deployed commit as HEAD-1, in case the remote
     # is updated during the test.
     - name: Get parent of deployed commit
-      shell: ostree show $(ostree rev-parse {{ ros_booted['checksum'] }}^) --print-metadata-key version | tr -d \'
+      shell: >
+        ostree show $(ostree rev-parse {{ ros_booted['checksum'] }}^)
+        --print-metadata-key version | tr -d \'
       register: ostree_show
 
     # the rpm_ostree_status above sets the ros_booted variable used below
@@ -134,7 +137,7 @@
 
 - name: rpm-ostree - deploy by commit
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - deploy_commit
@@ -219,7 +222,7 @@
 
 - name: rpm-ostree - cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup_pending
@@ -293,7 +296,7 @@
 
 - name: rpm-ostree - upgrade and rebase
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - upgrade_rebase
@@ -308,8 +311,8 @@
     # the rpm_ostree_status above sets the ros_booted variable used below
     - name: Set current commit version and refspec
       set_fact:
-         head_csum: "{{ ros_booted['checksum'] }}"
-         refspec: "{{ ros_booted['origin'] }}"
+        head_csum: "{{ ros_booted['checksum'] }}"
+        refspec: "{{ ros_booted['origin'] }}"
 
     - name: Get origin dir
       command: ostree admin --print-current-dir
@@ -320,10 +323,14 @@
 
     # update refspec in origin file so rpm-ostree upgrade uses local-branch
     - name: Update origin file
-      command: sed -i 's/^\(.*refspec\)=.*$/\1=local-branch/g' {{ current_dir.stdout }}.origin
+      command: >
+        sed -i 's/^\(.*refspec\)=.*$/\1=local-branch/g'
+        {{ current_dir.stdout }}.origin
 
     - name: Commit new local branch
-      command: ostree commit -b local-branch --tree=ref=local-branch --add-metadata-string version=test
+      command: >
+        ostree commit -b local-branch --tree=ref=local-branch
+        --add-metadata-string version=test
       register: new_commit
 
     # TODO: revert this conditional once F26 picks up rpm-ostree 2017.9
@@ -402,7 +409,7 @@
 
 - name: rpm-ostree - upgrade and rebase + install and uninstall
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - upgrade_rebase_install_uninstall
@@ -436,10 +443,14 @@
 
     # update refspec in origin file so rpm-ostree upgrade uses local-branch
     - name: Update origin file
-      command:  sed -i 's/^\(.*refspec\)=.*$/\1=local-branch/g' {{ current_dir.stdout }}.origin
+      command: >
+        sed -i 's/^\(.*refspec\)=.*$/\1=local-branch/g'
+        {{ current_dir.stdout }}.origin
 
     - name: Commit new local branch
-      command: ostree commit -b local-branch --tree=ref=local-branch --add-metadata-string version=test
+      command: >
+        ostree commit -b local-branch --tree=ref=local-branch
+        --add-metadata-string version=test
       register: new_commit
 
     # TODO: revert this conditional once F26 picks up rpm-ostree 2017.9
@@ -590,7 +601,7 @@
 #####################################################################################
 - name: rpm-ostree livefs
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - livefs
@@ -638,7 +649,8 @@
         checksum: "{{ rol_base_commit }}"
         packages: []
 
-    # Reboot and check that the deployment is now a typical package layered deployment
+    # Reboot and check that the deployment is now a typical package layered
+    # deployment
     - role: reboot
 
     - role: rpm_ostree_install_verify
@@ -673,8 +685,8 @@
 
     - role: rpm_ostree_rollback
 
-    # Reboot and verify that the system is back to the original deployment without livefs
-    # or layered packages
+    # Reboot and verify that the system is back to the original deployment
+    # without livefs or layered packages
     - role: reboot
 
     - role: rpm_ostree_uninstall_verify
@@ -715,7 +727,7 @@
 
 - name: rpm-ostree - client side initramfs
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - initramfs
@@ -735,7 +747,9 @@
         line: "rpm-ostree-test"
 
     - name: Enable initramfs
-      command: rpm-ostree initramfs --enable --arg="-I" --arg="/etc/rpmostree-file"
+      command: >
+        rpm-ostree initramfs --enable --arg="-I"
+        --arg="/etc/rpmostree-file"
 
     - include_role:
         name: reboot
@@ -775,7 +789,9 @@
         osname: "{{ ros_booted['osname'] }}"
 
     - name: Get bootloader entry
-      shell: grep ^initrd /boot/loader/entries/ostree-{{ osname }}-0.conf | sed -e 's,initrd ,/boot/,'
+      shell: >
+        grep ^initrd /boot/loader/entries/ostree-{{ osname }}-0.conf |
+        sed -e 's,initrd ,/boot/,'
       register: initrd
 
     - name: Check initramfs file
@@ -799,7 +815,9 @@
         name: reboot
 
     - name: Get bootloader entry
-      shell: grep ^initrd /boot/loader/entries/ostree-{{ osname }}-0.conf | sed -e 's,initrd ,/boot/,'
+      shell: >
+        grep ^initrd /boot/loader/entries/ostree-{{ osname }}-0.conf |
+        sed -e 's,initrd ,/boot/,'
       register: initrd_disabled
 
     - name: Check initramfs file

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -34,7 +34,7 @@
 #
 - name: System Containers - Setup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - setup
@@ -76,7 +76,7 @@
 
 - name: System Containers - Install/Uninstall
   hosts: all
-  become: yes
+  become: "yes"
 
   #  - Verify system containers can be installed through atomic command
   #  - Verify system containers can be uninstalled through the atomic command
@@ -106,7 +106,7 @@
 
 - name: System Containers - Reboot
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - reboot
@@ -170,7 +170,7 @@
 
 - name: System Containers - Pass Variables
   hosts: all
-  become: yes
+  become: "yes"
 
   # - Verify environment variables can be pass to the container
 
@@ -219,7 +219,7 @@
 
 - name: System Containers - Update/Rollback
   hosts: all
-  become: yes
+  become: "yes"
 
   # - Verify update/rollback of system containers
 
@@ -296,7 +296,7 @@
 
 - name: System Containers - Rootfs
   hosts: all
-  become: yes
+  become: "yes"
 
   # - Verify specification of rootfs for system containers.
 
@@ -370,15 +370,19 @@
     - name: Fail when rootfs dir is missing from main container
       fail:
         msg: |
-          Expected: /var/lib/containers/atomic/{{ g_hw_name }}/rootfs exists is True
-          Actual: /var/lib/containers/atomic/{{ g_hw_name }}/rootfs exists is {{ hw.stat.exists }}
+          Expected: /var/lib/containers/atomic/{{ g_hw_name }}/rootfs exists
+                    is True
+          Actual: /var/lib/containers/atomic/{{ g_hw_name }}/rootfs exists
+                  is {{ hw.stat.exists }}
       when: hw.stat.exists == False
 
     - name: Fail when rootfs dir exists for rootfs container
       fail:
         msg: |
-          Expected: /var/lib/containers/atomic/{{ g_hw_name }}-remote/rootfs exists is False
-          Actual: /var/lib/containers/atomic/{{ g_hw_name }}-remote/rootfs exists is {{ hwr.stat.exists }}
+          Expected: /var/lib/containers/atomic/{{ g_hw_name }}-remote/rootfs
+                    exists is False
+          Actual: /var/lib/containers/atomic/{{ g_hw_name }}-remote/rootfs
+                  exists is {{ hwr.stat.exists }}
       when: hwr.stat.exists != True
 
     - include: 'roles/atomic_system_uninstall/tasks/main.yml'
@@ -400,7 +404,7 @@
 
 - name: System Containers - Flannel & Etcd
   hosts: all
-  become: yes
+  become: "yes"
 
   #  Flannel & Etcd Tests
 
@@ -430,14 +434,14 @@
       service:
         name: flanneld
         state: stopped
-        enabled: no
+        enabled: "no"
       when: rpm_flannel.rc == 0
 
     - name: Stop etcd service if etcd rpm present
       service:
         name: etcd
         state: stopped
-        enabled: no
+        enabled: "no"
       when: rpm_etcd.rc == 0
 
     # The `aivc_atomic_install_cmd` is set by the required role:
@@ -514,7 +518,7 @@
 
 - name: System Containers - Set RUN_DIRECTORY & STATE_DIRECTORY
   hosts: all
-  become: yes
+  become: "yes"
 
   # - Verify setting RUN_DIRECTORY and STATE_DIRECTORY
 
@@ -539,7 +543,7 @@
         {{ g_hw_image }}
 
     - name: Get output of {{ g_hw_name }} info file
-      command:  cat /var/lib/containers/atomic/{{ g_hw_name }}/info
+      command: cat /var/lib/containers/atomic/{{ g_hw_name }}/info
       register: info_output
 
     - name: Convert output to JSON
@@ -550,14 +554,16 @@
       fail:
         msg: |
           Expected: RUN_DIRECTORY is set to {{ run_dir }}
-          Actual: RUN_DIRECTORY is set to {{ info_json['values']['RUN_DIRECTORY'] }}
+          Actual: RUN_DIRECTORY is set to
+                  {{ info_json['values']['RUN_DIRECTORY'] }}
       when: run_dir not in info_json['values']['RUN_DIRECTORY']
 
     - name: Verify STATE_DIRECTORY is set
       fail:
         msg: |
           Expected: STATE_DIRECTORY is set to {{ state_dir }}
-          Actual: STATE_DIRECTORY is set to {{ info_json['values']['STATE_DIRECTORY'] }}
+          Actual: STATE_DIRECTORY is set to
+                  {{ info_json['values']['STATE_DIRECTORY'] }}
       when: state_dir not in info_json['values']['STATE_DIRECTORY']
 
     - include: 'roles/atomic_system_uninstall/tasks/main.yml'
@@ -570,7 +576,7 @@
 
 - name: System Containers - Negative Testing
   hosts: all
-  become: yes
+  become: "yes"
 
   #  Negative Testing
   #    - Verify uninstalling a system container that does not exist fails
@@ -594,7 +600,9 @@
       register: aif_output
       failed_when: aif_output.rc == 0
 
-    - name: Create container with DESTDIR, NAME, EXEC_START, EXEC_STOP, HOST_UID, HOST_GID
+    - name: >
+        Create container with DESTDIR, NAME, EXEC_START, EXEC_STOP, HOST_UID,
+        HOST_GID
       command: >
         atomic install
         --system
@@ -607,7 +615,7 @@
         {{ g_hw_image }}
 
     - name: Get output of {{ g_hw_name }} info file
-      command:  cat /var/lib/containers/atomic/{{ g_hw_name }}/info
+      command: cat /var/lib/containers/atomic/{{ g_hw_name }}/info
       register: info_output
 
     - name: Fail if {{ g_invalid_value }} in output
@@ -629,7 +637,7 @@
 
 - name: System Containers - Cleanup
   hosts: all
-  become: yes
+  become: "yes"
 
   tags:
     - cleanup

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -34,7 +34,7 @@
 #
 - name: System Containers - Setup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - setup
@@ -76,7 +76,7 @@
 
 - name: System Containers - Install/Uninstall
   hosts: all
-  become: "yes"
+  become: true
 
   #  - Verify system containers can be installed through atomic command
   #  - Verify system containers can be uninstalled through the atomic command
@@ -106,7 +106,7 @@
 
 - name: System Containers - Reboot
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - reboot
@@ -170,7 +170,7 @@
 
 - name: System Containers - Pass Variables
   hosts: all
-  become: "yes"
+  become: true
 
   # - Verify environment variables can be pass to the container
 
@@ -219,7 +219,7 @@
 
 - name: System Containers - Update/Rollback
   hosts: all
-  become: "yes"
+  become: true
 
   # - Verify update/rollback of system containers
 
@@ -296,7 +296,7 @@
 
 - name: System Containers - Rootfs
   hosts: all
-  become: "yes"
+  become: true
 
   # - Verify specification of rootfs for system containers.
 
@@ -404,7 +404,7 @@
 
 - name: System Containers - Flannel & Etcd
   hosts: all
-  become: "yes"
+  become: true
 
   #  Flannel & Etcd Tests
 
@@ -434,14 +434,14 @@
       service:
         name: flanneld
         state: stopped
-        enabled: "no"
+        enabled: false
       when: rpm_flannel.rc == 0
 
     - name: Stop etcd service if etcd rpm present
       service:
         name: etcd
         state: stopped
-        enabled: "no"
+        enabled: false
       when: rpm_etcd.rc == 0
 
     # The `aivc_atomic_install_cmd` is set by the required role:
@@ -518,7 +518,7 @@
 
 - name: System Containers - Set RUN_DIRECTORY & STATE_DIRECTORY
   hosts: all
-  become: "yes"
+  become: true
 
   # - Verify setting RUN_DIRECTORY and STATE_DIRECTORY
 
@@ -576,7 +576,7 @@
 
 - name: System Containers - Negative Testing
   hosts: all
-  become: "yes"
+  become: true
 
   #  Negative Testing
   #    - Verify uninstalling a system container that does not exist fails
@@ -637,7 +637,7 @@
 
 - name: System Containers - Cleanup
   hosts: all
-  become: "yes"
+  become: true
 
   tags:
     - cleanup

--- a/tests/unique-machine-id/main.yml
+++ b/tests/unique-machine-id/main.yml
@@ -7,7 +7,7 @@
 #
 - name: Verify that /etc/machine_id is unique across hosts
   hosts: all
-  sudo: "yes"
+  sudo: true
 
   pre_tasks:
     - name: Fail if the inventory has more than 2 hosts

--- a/tests/unique-machine-id/main.yml
+++ b/tests/unique-machine-id/main.yml
@@ -7,7 +7,7 @@
 #
 - name: Verify that /etc/machine_id is unique across hosts
   hosts: all
-  sudo: yes
+  sudo: "yes"
 
   pre_tasks:
     - name: Fail if the inventory has more than 2 hosts
@@ -21,9 +21,11 @@
     - name: Set facts about distributions
       set_fact:
         host1_dist: "{{ hostvars[groups['all'][0]].ansible_distribution }}"
-        host1_dist_ver: "{{ hostvars[groups['all'][0]].ansible_distribution_version }}"
+        host1_dist_ver: >
+          "{{ hostvars[groups['all'][0]].ansible_distribution_version }}"
         host2_dist: "{{ hostvars[groups['all'][1]].ansible_distribution }}"
-        host2_dist_ver: "{{ hostvars[groups['all'][1]].ansible_distribution_version }}"
+        host2_dist_ver: >
+          "{{ hostvars[groups['all'][1]].ansible_distribution_version }}"
       run_once: true
 
     - name: Fail if the two hosts are not the same distribution


### PR DESCRIPTION
This commit fixes minor issues in the atomic host tests to comply
to the YAML spec.  The issues fixed were found using yamllint.

There were some instances of line length that could not be fixed
(i.e. Ansible when statements like  "'foo' in bar"). Using > or |
would break the logic so the line length had to be preserved.