### PR TITLE
tree: use F27 containers where possible

### DIFF
--- a/roles/atomic_images_delete_all/tasks/main.yml
+++ b/roles/atomic_images_delete_all/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 # vim: set ft=ansible:
 #
+- name: Remove all containers
+  command: atomic --assumeyes containers delete --all --force
+  ignore_errors: yes
+
 - name: Remove all images
   command: atomic --assumeyes images delete --all --force
   ignore_errors: yes

--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Set cockpit container name for Fedora/CentOS
   when: "'CentOS' in ansible_distribution or ansible_distribution == 'Fedora'"
   set_fact:
-    cockpit_cname: "registry.fedoraproject.org/f26/cockpit"
+    cockpit_cname: "registry.fedoraproject.org/f27/cockpit"
 
 - name: Install cockpit container with tag
   command: "atomic install {{ cockpit_cname }}:latest"

--- a/roles/etcd_sys_container_install/tasks/main.yml
+++ b/roles/etcd_sys_container_install/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Set facts
   when: ansible_distribution != 'RedHat'
   set_fact:
-    etcd_image: 'registry.fedoraproject.org/f26/etcd'
+    etcd_image: 'registry.fedoraproject.org/f27/etcd'
     etcd_name: 'etcd'
 
 # The `aivc_atomic_install_cmd` is set by the required role:

--- a/tests/atomic/vars/centos.yml
+++ b/tests/atomic/vars/centos.yml
@@ -1,5 +1,5 @@
 ---
 cockpit_short_name: "cockpit/ws"
 cockpit_fq_name: "docker.io/cockpit/ws"
-cockpit_cname: "registry.fedoraproject.org/f26/cockpit"
+cockpit_cname: "registry.fedoraproject.org/f27/cockpit"
 cp_name: "cockpit"

--- a/tests/atomic/vars/centosdev.yml
+++ b/tests/atomic/vars/centosdev.yml
@@ -1,5 +1,5 @@
 ---
 cockpit_short_name: "cockpit/ws"
 cockpit_fq_name: "docker.io/cockpit/ws"
-cockpit_cname: "registry.fedoraproject.org/f26/cockpit"
+cockpit_cname: "registry.fedoraproject.org/f27/cockpit"
 cp_name: "cockpit"

--- a/tests/atomic/vars/fedora.yml
+++ b/tests/atomic/vars/fedora.yml
@@ -1,5 +1,5 @@
 ---
 cockpit_short_name: "cockpit/ws"
 cockpit_fq_name: "docker.io/cockpit/ws"
-cockpit_cname: "registry.fedoraproject.org/f26/cockpit"
+cockpit_cname: "registry.fedoraproject.org/f27/cockpit"
 cp_name: "cockpit"

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -54,9 +54,9 @@
     - name: Set facts
       when: ansible_distribution != 'RedHat'
       set_fact:
-        etcd_image: 'registry.fedoraproject.org/f26/etcd'
+        etcd_image: 'registry.fedoraproject.org/f27/etcd'
         etcd_name: 'etcd'
-        flannel_image: 'registry.fedoraproject.org/f26/flannel'
+        flannel_image: 'registry.fedoraproject.org/f27/flannel'
         flannel_name: 'flannel'
 
   roles:


### PR DESCRIPTION
It would probably best to start using Fedora 27 containers instead of
Fedora 26.  While Fedora 26 will be 'maintained' until a month after
Fedora 28, I think we will get better support from the Fedora
community if we use the most recent release.

Additionally, I had to tweak the `atomic_images_delete_all` role to
remove any containers first before removing the images.  (This might
have been an artifact that came from re-using some test VMs, but
should be safe to do either way.)