### PR TITLE
test/i-s-t:  improve cleanup at end of test

### DIFF
--- a/roles/user_del/meta/main.yml
+++ b/roles/user_del/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/user_del/tasks/main.yml
+++ b/roles/user_del/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# vim: set ft=ansible:
+#
+# Deletes users on a system with prejudice.
+#
+# Parameters:
+#   - ud_users - list of users to be deleted
+#
+- name: Fail if ud_users is not defined
+  fail:
+    msg: |
+      You must supply at least one user as a value for 'ud_users'
+  when: ud_users is undefined
+
+- name: Delete users
+  command: "userdel -r -f {{ item }}"
+  ignore_errors: true
+  with_items:
+    - "{{ ud_users }}"

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -878,6 +878,15 @@
       tags:
         - rpm_ostree_cleanup_all
 
+    # remove any docker artifacts
+    - role: docker_remove_all
+
+    # remove users
+    - role: user_del
+      ud_users:
+        - "{{ g_uid1 }}"
+        - "{{ g_uid2 }}"
+
     # cleanup our subscriptions because we are nice people
     - when: ansible_distribution == 'RedHat'
       role: redhat_unsubscribe

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -880,12 +880,16 @@
 
     # remove any docker artifacts
     - role: docker_remove_all
+      tags:
+        - docker_remove_all
 
     # remove users
     - role: user_del
       ud_users:
         - "{{ g_uid1 }}"
         - "{{ g_uid2 }}"
+      tags:
+        - user_del
 
     # cleanup our subscriptions because we are nice people
     - when: ansible_distribution == 'RedHat'


### PR DESCRIPTION
This adds a role named `user_del` which will delete any users (with
prejudice!) passed as a list to the role.

The `improved-sanity-test` makes use of this new role at the very end
of the test and additionally calls `docker_remove_all` to cleanup any
docker artifacts (containers/images).