### PR TITLE
 k8s-cluster: fix test for F27AH

### DIFF
--- a/roles/k8_cluster_services_rc_setup/meta/main.yml
+++ b/roles/k8_cluster_services_rc_setup/meta/main.yml
@@ -1,2 +1,5 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: kubernetes_set_facts

--- a/roles/k8_cluster_services_rc_setup/tasks/main.yml
+++ b/roles/k8_cluster_services_rc_setup/tasks/main.yml
@@ -3,80 +3,73 @@
 #  This role sets up the replication controller and services for the webserver
 #  and database server
 #
-  - name: Fail if ansible_docker0.ipv4.address is not defined
-    when: ansible_docker0.ipv4.address is not defined
-    fail:
-      msg: "ansible_docker0.ipv4.address it not defined!"
-    run_once: true
+- name: Fail if kubectl_path is not defined
+  when: kubectl_path is not defined
+  fail:
+    msg: |
+      This role requires that `kubectl_path` be defined before it can be used.
+
+- name: Fail if ansible_docker0.ipv4.address is not defined
+  when: ansible_docker0.ipv4.address is not defined
+  fail:
+    msg: "ansible_docker0.ipv4.address it not defined!"
+  run_once: true
 
 
-  - name: copy db-rc.yml, db-service.yml, webserver-rc.yml, webserver-service.yml
-    copy:
-      src=roles/k8_cluster_services_rc_setup/files/{{ item }}
-      dest=/root
-      owner=root
-      group=root
-      mode=0644
-    with_items:
-      - db-rc.yml
-      - db-service.yml
-      - webserver-rc.yml
-      - webserver-service.yml
+- name: copy db-rc.yml, db-service.yml, webserver-rc.yml, webserver-service.yml
+  copy:
+    src: "roles/k8_cluster_services_rc_setup/files/{{ item }}"
+    dest: "/root"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  with_items:
+    - db-rc.yml
+    - db-service.yml
+    - webserver-rc.yml
+    - webserver-service.yml
 
-  - name: insert private registry ip in webserver controller image yml
-    replace:
-      dest: /root/db-rc.yml
-      regexp: 'PRIVATE'
-      replace: '{{ ansible_docker0.ipv4.address }}'
+- name: insert private registry ip in webserver controller image yml
+  replace:
+    dest: /root/db-rc.yml
+    regexp: 'PRIVATE'
+    replace: '{{ ansible_docker0.ipv4.address }}'
 
-  - name: insert private registry ip in db controller image yml
-    replace:
-      dest: /root/webserver-rc.yml
-      regexp: 'PRIVATE'
-      replace: '{{ ansible_docker0.ipv4.address }}'
+- name: insert private registry ip in db controller image yml
+  replace:
+    dest: /root/webserver-rc.yml
+    regexp: 'PRIVATE'
+    replace: '{{ ansible_docker0.ipv4.address }}'
 
-  - name: wait for kubernetes apiserver to be available
-    wait_for:
-      port: 8080
-      timeout: 120
+- name: wait for kubernetes apiserver to be available
+  wait_for:
+    port: 8080
+    timeout: 120
 
-  - name: Define kubectl path for F27AH
-    when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
-          (ansible_distribution == "CentOSDev")
-    set_fact:
-      kubectl_path: "/usr/local/bin/kubectl"
+- name: create db and webserver service
+  command: "{{ kubectl_path }} create -f /root/{{ item }}"
+  with_items:
+    - db-service.yml
+    - webserver-service.yml
+  ignore_errors: True
 
-  - name: Define kubectl path for F26AH, Centos/RHEL
-    when: (ansible_distribution == "RedHat") or
-          (ansible_distribution == "Fedora" and ansible_distribution_major_version < '27') or
-          (ansible_distribution == "CentOS")
-    set_fact:
-      kubectl_path: "/usr/bin/kubectl"
+- name: create db and webserver replication controller
+  command: "{{ kubectl_path }} create -f /root/{{ item }}"
+  with_items:
+    - db-rc.yml
+    - webserver-rc.yml
+  ignore_errors: True
 
