### PR TITLE
bdsf: utilize the tools container to hide noisy JSON keys

### DIFF
--- a/roles/booted_deployment_set_fact/meta/main.yml
+++ b/roles/booted_deployment_set_fact/meta/main.yml
@@ -1,2 +1,6 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: docker_pull
+    dp_image: docker.io/miabbott/aht-tools:latest

--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -12,7 +12,11 @@
     bdsf_ansible_host: "{{ ansible_host }}"
 
 - name: Get rpm-ostree status output
-  command: rpm-ostree status --json
+  shell: >
+    rpm-ostree status --json |
+    docker run -i docker.io/miabbott/aht-tools
+    jq 'del(.deployments[]["layered-commit-meta"]["rpmostree.rpmdb.pkglist"],
+            .deployments[]["base-commit-meta"]["rpmostree.rpmdb.pkglist"])'
   register: bdsf_ros_status
 
 - name: Set json output


### PR DESCRIPTION
Similar to the `rpm_ostree_status` role, when we output the status in
JSON format, one of the keys has a list of all the packages that are
included in the ostree commit.  In f6a7086, we introduced the use of a
tools container to pipe the JSON output through `jq` to hide the noisy
keys.  This is basically the same implementation.

(We probably should consolidate the two roles, but that is for another
PR...)