### PR TITLE
gitignore: add test artifacts to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ inventory*
 *.pyc
 *.pyo
 .*.swp
+
+# ignore test artifacts
+*bdsf_archive.yml
+*journal


### PR DESCRIPTION
When running tests locally, we can start accumulating tests artifacts
that clutter up the output of `git status`, so let's start excluding
some of them.