-  - name: create db and webserver service
-    command: "{{ kubectl_path }} create -f /root/{{ item }}"
-    with_items:
-      - db-service.yml
-      - webserver-service.yml
-    ignore_errors: True
+- name: verify db pod is running
+  shell: "{{ kubectl_path }} get pods | grep db-controller"
+  register: output
+  until: output.stdout.find("Running") > -1
+  retries: 12
+  delay: 10
 
-  - name: create db and webserver replication controller
-    command: "{{ kubectl_path }} create -f /root/{{ item }}"
-    with_items:
-      - db-rc.yml
-      - webserver-rc.yml
-    ignore_errors: True
-
-  - name: verify db pod is running
-    shell: "{{ kubectl_path }} get pods | grep db-controller"
-    register: output
-    until: output.stdout.find("Running") > -1
-    retries: 12
-    delay: 10
-
-  - name: verify webserver-controller is running
-    shell: "{{ kubectl_path }} get pods | grep webserver-controller"
-    register: output
-    until: output.stdout.find("Running") > -1
-    retries: 12
-    delay: 10
+- name: verify webserver-controller is running
+  shell: "{{ kubectl_path }} get pods | grep webserver-controller"
+  register: output
+  until: output.stdout.find("Running") > -1
+  retries: 12
+  delay: 10

--- a/roles/k8_cluster_services_rc_setup/tasks/main.yml
+++ b/roles/k8_cluster_services_rc_setup/tasks/main.yml
@@ -25,45 +25,57 @@
 
   - name: insert private registry ip in webserver controller image yml
     replace:
-      dest=/root/db-rc.yml
-      regexp='PRIVATE'
-      replace='{{ ansible_docker0.ipv4.address }}'
+      dest: /root/db-rc.yml
+      regexp: 'PRIVATE'
+      replace: '{{ ansible_docker0.ipv4.address }}'
 
   - name: insert private registry ip in db controller image yml
     replace:
-      dest=/root/webserver-rc.yml
-      regexp='PRIVATE'
-      replace='{{ ansible_docker0.ipv4.address }}'
+      dest: /root/webserver-rc.yml
+      regexp: 'PRIVATE'
+      replace: '{{ ansible_docker0.ipv4.address }}'
 
   - name: wait for kubernetes apiserver to be available
     wait_for:
       port: 8080
       timeout: 120
 
+  - name: Define kubectl path for F27AH
+    when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+          (ansible_distribution == "CentOSDev")
+    set_fact:
+      kubectl_path: "/usr/local/bin/kubectl"
+
+  - name: Define kubectl path for F26AH, Centos/RHEL
+    when: (ansible_distribution == "RedHat") or
+          (ansible_distribution == "Fedora" and ansible_distribution_major_version < '27') or
+          (ansible_distribution == "CentOS")
+    set_fact:
+      kubectl_path: "/usr/bin/kubectl"
 
   - name: create db and webserver service
-    command: kubectl create -f /root/{{ item }}
+    command: "{{ kubectl_path }} create -f /root/{{ item }}"
     with_items:
       - db-service.yml
       - webserver-service.yml
     ignore_errors: True
 
   - name: create db and webserver replication controller
-    command: kubectl create -f /root/{{ item }}
+    command: "{{ kubectl_path }} create -f /root/{{ item }}"
     with_items:
       - db-rc.yml
       - webserver-rc.yml
     ignore_errors: True
 
   - name: verify db pod is running
-    shell: kubectl get pods | grep db-controller
+    shell: "{{ kubectl_path }} get pods | grep db-controller"
     register: output
     until: output.stdout.find("Running") > -1
     retries: 12
     delay: 10
 
   - name: verify webserver-controller is running
-    shell: kubectl get pods | grep webserver-controller
+    shell: "{{ kubectl_path }} get pods | grep webserver-controller"
     register: output
     until: output.stdout.find("Running") > -1
     retries: 12

--- a/roles/k8_remove_all/meta/main.yml
+++ b/roles/k8_remove_all/meta/main.yml
@@ -1,2 +1,5 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: kubernetes_set_facts

--- a/roles/k8_remove_all/tasks/main.yml
+++ b/roles/k8_remove_all/tasks/main.yml
@@ -1,35 +1,15 @@
 ---
