### PR TITLE
k8s_set_facts: setup facts when kube node RPM not installed

### DIFF
--- a/roles/kubernetes_set_facts/tasks/main.yml
+++ b/roles/kubernetes_set_facts/tasks/main.yml
@@ -36,7 +36,8 @@
 
 - name: Define kube 1.7 master nodes, worker nodes and etcd images
   when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
-        (ansible_distribution == "CentOSDev")
+        (ansible_distribution == "CentOSDev") or
+        (g_atomic_host is not defined)
   set_fact:
     kube_maj_ver: "1.7"
     kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"


### PR DESCRIPTION
The logic for determining the use of system containers was missing a
case when the `kubernetes-node` RPM was not installed on the host, but
the host was also not a Fedora/CentOS platform.  For example, our
internal 'autobrew' streams.

This updates the logic to handle this case.