### PR TITLE
selinux_verify: adjust order of processes to be checked

### DIFF
--- a/roles/selinux_verify/vars/common.yml
+++ b/roles/selinux_verify/vars/common.yml
@@ -21,6 +21,6 @@ common_files:
   - { key: '/usr/sbin/sshd', value: 'system_u:object_r:sshd_exec_t:s0' }
 
 common_procs:
-  - { key: 'NetworkManager', value: 'system_u:system_r:NetworkManager_t:s0' }
   - { key: 'rpm-ostreed', value: 'system_u:system_r:install_t:s0' }
+  - { key: 'NetworkManager', value: 'system_u:system_r:NetworkManager_t:s0' }
   - { key: 'sshd', value: 'system_u:system_r:sshd_t:s0' }


### PR DESCRIPTION
When testing against systems that have slower CPUs or slower network
links, I was encountering a situation where I was not able to get the
SELinux label of the `rpm-ostree` daemon after using `rpm-ostree
status`.  I believe this was happening because the tests check the
SELinux label of `NetworkManager` first, allowing the `rpm-ostree`
process to spin down before we could check the label. (The daemon
appears to be activated via DBus (I think?), so it does not show
up in the running process list all the time.)

This change just puts `rpm-ostreed` at the top of the list so that it
is checked first.