-- name: Remove all the manifests
-  file:
-    path: "/etc/kubernetes/manifests/{{ item }}"
-    state: absent
-  with_items:
-    - apiserver-pod.json
-    - controller-mgr-pod.json
-    - scheduler-pod.json
-
-- name: Disable services
-  service:
-    name: "{{ item }}"
-    enabled: no
-    state: stopped
-  with_items:
-    - kube-proxy
-    - kubelet
-
-- name: Define kubectl path for F27AH
-  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
-        (ansible_distribution == "CentOSDev")
-  set_fact:
-    kubectl_path: "/usr/local/bin/kubectl"
-
-- name: Define kubectl path for F26AH, Centos/RHEL
-  when: (ansible_distribution == "RedHat") or
-        (ansible_distribution == "Fedora" and ansible_distribution_major_version < '27') or
-        (ansible_distribution == "CentOS")
-  set_fact:
-    kubectl_path: "/usr/bin/kubectl"
-
+# vim: set ft=ansible:
+#
+# This role removes any manifest files, kube services, kube rcs, and kube
+# pods from the host.  It has a dependency on the `kubernetes_set_facts`
+# role
+#
+- name: Fail if kubectl_path is not defined
+  when: kubectl_path is not defined
+  fail:
+    msg: |
+      This role requires that `kubectl_path` is defined before it can be used.
 
 - name: Remove all services
   command: "{{ kubectl_path }} delete svc --all"
@@ -39,3 +19,34 @@
 
 - name: Remove all pods
   command: "{{ kubectl_path }} delete po --all"
+
+- name: Remove all the manifests
+  file:
+    path: "/etc/kubernetes/manifests/{{ item }}"
+    state: absent
+  with_items:
+    - apiserver-pod.json
+    - controller-mgr-pod.json
+    - scheduler-pod.json
+
+- name: Disable system container services
+  when: kube_system_containers
+  service:
+    name: "{{ item }}"
+    enabled: false
+    state: "stopped"
+  with_items:
+    - kube-apiserver
+    - kube-controller-manager
+    - kube-scheduler
+
+- name: Disable core kube/etcd services
+  service:
+    name: "{{ item }}"
+    enabled: false
+    state: "stopped"
+  with_items:
+    - kube-proxy
+    - kubelet
+    - etcd
+

--- a/roles/k8_remove_all/tasks/main.yml
+++ b/roles/k8_remove_all/tasks/main.yml
@@ -17,11 +17,25 @@
     - kube-proxy
     - kubelet
 
+- name: Define kubectl path for F27AH
+  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+        (ansible_distribution == "CentOSDev")
+  set_fact:
+    kubectl_path: "/usr/local/bin/kubectl"
+
+- name: Define kubectl path for F26AH, Centos/RHEL
+  when: (ansible_distribution == "RedHat") or
+        (ansible_distribution == "Fedora" and ansible_distribution_major_version < '27') or
+        (ansible_distribution == "CentOS")
+  set_fact:
+    kubectl_path: "/usr/bin/kubectl"
+
+
 - name: Remove all services
-  command: kubectl delete svc --all
+  command: "{{ kubectl_path }} delete svc --all"
 
 - name: Remove all RCs
-  command: kubectl delete rc --all
+  command: "{{ kubectl_path }} delete rc --all"
 
 - name: Remove all pods
-  command: kubectl delete po --all
+  command: "{{ kubectl_path }} delete po --all"

