### PR TITLE
Install k8 worker nodes and etcd system containers for Fedora 27AH

### DIFF
--- a/roles/k8_cluster_services_rc_setup/tasks/main.yml
+++ b/roles/k8_cluster_services_rc_setup/tasks/main.yml
@@ -25,45 +25,57 @@
 
   - name: insert private registry ip in webserver controller image yml
     replace:
-      dest=/root/db-rc.yml
-      regexp='PRIVATE'
-      replace='{{ ansible_docker0.ipv4.address }}'
+      dest: /root/db-rc.yml
+      regexp: 'PRIVATE'
+      replace: '{{ ansible_docker0.ipv4.address }}'
 
   - name: insert private registry ip in db controller image yml
     replace:
-      dest=/root/webserver-rc.yml
-      regexp='PRIVATE'
-      replace='{{ ansible_docker0.ipv4.address }}'
+      dest: /root/webserver-rc.yml
+      regexp: 'PRIVATE'
+      replace: '{{ ansible_docker0.ipv4.address }}'
 
   - name: wait for kubernetes apiserver to be available
     wait_for:
       port: 8080
       timeout: 120
 
+  - name: Define kubectl path for F27AH
+    when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+          (ansible_distribution == "CentOSDev")
+    set_fact:
+      kubectl_path: "/usr/local/bin/kubectl"
+
+  - name: Define kubectl path for F26AH, Centos/RHEL
+    when: (ansible_distribution == "RedHat") or
+          (ansible_distribution == "Fedora" and ansible_distribution_major_version < '27') or
+          (ansible_distribution == "CentOS")
+    set_fact:
+      kubectl_path: "/usr/bin/kubectl"
 
   - name: create db and webserver service
-    command: kubectl create -f /root/{{ item }}
+    command: "{{ kubectl_path }} create -f /root/{{ item }}"
     with_items:
       - db-service.yml
       - webserver-service.yml
     ignore_errors: True
 
   - name: create db and webserver replication controller
-    command: kubectl create -f /root/{{ item }}
+    command: "{{ kubectl_path }} create -f /root/{{ item }}"
     with_items:
       - db-rc.yml
       - webserver-rc.yml
     ignore_errors: True
 
   - name: verify db pod is running
-    shell: kubectl get pods | grep db-controller
+    shell: "{{ kubectl_path }} get pods | grep db-controller"
     register: output
     until: output.stdout.find("Running") > -1
     retries: 12
     delay: 10
 
   - name: verify webserver-controller is running
-    shell: kubectl get pods | grep webserver-controller
+    shell: "{{ kubectl_path }} get pods | grep webserver-controller"
     register: output
     until: output.stdout.find("Running") > -1
     retries: 12

--- a/roles/k8_remove_all/tasks/main.yml
+++ b/roles/k8_remove_all/tasks/main.yml
@@ -17,11 +17,25 @@
     - kube-proxy
     - kubelet
 
+- name: Define kubectl path for F27AH
+  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+        (ansible_distribution == "CentOSDev")
+  set_fact:
+    kubectl_path: "/usr/local/bin/kubectl"
+
+- name: Define kubectl path for F26AH, Centos/RHEL
+  when: (ansible_distribution == "RedHat") or
+        (ansible_distribution == "Fedora" and ansible_distribution_major_version < '27') or
+        (ansible_distribution == "CentOS")
+  set_fact:
+    kubectl_path: "/usr/bin/kubectl"
+
+
 - name: Remove all services
-  command: kubectl delete svc --all
+  command: "{{ kubectl_path }} delete svc --all"
 
 - name: Remove all RCs
-  command: kubectl delete rc --all
+  command: "{{ kubectl_path }} delete rc --all"
 
 - name: Remove all pods
-  command: kubectl delete po --all
+  command: "{{ kubectl_path }} delete po --all"

--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -9,7 +9,9 @@
     rv_rpms: kubernetes-node
 
 - name: Define kube 1.5 vars
-  when: g_atomic_host['kubernetes-node'] | version_compare('1.6', '<')
+  when:
+    - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '<')
   set_fact:
     kube_maj_ver: "1.5"
     kube_apiserver: "registry.access.redhat.com/rhel7/kubernetes-apiserver"
@@ -17,14 +19,31 @@
     kube_scheduler: "registry.access.redhat.com/rhel7/kubernetes-scheduler"
 
 - name: Define kube 1.6 images
