### PR TITLE
tools: add a README file for the tools container

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,12 @@
+Small tools container for use with [atomic-host-tests](https://github.com/projectatomic/atomic-host-tests)
+
+As of 09-Jan-2017, the following utilities/packages are installed
+  - `jq`
+
+To run the container:
+
+`# docker run -i docker.io/miabbott/aht-tools <command> <cmd_args>`
+
+For example:
+
+`# rpm-ostree status --json | docker run -i docker.io/miabbott/aht-tools jq '.'`


### PR DESCRIPTION
This will be used as part of the Docker Hub automated build process,
rather than the README which is in the root of the repo.

See https://hub.docker.com/r/miabbott/aht-tools/