--- a/roles/kubernetes_set_facts/meta/main.yml
+++ b/roles/kubernetes_set_facts/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/kubernetes_set_facts/tasks/main.yml
+++ b/roles/kubernetes_set_facts/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# vim: set ft=ansible:
+#
+# This role sets up some facts related kubernetes that can be used by other
+# roles as a dependency.  The initial target is the `kubernetes_setup` role.
+#
+- name: Get kubernetes version
+  include_role:
+    name: rpm_version
+  vars:
+    rv_rpms: kubernetes-node
+
+- name: Define kube 1.5 vars
+  when:
+    - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '<')
+  set_fact:
+    kube_maj_ver: "1.5"
+    kube_apiserver: "registry.access.redhat.com/rhel7/kubernetes-apiserver"
+    kube_controller_manager: "registry.access.redhat.com/rhel7/kubernetes-controller-mgr"
+    kube_scheduler: "registry.access.redhat.com/rhel7/kubernetes-scheduler"
+    kube_system_containers: false
+
+- name: Define kube 1.6 images
+  when:
+    - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '>=')
+  set_fact:
+    kube_maj_ver: "1.6"
+    kube_apiserver: "registry.fedoraproject.org/f26/kubernetes-apiserver"
+    kube_controller_manager: "registry.fedoraproject.org/f26/kubernetes-controller-manager"
+    kube_scheduler: "registry.fedoraproject.org/f26/kubernetes-scheduler"
+    kube_system_containers: false
+
+- name: Define kube 1.7 master nodes, worker nodes and etcd images
+  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+        (ansible_distribution == "CentOSDev")
+  set_fact:
+    kube_maj_ver: "1.7"
+    kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"
+    kube_controller_manager: "registry.fedoraproject.org/f27/kubernetes-controller-manager"
+    kube_scheduler: "registry.fedoraproject.org/f27/kubernetes-scheduler"
+    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet"
+    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
+    etcd: "registry.fedoraproject.org/f27/etcd"
+    kube_system_containers: true

--- a/roles/kubernetes_set_facts/tasks/main.yml
+++ b/roles/kubernetes_set_facts/tasks/main.yml
@@ -20,6 +20,7 @@
     kube_controller_manager: "registry.access.redhat.com/rhel7/kubernetes-controller-mgr"
     kube_scheduler: "registry.access.redhat.com/rhel7/kubernetes-scheduler"
     kube_system_containers: false
+    kubectl_path: "/usr/bin/kubectl"
 
 - name: Define kube 1.6 images
   when:
@@ -31,6 +32,7 @@
     kube_controller_manager: "registry.fedoraproject.org/f26/kubernetes-controller-manager"
     kube_scheduler: "registry.fedoraproject.org/f26/kubernetes-scheduler"
     kube_system_containers: false
+    kubectl_path: "/usr/bin/kubectl"
 
 - name: Define kube 1.7 master nodes, worker nodes and etcd images
   when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
@@ -44,3 +46,4 @@
     kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
     etcd: "registry.fedoraproject.org/f27/etcd"
     kube_system_containers: true
+    kubectl_path: "/usr/local/bin/kubectl"

--- a/roles/kubernetes_setup/meta/main.yml
+++ b/roles/kubernetes_setup/meta/main.yml
@@ -1,2 +1,5 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: kubernetes_set_facts

--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -1,49 +1,17 @@
 ---
+# vim: set ft=ansible:
 #
-#  This role sets up kubernetes apiserver, controller-mgr, and scheduler pods
+# This role sets up kubernetes apiserver, controller-mgr, and scheduler pods.
+# It requires that the `kubernetes_set_fact` role be run before it can be
+# successfully used.
 #
-- name: Get kubernetes version
-  include_role:
-    name: rpm_version
-  vars:
-    rv_rpms: kubernetes-node
-
-- name: Define kube 1.5 vars
-  when:
-    - g_atomic_host is defined
-    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '<')
-  set_fact:
-    kube_maj_ver: "1.5"
-    kube_apiserver: "registry.access.redhat.com/rhel7/kubernetes-apiserver"
-    kube_controller_manager: "registry.access.redhat.com/rhel7/kubernetes-controller-mgr"
-    kube_scheduler: "registry.access.redhat.com/rhel7/kubernetes-scheduler"
-    use_system_containers: false
-
-- name: Define kube 1.6 images
-  when:
-    - g_atomic_host is defined
-    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '>=')
-  set_fact:
-    kube_maj_ver: "1.6"
-    kube_apiserver: "registry.fedoraproject.org/f26/kubernetes-apiserver"
-    kube_controller_manager: "registry.fedoraproject.org/f26/kubernetes-controller-manager"
-    kube_scheduler: "registry.fedoraproject.org/f26/kubernetes-scheduler"
-    use_system_containers: false
-
-- name: Define kube 1.7 master nodes, worker nodes and etcd images
-  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
-        (ansible_distribution == "CentOSDev")
-  set_fact:
-    kube_maj_ver: "1.7"
-    kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"
-    kube_controller_manager: "registry.fedoraproject.org/f27/kubernetes-controller-manager"
-    kube_scheduler: "registry.fedoraproject.org/f27/kubernetes-scheduler"
-    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet"
-    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
-    etcd: "registry.fedoraproject.org/f27/etcd"
-    use_system_containers: true
-
-- when: use_system_containers
+- name: Fail if kube_system_containers is not defined
+  when: kube_system_containers is not defined
+  fail:
+    msg: |
+      This role requires that the `kubernetes_set_fact` role is run
+      before it can be used.
+- when: kube_system_containers
   block:
     - name: Pull k8s and etcd images from the registry
       command: "atomic pull --storage ostree {{ item }}"
