### PR TITLE
journal_fatal_msgs: add check for SELinux denials from kernel

### DIFF
--- a/roles/journal_fatal_msgs/meta/main.yml
+++ b/roles/journal_fatal_msgs/meta/main.yml
@@ -11,6 +11,13 @@ dependencies:
     fail_if_found: true
     extra_args: '_TRANSPORT=audit'
 
+  # check for SELinux denials from kernel
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1536690
+  - role: journal_search
+    search_string: 'avc:  denied'
+    fail_if_found: true
+    extra_args: '_TRANSPORT=kernel'
+
   # check for kernel Oops
   - role: journal_search
     search_string: Oops


### PR DESCRIPTION
In RHBZ#1536690, I observed there were SELinux denials present on the
host, but our tests were catching them.  These denial messages were on
the 'kernel' transport and we were only checking the 'audit' transport,
so I've added a new rule to look for denials from that 'kernel'
transport.