### PR TITLE
i-s-t: add test for non-priv systemd container

### DIFF
--- a/roles/docker_build/files/centos/systemd_httpd/Dockerfile
+++ b/roles/docker_build/files/centos/systemd_httpd/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.centos.org/centos/centos:latest
+LABEL maintainer="Micah Abbott <miabbott@redhat.com>" \
+      version=1.0
+
+ENV container docker
+
+ADD makecache.sh /
+
+RUN /makecache.sh && \
+    yum -y install httpd && \
+    yum clean all && \
+    systemctl enable httpd
+
+STOPSIGNAL SIGRTMIN+3
+EXPOSE 80
+
+ENTRYPOINT [ "/sbin/init" ]

--- a/roles/docker_build/files/centos/systemd_httpd/makecache.sh
+++ b/roles/docker_build/files/centos/systemd_httpd/makecache.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xeou pipefail
+retries=5
+while [ $retries -gt 0 ]; do
+	if yum makecache; then
+		break
+	fi
+	retries=$((retries - 1))
+done
+

--- a/roles/docker_build/files/fedora/systemd_httpd/Dockerfile
+++ b/roles/docker_build/files/fedora/systemd_httpd/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.fedoraproject.org/fedora:latest
+LABEL maintainer="Micah Abbott <miabbott@redhat.com>" \
+      version=1.0
+
+ENV container docker
+
+ADD makecache.sh /
+
+RUN /makecache.sh && \
+    dnf -y install httpd && \
+    dnf clean all && \
+    systemctl enable httpd
+
+STOPSIGNAL SIGRTMIN+3
+EXPOSE 80
+
+ENTRYPOINT [ "/sbin/init" ]

--- a/roles/docker_build/files/fedora/systemd_httpd/makecache.sh
+++ b/roles/docker_build/files/fedora/systemd_httpd/makecache.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xeou pipefail
+retries=5
+while [ $retries -gt 0 ]; do
+	if yum makecache; then
+		break
+	fi
+	retries=$((retries - 1))
+done
+

--- a/roles/docker_build/files/rhel7/systemd_httpd/Dockerfile
+++ b/roles/docker_build/files/rhel7/systemd_httpd/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.access.redhat.com/rhel7:latest
+LABEL maintainer="Micah Abbott <miabbott@redhat.com>" \
+      version=1.0
+
+ENV container docker
+
+ADD makecache.sh /
+
+RUN /makecache.sh && \
+    yum install --disablerepo=\* \
+                --enablerepo=rhel-7-server-rpms \
+                -y httpd && \
+    yum clean all && \
+    systemctl enable httpd
+
+STOPSIGNAL SIGRTMIN+3
+EXPOSE 80
+
+ENTRYPOINT [ "/sbin/init" ]

--- a/roles/docker_build/files/rhel7/systemd_httpd/makecache.sh
+++ b/roles/docker_build/files/rhel7/systemd_httpd/makecache.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xeou pipefail
+retries=5
+while [ $retries -gt 0 ]; do
+	if yum --disablerepo=\* --enablerepo=rhel-7-server-rpms makecache; then
+		break
+	fi
+	retries=$((retries - 1))
+done
+

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -366,6 +366,16 @@
       tags:
         - docker_rm_container_again
 
+    # Configure container_manage_cgroup boolean
+    # See - https://bugzilla.redhat.com/show_bug.cgi?id=1510139
+    #     - https://bugzilla.redhat.com/show_bug.cgi?id=1554881
+    - when: ansible_distribution == "RedHat" or
+            ansible_distribution == "Fedora"
+      role: selinux_boolean
+      g_seboolean: "container_manage_cgroup"
+      tags:
+        - container_manage_cgroup_bool
+
     # TEST
     # Build non-priviledged systemd httpd container
     - role: docker_build

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -375,6 +375,7 @@
       g_seboolean: "container_manage_cgroup"
       tags:
         - container_manage_cgroup_bool
+        - non_priv_systemd_httpd_container
 
     # TEST
     # Build non-priviledged systemd httpd container
@@ -383,6 +384,7 @@
       db_image_name: "{{ g_osname }}_systemd_httpd"
       tags:
         - docker_build_systemd