@@ -109,10 +77,9 @@
         - "kube-controller-manager"
         - "kube-scheduler"
 
-- when: not use_system_containers
+- when: not kube_system_containers
   block:
     - name: pull kubernetes api-server, controller-mgr, scheduler
-      when: not use_system_containers
       command: docker pull {{ item }}
       register: docker_pull
       retries: 6

--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -17,6 +17,7 @@
     kube_apiserver: "registry.access.redhat.com/rhel7/kubernetes-apiserver"
     kube_controller_manager: "registry.access.redhat.com/rhel7/kubernetes-controller-mgr"
     kube_scheduler: "registry.access.redhat.com/rhel7/kubernetes-scheduler"
+    use_system_containers: false
 
 - name: Define kube 1.6 images
   when:
@@ -27,11 +28,11 @@
     kube_apiserver: "registry.fedoraproject.org/f26/kubernetes-apiserver"
     kube_controller_manager: "registry.fedoraproject.org/f26/kubernetes-controller-manager"
     kube_scheduler: "registry.fedoraproject.org/f26/kubernetes-scheduler"
+    use_system_containers: false
 
 - name: Define kube 1.7 master nodes, worker nodes and etcd images
   when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
         (ansible_distribution == "CentOSDev")
-
   set_fact:
     kube_maj_ver: "1.7"
     kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"
@@ -40,25 +41,16 @@
     kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet"
     kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
     etcd: "registry.fedoraproject.org/f27/etcd"
+    use_system_containers: true
 
-- name: pull kubernetes api-server, controller-mgr, scheduler
-  when:
-    - g_atomic_host is defined
-  command: docker pull {{ item }}
-  register: pull
-  failed_when: item not in pull.stdout
-  with_items:
-    - "{{ kube_apiserver }}"
-    - "{{ kube_controller_manager }}"
-    - "{{ kube_scheduler }}"
-
-- block:
-    - name: Pull k8 and etcd images from the registry
-      command:  atomic pull --storage ostree "{{ item }}"
-      register: ap
-      retries: 3
+- when: use_system_containers
+  block:
+    - name: Pull k8s and etcd images from the registry
+      command: "atomic pull --storage ostree {{ item }}"
+      register: atomic_pull
+      retries: 6
       delay: 10
-      until: "ap.rc == 0"
+      until: atomic_pull|success
       with_items:
         - "{{ kube_apiserver }}"
         - "{{ kube_controller_manager }}"
@@ -67,105 +59,123 @@
         - "{{ kube_proxy }}"
         - "{{ etcd }}"
 
-    - name: Install master node system containers that is, k8-apiserver, k8-controller_manager and k8-scheduler
-      command: "{{ item }}"
+    - name: Install etcd + k8s system containers
+      command: "atomic install --system --system-package=no {{ item }}"
       with_items:
-        - atomic install --system --system-package=no --name kube-apiserver {{ kube_apiserver }}
-        - atomic install --system --system-package=no --name kube-controller-manager {{ kube_controller_manager }}
-        - atomic install --system --system-package=no --name kube-scheduler {{ kube_scheduler }}
+        - "--name etcd {{ etcd }}"
+        - "--name kube-apiserver {{ kube_apiserver }}"
+        - "--name kube-controller-manager {{ kube_controller_manager }}"
+        - "--name kube-scheduler {{ kube_scheduler }}"
+        - "--name kubelet {{ kube_kubelet }}"
+        - "--name kube-proxy {{ kube_proxy }}"
 
