### PR TITLE
ci: enable extra args to be passed to .test_director

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -44,5 +44,5 @@ cluster:
 context: centos/7/atomic
 
 tests:
-  - ./test_director --skip-tags kernel_avc_denied
+  - ./.test_director --skip-tags kernel_avc_denied
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -25,11 +25,11 @@ inherit: true
 cluster:
   hosts:
     - name: testnode
-      distro: centos/7/atomic
+      distro: centos/7/atomic/continuous
   container:
       image: registry.fedoraproject.org/fedora:27
 
-context: centos/7/atomic
+context: centos/7/atomic/continuous
 
 ---
 inherit: true
@@ -37,8 +37,12 @@ inherit: true
 cluster:
   hosts:
     - name: testnode
-      distro: centos/7/atomic/continuous
+      distro: centos/7/atomic
   container:
       image: registry.fedoraproject.org/fedora:27
 
-context: centos/7/atomic/continuous
+context: centos/7/atomic
+
+tests:
+  - ./test_director --skip-tags kernel_avc_denied
+

--- a/.test_director
+++ b/.test_director
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -xeuo pipefail
 
-EXTRA_ARGS=""
-if [ $# -gt 0 ]; then
-    EXTRA_ARGS="$1"
-fi
-
 VIRTUAL_ENV_DISABLE_PROMPT=1
 
 if [ ! -d venv ]; then
@@ -23,7 +18,7 @@ NEW_TESTS=( $(git diff --name-only $(git merge-base origin/master HEAD) | grep '
 # no new tests found, just run improved sanity test
 if [ ${#NEW_TESTS[@]} -eq 0 ]; then
     ansible-playbook --syntax-check tests/improved-sanity-test/main.yml
-    ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml $EXTRA_ARGS
+    ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml "$@"
 else
     # added or modified tests found, iterate through and run each one
     printf '%s\n' "${NEW_TESTS[@]}"
@@ -31,7 +26,7 @@ else
         # diff may contain deleted tests so only run tests that exist
         if [ -f $NEW_TEST ]; then
             ansible-playbook --syntax-check $NEW_TEST
-            ansible-playbook -vi testnode, $NEW_TEST $EXTRA_ARGS
+            ansible-playbook -vi testnode, $NEW_TEST "$@"
         fi
     done
 fi

--- a/.test_director
+++ b/.test_director
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -xeuo pipefail
 
+EXTRA_ARGS=""
+if [ $# -gt 0 ]; then
+    EXTRA_ARGS="$1"
+fi
+
 VIRTUAL_ENV_DISABLE_PROMPT=1
 
 if [ ! -d venv ]; then
@@ -18,15 +23,15 @@ NEW_TESTS=( $(git diff --name-only $(git merge-base origin/master HEAD) | grep '
 # no new tests found, just run improved sanity test
 if [ ${#NEW_TESTS[@]} -eq 0 ]; then
     ansible-playbook --syntax-check tests/improved-sanity-test/main.yml
-    ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml
+    ansible-playbook -vi testnode, tests/improved-sanity-test/main.yml $EXTRA_ARGS
 else
     # added or modified tests found, iterate through and run each one
     printf '%s\n' "${NEW_TESTS[@]}"
     for NEW_TEST in "${NEW_TESTS[@]}"; do
         # diff may contain deleted tests so only run tests that exist
         if [ -f $NEW_TEST ]; then
-	    ansible-playbook --syntax-check $NEW_TEST
-            ansible-playbook -vi testnode, $NEW_TEST
+            ansible-playbook --syntax-check $NEW_TEST
+            ansible-playbook -vi testnode, $NEW_TEST $EXTRA_ARGS
         fi
     done
 fi


### PR DESCRIPTION
The `centos/7/atomic` context has been consistently failing because
there are AVC denials from the kernel that are present in the version
of CentOS AH we are using.  This is preventing any useful CI checks
from being run on that platform.

This change introduces a simple check to the `.test_director` script to
see if any arguments were passed to the script.  This way, we are able
to skip tags we know are causing problems in our CI checks.

In order to utilize this change, I re-arranged the order of contexts
in the `.papr.yml` file in order to maintain inheritence between the
contexts and only pass in the extra args to the `centos/7/atomic`
context.