### PR TITLE
roles: new resize_lv role

### DIFF
--- a/roles/resize_lv/meta/main.yml
+++ b/roles/resize_lv/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/resize_lv/tasks/main.yml
+++ b/roles/resize_lv/tasks/main.yml
@@ -7,21 +7,19 @@
 # Atomic Host systems, the logical volume names are well known, but the
 # volume group names can differ based on install method.
 #
-# If you have advance knowledge of the sizes of the volume groups and
-# logical volumes, you can specify the desired size of the logical volume,
-# otherwise it defaults to consuming 50% of the available space in the
-# volume group.
+# Additionally, you must specify the desired size of the logical volume
+# in units of G.  If the current size of the logical volume is less than
+# the desired value, the volume will be extended.
 #
 # Required variables:
-#  - rl_lvname:  name of the logical volume
-#
-# Optional variables:
+#   - rl_lvname:  name of the logical volume
 #   - rl_lvsize:  desired size in G of the logical volume
 
 - name: Fail if variables aren't set
-  when: rl_lvname is not defined
+  when: rl_lvname is not defined or
+        rl_lvsize is not defined
   fail:
-    msg: "The variable 'rl_lvname' was not defined"
+    msg: "The variables 'rl_lvaname' and 'rl_lvsize' must be defined"
 
 - name: Determine the name of the volume group
   command: vgs --no-headings -o vg_name
@@ -31,16 +29,17 @@
   set_fact:
     rl_vgname: "{{ rl_vgs_name.stdout|trim }}"
 
+- name: Get current size of logical volume
+  command: "lvs -o lv_size --no-headings --units G --nosuffix {{ rl_vgname }}/{{ rl_lvname }}"
+  register: rl_lvs_size
+
+- name: Set current lvsize fact
+  set_fact:
+    rl_lvsize_current: "{{ rl_lvs_size.stdout|trim|round|int }}"
+
 - name: Resize the logical volume to known size
-  when: rl_lvsize is defined
+  when: rl_lvsize_current|int < rl_lvsize|int
   lvol:
     vg: "{{ rl_vgname }}"
     lv: "{{ rl_lvname }}"
     size: "{{ rl_lvsize }}G"
-
-- name: Resize the logical volume to consume 50% free space
-  when: rl_lvsize is not defined
-  lvol:
-    vg: "{{ rl_vgname }}"
-    lv: "{{ rl_lvname }}"
-    size: +50%FREE

--- a/roles/resize_lv/tasks/main.yml
+++ b/roles/resize_lv/tasks/main.yml
@@ -35,11 +35,18 @@
 
 - name: Set current lvsize fact
   set_fact:
-    rl_lvsize_current: "{{ rl_lvs_size.stdout|trim|round|int }}"
+    rl_lvsize_current: "{{ rl_lvs_size.stdout|trim|float|round|int }}"
 
-- name: Resize the logical volume to known size
-  when: rl_lvsize_current|int < rl_lvsize|int
-  lvol:
-    vg: "{{ rl_vgname }}"
-    lv: "{{ rl_lvname }}"
-    size: "{{ rl_lvsize }}G"
+- when: rl_lvsize_current|int < rl_lvsize|int
+  block:
+    - name: Resize the logical volume
+      lvol:
+        vg: "{{ rl_vgname }}"
+        lv: "{{ rl_lvname }}"
+        size: "{{ rl_lvsize }}G"
+
+    - name: Resize the filesystem
+      filesystem:
+        fstype: xfs
+        dev: "/dev/{{ rl_vgname }}/{{ rl_lvname }}"
+        resizefs: true

--- a/roles/resize_lv/tasks/main.yml
+++ b/roles/resize_lv/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# vim: set ft=ansible:
+#
+# This is a role that can be used to resize a logical volume on the host.
+# It requires that you know the name of the logical volume and will try
+# to determine the name of the volume group.  Since this is to be used on
+# Atomic Host systems, the logical volume names are well known, but the
+# volume group names can differ based on install method.
+#
+# If you have advance knowledge of the sizes of the volume groups and
+# logical volumes, you can specify the desired size of the logical volume,
+# otherwise it defaults to consuming 50% of the available space in the
+# volume group.
+#
+# Required variables:
+#  - rl_lvname:  name of the logical volume
+#
+# Optional variables:
+#   - rl_lvsize:  desired size in G of the logical volume
+
+- name: Fail if variables aren't set
+  when: rl_lvname is not defined
+  fail:
+    msg: "The variable 'rl_lvname' was not defined"
+
+- name: Determine the name of the volume group
+  command: vgs --no-headings -o vg_name
+  register: rl_vgs_name
+
+- name: Set vgname fact
+  set_fact:
+    rl_vgname: "{{ rl_vgs_name.stdout|trim }}"
+
+- name: Resize the logical volume to known size
+  when: rl_lvsize is defined
+  lvol:
+    vg: "{{ rl_vgname }}"
+    lv: "{{ rl_lvname }}"
+    size: "{{ rl_lvsize }}G"
+
+- name: Resize the logical volume to consume 50% free space
+  when: rl_lvsize is not defined
+  lvol:
+    vg: "{{ rl_vgname }}"
+    lv: "{{ rl_lvname }}"
+    size: +50%FREE

--- a/roles/resize_lv/tasks/main.yml
+++ b/roles/resize_lv/tasks/main.yml
@@ -19,7 +19,7 @@
   when: rl_lvname is not defined or
         rl_lvsize is not defined
   fail:
-    msg: "The variables 'rl_lvaname' and 'rl_lvsize' must be defined"
+    msg: "The variables 'rl_lvname' and 'rl_lvsize' must be defined"
 
 - name: Determine the name of the volume group
   command: vgs --no-headings -o vg_name


### PR DESCRIPTION
We may want to resize a logical volume during our tests, in order to
make room for `ostree` host content or system container content.  This
role provides simple functionality to do so.