### PR TITLE
Don't retry when expecting failures

### DIFF
--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -225,10 +225,7 @@
     - name: Attempt to install rpm
       command: rpm -i {{ g_rpm_url }}
       register: attempted_install
-      retries: 5
-      delay: 60
-      until: attempted_install|success
-      failed_when: attempted_install.rc != 1
+      failed_when: attempted_install.rc == 0
 
     - include_role:
         name: rpm_ostree_status


### PR DESCRIPTION
Addresses #317 .  Retries were added to increase reliability of tests
when performing network operations, however, we should not retry
when we expect a failure.

I also added a minor fix to only fail when the command succeeds.