### PR TITLE
Use force option for atomic images delete all

### DIFF
--- a/roles/atomic_images_delete_all/tasks/main.yml
+++ b/roles/atomic_images_delete_all/tasks/main.yml
@@ -2,7 +2,7 @@
 # vim: set ft=ansible:
 #
 - name: Remove all images
-  command: atomic --assumeyes images delete --all
+  command: atomic --assumeyes images delete --all --force
   ignore_errors: yes
 
 - name: Prune images


### PR DESCRIPTION
The atomic_images_delete_all role was failing because the atomic
images delete command cannot delete an image if it is used in
an exited container.  The --force option is used to work around
this.