-  when: g_atomic_host['kubernetes-node'] | version_compare('1.6', '>=')
+  when:
+    - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '>=')
   set_fact:
     kube_maj_ver: "1.6"
     kube_apiserver: "registry.fedoraproject.org/f26/kubernetes-apiserver"
     kube_controller_manager: "registry.fedoraproject.org/f26/kubernetes-controller-manager"
     kube_scheduler: "registry.fedoraproject.org/f26/kubernetes-scheduler"
 
+- name: Define kube 1.7 master nodes, worker nodes and etcd images
+  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+        (ansible_distribution == "CentOSDev")
+
+  set_fact:
+    kube_maj_ver: "1.7"
+    kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"
+    kube_controller_manager: "registry.fedoraproject.org/f27/kubernetes-controller-manager"
+    kube_scheduler: "registry.fedoraproject.org/f27/kubernetes-scheduler"
+    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet"
+    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
+    etcd: "registry.fedoraproject.org/f27/etcd"
+
 - name: pull kubernetes api-server, controller-mgr, scheduler
+  when:
+    - g_atomic_host is defined
   command: docker pull {{ item }}
   register: pull
   failed_when: item not in pull.stdout
@@ -32,6 +51,37 @@
     - "{{ kube_apiserver }}"
     - "{{ kube_controller_manager }}"
     - "{{ kube_scheduler }}"
+
+- block:
+    - name: Pull k8 and etcd images from the registry
+      command:  atomic pull --storage ostree "{{ item }}"
+      register: ap
+      retries: 3
+      delay: 10
+      until: "ap.rc == 0"
+      with_items:
+        - "{{ kube_apiserver }}"
+        - "{{ kube_controller_manager }}"
+        - "{{ kube_scheduler }}"
+        - "{{ kube_kubelet }}"
+        - "{{ kube_proxy }}"
+        - "{{ etcd }}"
+
+    - name: Install master node system containers that is, k8-apiserver, k8-controller_manager and k8-scheduler
+      command: "{{ item }}"
+      with_items:
+        - atomic install --system --system-package=no --name kube-apiserver {{ kube_apiserver }}
+        - atomic install --system --system-package=no --name kube-controller-manager {{ kube_controller_manager }}
+        - atomic install --system --system-package=no --name kube-scheduler {{ kube_scheduler }}
+
+    - name: Install worker node system containers, that is k8-kubelet, k8-proxy and etcd
+      command: "{{ item }}"
+      with_items:
+        - atomic install --system --system-package=no --name kubelet {{ kube_kubelet }}
+        - atomic install --system --system-package=no --name kube-proxy {{ kube_proxy }}
+        - atomic install --system --system-package=no --storage=ostree --name etcd {{ etcd }}
+  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+        (ansible_distribution == "CentOSDev")
 
 - name: make db directory
   file:

--- a/roles/rpm_version/tasks/version.yml
+++ b/roles/rpm_version/tasks/version.yml
@@ -15,8 +15,10 @@
 - name: Determine version of {{ rv_rpm }}
   command: rpm -q --queryformat '%{VERSION}' {{ rv_rpm }}
   register: rpmq
+  ignore_errors: true
 
 - name: Set facts
+  when: rpmq.rc == 0
   set_fact:
     rv_version: "{{ rpmq.stdout }}"
     g_atomic_host: "{{ g_atomic_host|default({}) | combine( { rv_rpm: rpmq.stdout } ) }}"

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -20,6 +20,9 @@
   hosts: all
   become: true
 
+  vars_files:
+    - vars.yml
+
   roles:
     # This playbook requires Ansible 2.2 and an Atomic Host
     - role: ansible_version_check
@@ -45,6 +48,11 @@
       tags:
         - docker_build_tag_push
 
+    - when: ansible_distribution == "CentOSDev"
+      role: resize_lv
+      tags:
+        - resize_lv
+
     - role: kubernetes_setup
       tags:
         - kubernetes_setup
@@ -54,7 +62,7 @@
         - k8_cluster_services_rc_setup
 
   post_tasks:
-    - name: check if everything works!
+    - name: Check if everything works!
       shell: curl http://localhost:80/cgi-bin/action | grep "RedHat rocks"
 
 

--- a/tests/k8-cluster/vars.yml
+++ b/tests/k8-cluster/vars.yml
@@ -1,0 +1,3 @@
+---
+rl_lvname: 'root'
+rl_lvsize: '6'


### PR DESCRIPTION
This is required, as from Fedora27AH, k8, flannel and etcd are no
longer part of the Host's image.