-    - name: Install worker node system containers, that is k8-kubelet, k8-proxy and etcd
-      command: "{{ item }}"
+    # Start etcd a little early to allow it to get setup + ready
+    - name: Start etcd
+      service:
+        name: 'etcd'
+        state: 'started'
+        enabled: true
+
+    - name: Edit /etc/kubernetes/apiserver
+      replace:
+        dest: "/etc/kubernetes/apiserver"
+        regexp: "^KUBE_ADMISSION_CONTROL=.*$"
+        replace: 'KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ResourceQuota'
+
+    # Start apiserver to get it primed
+    - name: Start apiserver
+      service:
+        name: 'kube-apiserver'
+        state: 'started'
+        enabled: true
+
+    - name: Add args to /etc/kubernetes/kubelet
+      lineinfile:
+        dest: /etc/kubernetes/kubelet
+        backup: true
+        backrefs: true
+        regexp: '(^KUBELET_ARGS=\".*)\"\s*$'
+        line: '\1 --register-node=true'
+
+    # Start the rest of the services
+    - name: Start kubernetes services
+      service:
+        name: "{{ item }}"
+        state: "started"
+        enabled: true
       with_items:
-        - atomic install --system --system-package=no --name kubelet {{ kube_kubelet }}
-        - atomic install --system --system-package=no --name kube-proxy {{ kube_proxy }}
-        - atomic install --system --system-package=no --storage=ostree --name etcd {{ etcd }}
-  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
-        (ansible_distribution == "CentOSDev")
+        - "kubelet"
+        - "kube-proxy"
+        - "kube-controller-manager"
+        - "kube-scheduler"
 
-- name: make db directory
-  file:
-    path: /etc/kubernetes/manifests
-    state: directory
-    mode: 0755
+- when: not use_system_containers
+  block:
+    - name: pull kubernetes api-server, controller-mgr, scheduler
+      when: not use_system_containers
+      command: docker pull {{ item }}
+      register: docker_pull
+      retries: 6
+      delay: 10
+      until: docker_pull|success
+      with_items:
+        - "{{ kube_apiserver }}"
+        - "{{ kube_controller_manager }}"
+        - "{{ kube_scheduler }}"
 
-- name: template out apiserver, controller-manager, and scheduler pods
-  template:
-    src: roles/kubernetes_setup/files/{{ item }}.j2
-    dest: /etc/kubernetes/manifests/{{ item }}.json
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - apiserver-pod
-    - controller-mgr-pod
-    - scheduler-pod
+    - name: make db directory
+      file:
+        path: /etc/kubernetes/manifests
+        state: directory
+        mode: 0755
 
-# Thank you based Google gods
-# https://groups.google.com/d/msg/ansible-project/JvHfchsgRaU/Vw_CzBbvadgJ
-#
-# Shoddy explanation of regexp:
-#   - open of capture group 1: matched by (
-#   - <startofline>: matched by ^
-#   - the string "KUBELET_ARGS=": matched literally (double quote is escaped)
-#   - any characters after above string: matched by .*
-#   - close of capture group 1: matched by )
-#   - the closing " char: matched by \"
-#   - any spaces/tabs: matched by \s*
-#   - <endofline>: matched by $
-#
-# The capture group 1 is referred to as \1 in the 'line:' statement and
-# will be used as the begining of the line to be inserted into the file.
-# Thus, any exiting values to KUBELET_ARGS are preserved and the two
-# new options (--register-node and --pod-manifest-path) are cleanly
-# appended.
-- name: add kubelet args
-  lineinfile:
-    dest: /etc/kubernetes/kubelet
-    backup: true
-    backrefs: true
-    regexp: '(^KUBELET_ARGS=\".*)\"\s*$'
-    line: '\1 --register-node=true --pod-manifest-path=/etc/kubernetes/manifests/"'
+    - name: template out apiserver, controller-manager, and scheduler pods
+      template:
+        src: roles/kubernetes_setup/files/{{ item }}.j2
+        dest: /etc/kubernetes/manifests/{{ item }}.json
+        owner: root
+        group: root
+        mode: 0644
+      with_items:
+        - apiserver-pod
+        - controller-mgr-pod
+        - scheduler-pod
 
