### PR TITLE
Fix action script

### DIFF
--- a/roles/docker_build_tag_push/files/centos/web/action
+++ b/roles/docker_build_tag_push/files/centos/web/action
@@ -25,4 +25,4 @@ with con:
     print '</body>'
     print '</html>'
 
-    con.close()
+con.close()

--- a/roles/docker_build_tag_push/files/fedora/web/action
+++ b/roles/docker_build_tag_push/files/fedora/web/action
@@ -25,4 +25,4 @@ with con:
     print '</body>'
     print '</html>'
 
-    con.close()
+con.close()

--- a/roles/docker_build_tag_push/files/rhel7/web/action
+++ b/roles/docker_build_tag_push/files/rhel7/web/action
@@ -25,4 +25,4 @@ with con:
     print '</body>'
     print '</html>'
 
-    con.close()
+con.close()


### PR DESCRIPTION
Closing the mysqldb connection inside the with statement block was
causing segmentation faults and tracebacks in newer versions of
python.  This caused errors getting the action page from Apache.

Moving the connection close outside the with statement fixed this
on fedora, rhel, and centos.