+        - non_priv_systemd_httpd_container
 
     # TEST
     # Run non-privileged systemd httpd container
@@ -391,6 +393,7 @@
       dr_run_options: "-d -p 80:80"
       tags:
         - docker_run_systemd
+        - non_priv_systemd_httpd_container
 
     # TEST
     # Verify that port 80 is open and the URL is accessible
@@ -399,6 +402,7 @@
       cop_url: "http://localhost:80/"
       tags:
         - check_open_port_systemd
+        - non_priv_systemd_httpd_container
 
     # TEST
     # Remove the non-privileged systemd httpd container
@@ -406,6 +410,7 @@
       drc_container_name: "{{ g_osname }}_systemd_httpd"
       tags:
         - docker_rm_container_systemd
+        - non_priv_systemd_httpd_container
 
     # TEST
     # Install, run and uninstall cockpit using atomic command
@@ -756,6 +761,7 @@
       dr_run_options: "-d -p 80:80"
       tags:
         - docker_run_systemd
+        - non_priv_systemd_httpd_container
 
     # Verify that port 80 is open and URL is accessible
     - role: check_open_port
@@ -763,12 +769,14 @@
       cop_url: "http://localhost:80/"
       tags:
         - check_open_port_systemd
+        - non_priv_systemd_httpd_container
 
     # Remove the systemd httpd container
     - role: docker_rm_container
       drc_container_name: "{{ g_osname }}_systemd_httpd"
       tags:
         - docker_rm_container_systemd
+        - non_priv_systemd_httpd_container
 
     # Remove all things docker
     - role: docker_remove_all

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -367,6 +367,37 @@
         - docker_rm_container_again
 
     # TEST
+    # Build non-priviledged systemd httpd container
+    - role: docker_build
+      db_src: "roles/docker_build/files/{{ g_osname }}/systemd_httpd/"
+      db_image_name: "{{ g_osname }}_systemd_httpd"
+      tags:
+        - docker_build_systemd
+
+    # TEST
+    # Run non-privileged systemd httpd container
+    - role: docker_run
+      dr_image_name: "{{ g_osname }}_systemd_httpd"
+      dr_run_options: "-d -p 80:80"
+      tags:
+        - docker_run_systemd
+
+    # TEST
+    # Verify that port 80 is open and the URL is accessible
+    - role: check_open_port
+      cop_port: "80"
+      cop_url: "http://localhost:80/"
+      tags:
+        - check_open_port_systemd
+
+    # TEST
+    # Remove the non-privileged systemd httpd container
+    - role: docker_rm_container
+      drc_container_name: "{{ g_osname }}_systemd_httpd"
+      tags:
+        - docker_rm_container_systemd
+
+    # TEST
     # Install, run and uninstall cockpit using atomic command
     - role: atomic_installation_verify
       tags:
@@ -708,6 +739,27 @@
       tags:
         - docker_rmi
 
+    # TEST
+    # Verify we can start the non-privileged systemd httpd container
+    - role: docker_run
+      dr_image_name: "{{ g_osname }}_systemd_httpd"
+      dr_run_options: "-d -p 80:80"
+      tags:
+        - docker_run_systemd
+
+    # Verify that port 80 is open and URL is accessible
+    - role: check_open_port
+      cop_port: "80"
+      cop_url: "http://localhost:80/"
+      tags:
+        - check_open_port_systemd
+
+    # Remove the systemd httpd container
+    - role: docker_rm_container
+      drc_container_name: "{{ g_osname }}_systemd_httpd"
+      tags:
+        - docker_rm_container_systemd
+
     # Remove all things docker
     - role: docker_remove_all
       tags:
@@ -748,7 +800,7 @@
       tags:
         - reboot_post_upgrade
 
-# --
+# ---
 
 - name: Improved Sanity Test - Post-Rollback
   hosts: all


### PR DESCRIPTION
Since it is possible to run systemd in a container without the
`--privileged` flag, we decided we should have a test for this going
forward.

This change adds in the files necessary to build an `httpd` container
that uses `systemd` as its init mechanism.  Additionally, we add the
building/running of said container to the `improved-sanity-test`.