-- name: stop docker, etcd, kube-proxy, kubelet
-  service:
-    name: "{{ item }}"
-    state: stopped
-  with_items:
-    - docker
-    - etcd
-    - kube-proxy
-    - kubelet
+    # Thank you based Google gods
+    # https://groups.google.com/d/msg/ansible-project/JvHfchsgRaU/Vw_CzBbvadgJ
+    #
+    # Shoddy explanation of regexp:
+    #   - open of capture group 1: matched by (
+    #   - <startofline>: matched by ^
+    #   - the string "KUBELET_ARGS=": matched literally (double quote is escaped)
+    #   - any characters after above string: matched by .*
+    #   - close of capture group 1: matched by )
+    #   - the closing " char: matched by \"
+    #   - any spaces/tabs: matched by \s*
+    #   - <endofline>: matched by $
+    #
+    # The capture group 1 is referred to as \1 in the 'line:' statement and
+    # will be used as the begining of the line to be inserted into the file.
+    # Thus, any exiting values to KUBELET_ARGS are preserved and the two
+    # new options (--register-node and --pod-manifest-path) are cleanly
+    # appended.
+    - name: add kubelet args
+      lineinfile:
+        dest: /etc/kubernetes/kubelet
+        backup: true
+        backrefs: true
+        regexp: '(^KUBELET_ARGS=\".*)\"\s*$'
+        line: '\1 --register-node=true --pod-manifest-path=/etc/kubernetes/manifests/"'
 
-- name: start docker, etcd, kube-proxy, kubelet
-  service:
-    name: "{{ item }}"
-    state: started
-    enabled: yes
-  with_items:
-    - docker
-    - etcd
-    - kube-proxy
-    - kubelet
-
-- name: stop docker, kube-proxy.service, kubelet.service
-  service:
-    name: "{{ item }}"
-    state: stopped
-  with_items:
-    - docker
-    - kube-proxy.service
-    - kubelet.service
-
-- name: start docker, kube-proxy.service, kubelet.service
-  service:
-    name: "{{ item }}"
-    state: started
-    enabled: yes
-  with_items:
-    - docker
-    - kube-proxy.service
-    - kubelet.service
+    - name: start etcd, kube-proxy, kubelet
+      service:
+        name: "{{ item }}"
+        state: started
+        enabled: yes
+      with_items:
+        - etcd
+        - kubelet
+        - kube-proxy
 
 - name: test etcd
   command: curl http://localhost:2379/version

--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -9,7 +9,9 @@
     rv_rpms: kubernetes-node
 
 - name: Define kube 1.5 vars
-  when: g_atomic_host['kubernetes-node'] | version_compare('1.6', '<')
+  when:
+    - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '<')
   set_fact:
     kube_maj_ver: "1.5"
     kube_apiserver: "registry.access.redhat.com/rhel7/kubernetes-apiserver"
@@ -17,14 +19,31 @@
     kube_scheduler: "registry.access.redhat.com/rhel7/kubernetes-scheduler"
 
 - name: Define kube 1.6 images
-  when: g_atomic_host['kubernetes-node'] | version_compare('1.6', '>=')
+  when:
+    - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] | version_compare('1.6', '>=')
   set_fact:
     kube_maj_ver: "1.6"
     kube_apiserver: "registry.fedoraproject.org/f26/kubernetes-apiserver"
     kube_controller_manager: "registry.fedoraproject.org/f26/kubernetes-controller-manager"
     kube_scheduler: "registry.fedoraproject.org/f26/kubernetes-scheduler"
 
+- name: Define kube 1.7 master nodes, worker nodes and etcd images
+  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+        (ansible_distribution == "CentOSDev")
+
+  set_fact:
+    kube_maj_ver: "1.7"
+    kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"
+    kube_controller_manager: "registry.fedoraproject.org/f27/kubernetes-controller-manager"
+    kube_scheduler: "registry.fedoraproject.org/f27/kubernetes-scheduler"
+    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet"
+    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
+    etcd: "registry.fedoraproject.org/f27/etcd"
+
 - name: pull kubernetes api-server, controller-mgr, scheduler
+  when:
+    - g_atomic_host is defined
   command: docker pull {{ item }}
   register: pull
   failed_when: item not in pull.stdout
@@ -32,6 +51,37 @@
     - "{{ kube_apiserver }}"
     - "{{ kube_controller_manager }}"
     - "{{ kube_scheduler }}"
