### PR TITLE
roles: new role to validate firewalld install/config

### DIFF
--- a/roles/firewalld_service_verify/meta/main.yml
+++ b/roles/firewalld_service_verify/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/firewalld_service_verify/tasks/main.yml
+++ b/roles/firewalld_service_verify/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+# vim: set ft=ansible:
+#
+# This role confirms that the 'firewalld' package/service is correctly
+# installed (or not installed) on the host under test.
+#
+- name: Default to firewalld being uninstalled
+  set_fact:
+    firewalld_installed: false
+
+- name: Determine if firewalld should be installed
+  when: (ansible_distribution == 'Fedora' and
+         ansible_distribution_major_version | version_compare('26', '>')) or
+        (ansible_distribution == 'RedHat' and
+         ansible_distribution_version | version_compare('7.4', '>'))
+  set_fact:
+    firewalld_installed: true
+
+- when: firewalld_installed
+  block:
+    - name: Verify firewalld package is installed
+      command: rpm -q firewalld
+
+    - name: Verify firewalld is disabled by default
+      command: systemctl is-enabled -q firewalld
+      register: is_enabled
+      failed_when: is_enabled.rc == 0
+
+    # Because of the declarative nature of Ansible, we don't have to perform
+    # a second check to see if the service was successfully enabled/started.
+    # If either of those conditions were not met, the task will fail
+    - name: Verify firewalld can be started/enabled successfully
+      service:
+        name: firewalld
+        enabled: true
+        state: 'started'
+
+    - name: Revert firewalld back to stopped/disabled
+      service:
+        name: firewalld
+        enabled: false
+        state: 'stopped'
+
+- when: not firewalld_installed
+  block:
+    - name: Verify firewalld package is not installed
+      command: rpm -q firewalld
+      register: rpmq
+      failed_when: rpmq.rc == 0
+
+    - name: Verify firewalld cannot be enabled/started
+      service:
+        name: firewalld
+        enabled: true
+        state: 'started'
+      register: enable_start
+      failed_when: enable_start|success

--- a/roles/firewalld_service_verify/tasks/main.yml
+++ b/roles/firewalld_service_verify/tasks/main.yml
@@ -24,7 +24,7 @@
     - name: Verify firewalld is disabled by default
       command: systemctl is-enabled -q firewalld
       register: is_enabled
-      failed_when: is_enabled.rc == 0
+      failed_when: is_enabled|success
 
     # Because of the declarative nature of Ansible, we don't have to perform
     # a second check to see if the service was successfully enabled/started.
@@ -46,7 +46,7 @@
     - name: Verify firewalld package is not installed
       command: rpm -q firewalld
       register: rpmq
-      failed_when: rpmq.rc == 0
+      failed_when: rpmq|success
 
     - name: Verify firewalld cannot be enabled/started
       service:

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -164,6 +164,12 @@
         - selinux_boolean
 
     # TEST
+    # Verify that 'firewalld' is correctly installed/configured
+    - role: firewalld_service_verify
+      tags:
+        - firewalld_service_verify
+
+    # TEST
     # Verify that the Docker storage defaults are correct
     - role: docker_storage_verify
       tags:
@@ -490,6 +496,12 @@
     - role: selinux_boolean_verify
       tags:
         - selinux_boolean_verify
+
+    # TEST
+    # Verify that 'firewalld' is correctly installed/configured
+    - role: firewalld_service_verify
+      tags:
+        - firewalld_service_verify
 
     # Verify that the Docker storage defaults haven't changed
     - role: docker_storage_verify


### PR DESCRIPTION
This introduces a new role which can be used to validate the
installation/configuration of the `firewalld` service.  It will
determine if the host under test should have `firewalld` installed and
how it should be configured if it is installed.

This initial attempt is very simple, but could be expanded to do more
complex checks if desired.

The role is used in the `improved-sanity-test` before the host is
upgraded and after upgrade.

Closes #315