+
+- block:
+    - name: Pull k8 and etcd images from the registry
+      command:  atomic pull --storage ostree "{{ item }}"
+      register: ap
+      retries: 3
+      delay: 10
+      until: "ap.rc == 0"
+      with_items:
+        - "{{ kube_apiserver }}"
+        - "{{ kube_controller_manager }}"
+        - "{{ kube_scheduler }}"
+        - "{{ kube_kubelet }}"
+        - "{{ kube_proxy }}"
+        - "{{ etcd }}"
+
+    - name: Install master node system containers that is, k8-apiserver, k8-controller_manager and k8-scheduler
+      command: "{{ item }}"
+      with_items:
+        - atomic install --system --system-package=no --name kube-apiserver {{ kube_apiserver }}
+        - atomic install --system --system-package=no --name kube-controller-manager {{ kube_controller_manager }}
+        - atomic install --system --system-package=no --name kube-scheduler {{ kube_scheduler }}
+
+    - name: Install worker node system containers, that is k8-kubelet, k8-proxy and etcd
+      command: "{{ item }}"
+      with_items:
+        - atomic install --system --system-package=no --name kubelet {{ kube_kubelet }}
+        - atomic install --system --system-package=no --name kube-proxy {{ kube_proxy }}
+        - atomic install --system --system-package=no --storage=ostree --name etcd {{ etcd }}
+  when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
+        (ansible_distribution == "CentOSDev")
 
 - name: make db directory
   file:

--- a/roles/rpm_version/tasks/version.yml
+++ b/roles/rpm_version/tasks/version.yml
@@ -15,8 +15,10 @@
 - name: Determine version of {{ rv_rpm }}
   command: rpm -q --queryformat '%{VERSION}' {{ rv_rpm }}
   register: rpmq
+  ignore_errors: true
 
 - name: Set facts
+  when: rpmq.rc == 0
   set_fact:
     rv_version: "{{ rpmq.stdout }}"
     g_atomic_host: "{{ g_atomic_host|default({}) | combine( { rv_rpm: rpmq.stdout } ) }}"

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -20,9 +20,6 @@
   hosts: all
   become: true
 
-  vars_files:
-    - vars.yml
-
   roles:
     # This playbook requires Ansible 2.2 and an Atomic Host
     - role: ansible_version_check
@@ -50,6 +47,8 @@
 
     - when: ansible_distribution == "CentOSDev"
       role: resize_lv
+      rl_lvname: 'root'
+      rl_lvsize: '6'
       tags:
         - resize_lv
 

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -20,6 +20,9 @@
   hosts: all
   become: true
 
+  vars_files:
+    - vars.yml
+
   roles:
     # This playbook requires Ansible 2.2 and an Atomic Host
     - role: ansible_version_check
@@ -45,6 +48,11 @@
       tags:
         - docker_build_tag_push
 
+    - when: ansible_distribution == "CentOSDev"
+      role: resize_lv
+      tags:
+        - resize_lv
+
     - role: kubernetes_setup
       tags:
         - kubernetes_setup
@@ -54,7 +62,7 @@
         - k8_cluster_services_rc_setup
 
   post_tasks:
-    - name: check if everything works!
+    - name: Check if everything works!
       shell: curl http://localhost:80/cgi-bin/action | grep "RedHat rocks"
 
 

--- a/tests/k8-cluster/vars.yml
+++ b/tests/k8-cluster/vars.yml
@@ -1,0 +1,3 @@
+---
+rl_lvname: 'root'
+rl_lvsize: '6'

--- a/tests/k8-cluster/vars.yml
+++ b/tests/k8-cluster/vars.yml
@@ -1,3 +1,0 @@
----
-rl_lvname: 'root'
-rl_lvsize: '6'


### PR DESCRIPTION
In Fedora 27 Atomic Host, all of the `kubernetes` related packages
were removed from the host.  The replacement functionality is now
provided by system containers.

This set of changes reworks the `kubernetes_setup` role to utilize the
new system containers to bring up a single node cluster and then
proceed with the remaininder of the `k8s-cluster` test.

NOTE:  the system containers are only used in the case where the
`kubernetes` packages are not present on the host.  For other
platforms where they are present on the host, the original method of
using manifests continues to be used.

Many thanks to Kedar Bidarkar for starting this work!

