### PR TITLE
Vagrantfile: major updates to get current with test states

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,34 +149,27 @@ handlers:
 ### Vagrant
 
 You can see how the playbooks would run by using the supplied
-Vagrantfile which defines multiple boxes to test with. The Vagrantfile
-requires a 'vagrant-reload' plugin available from the following GitHub repo:
+Vagrantfile which defines multiple boxes to test with.
 
-https://github.com/aidanns/vagrant-reload
-
-With the plugin installed, you should be able to choose a CentOS AH box, a
-Fedora 24/25 AH box, or a CentOS AH Continuous (CAHC) box.
+You should be able to choose a CentOS AH box, a Fedora 27 AH box,
+or a CentOS AH Continuous (CAHC) box.
 
 ```
 $ vagrant up centos
 
 or
 
-$ vagrant up {fedora24|fedora25}
+$ vagrant up fedora27
 
 or
 
 $ vagrant up cahc
 ```
 
-By default, the Vagrantfile will run the `tests/improved-sanity-test/main.yml`
-playbook after Vagrant completes the provisioning of the box.  The playbook
-which is run can be changed by setting the environment variable `PLAYBOOK_FILE`
-to point to a playbook in the repo.
+By default, the Vagrantfile will run the `tests/improved-sanity-test/main.yml`.
+The playbook which is run can be changed by setting the environment variable
+`PLAYBOOK_FILE` to point to a playbook in the repo.
 
 ```
 $ PLAYBOOK_FILE=tests/docker-swarm/main.yml vagrant up cahc
 ```
-
-**NOTE**: By default, the Vagrant boxes will provision HEAD-1 of the flavor of
-Atomic Host you want to bring up.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,12 +1,54 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# !!!NOTE!!!! This Vagrantfile requires the 'vagrant-reload' plugin
+# https://github.com/aidanns/vagrant-reload
+
 # This Vagrantfile defines multiple boxes that are tooled to test/run the
-# sanity playbook in 'tests/improved-sanity-test/main.yml'.
+# sanity playbook in 'tests/improved-sanity-test/main.yml'. As part of the
+# provisioning step, the box will be updated to the latest commit available
+# on the stream it is tracking.  Unfortunately, the box will always reboot
+# regardless if it has been updated or not.
 #
 # The playbook is configurable using the $playbook_file variable right before
 # the 'Vagrant.configure()' stanza.
+
+# These scripts are used to bring the box up to date with the latest commit
+# available on the stream.
 #
+$cahc = <<CAHC
+#!/bin/bash
+set -xeuo pipefail
+local=$(ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous)
+sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
+remote=$(ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous)
+if [ "$local" != "$remote" ]; then
+    sudo rpm-ostree deploy $remote
+fi
+CAHC
+
+$centos = <<CENTOS
+#!/bin/bash
+set -xeuo pipefail
+local=$(ostree rev-parse centos-atomic-host/7/x86_64/standard)
+sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-host:centos-atomic-host/7/x86_64/standard
+remote=$(ostree rev-parse centos-atomic-host/7/x86_64/standard)
+if [ "$local" != "$remote" ]; then
+    sudo rpm-ostree deploy $remote
+fi
+CENTOS
+
+$fedora27 = <<FEDORA27
+#!/bin/bash
+set -xeuo pipefail
+local=$(ostree rev-parse fedora/27/x86_64/atomic-host)
+sudo ostree pull --commit-metadata-only --depth=1 fedora-atomic:fedora/27/x86_64/atomic-host
+remote=$(ostree rev-parse fedora/27/x86_64/atomic-host)
+if [ "$local" != "$remote" ]; then
+    sudo rpm-ostree deploy $remote
+fi
+FEDORA27
+
 # Define the Ansible playbook you want to run here
 # Alternately, you can set the 'PLAYBOOK_FILE' environment variable to
 # override this value
@@ -17,6 +59,8 @@ Vagrant.configure(2) do |config|
         cahc.vm.box = "centos/7/atomic/continuous"
         cahc.vm.box_url = "https://ci.centos.org/artifacts/sig-atomic/centos-continuous/images/cloud/latest/images/centos-atomic-host-7-vagrant-libvirt.box"
         cahc.vm.hostname = "cahc-dev"
+        cahc.vm.provision "shell", inline: $cahc
+        cahc.vm.provision :reload
         # Because Vagrant enforces outside-in ordering with the provisioner
         # we have to specify the same playbook in multiple places
         cahc.vm.provision "ansible" do |ansible|
@@ -27,6 +71,8 @@ Vagrant.configure(2) do |config|
     config.vm.define "centos" do |centos|
         centos.vm.box = "centos/atomic-host"
         centos.vm.hostname = "centosah-dev"
+        centos.vm.provision "shell", inline: $centos
+        centos.vm.provision :reload
         # Because Vagrant enforces outside-in ordering with the provisioner
         # we have to specify the same playbook in multiple places
         centos.vm.provision "ansible" do |ansible|
@@ -38,6 +84,8 @@ Vagrant.configure(2) do |config|
     config.vm.define "fedora27", autostart: false do |fedora27|
         fedora27.vm.box = "fedora/27-atomic-host"
         fedora27.vm.hostname = "fedora27ah-dev"
+        fedora27.vm.provision "shell", inline: $fedora27
+        fedora27.vm.provision :reload
         # Because Vagrant enforces outside-in ordering with the provisioner
         # we have to specify the same playbook in multiple places
         fedora27.vm.provision "ansible" do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,57 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# !!!NOTE!!!! This Vagrantfile requires the 'vagrant-reload' plugin
-# https://github.com/aidanns/vagrant-reload
-
 # This Vagrantfile defines multiple boxes that are tooled to test/run the
 # sanity playbook in 'tests/improved-sanity-test/main.yml'.
 #
-# Each box boots into the OS, deploys HEAD^ of a particular tree, then runs
-# the playbook (which currently includes upgrading to HEAD of the same tree).
-#
 # The playbook is configurable using the $playbook_file variable right before
 # the 'Vagrant.configure()' stanza.
-
-# Define scripts to deploy HEAD^ of various trees
-# - HEAD^ of CAHC
-# - HEAD^ of base CentOS AH
-# - HEAD^ of Fedora 24 AH
-# - HEAD^ of Fedora 25 AH
 #
-$cahc = <<CAHC
-#!/bin/bash
-set -xeuo pipefail
-sudo rpm-ostree deploy $(ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous^)
-CAHC
-
-$centos = <<CENTOS
-#!/bin/bash
-set -xeuo pipefail
-current=$(ostree rev-parse centos-atomic-host/7/x86_64/standard)
-sed -i 's|true|false|' /etc/ostree/remotes.d/centos-atomic-host.conf
-sudo ostree pull --commit-metadata-only --depth=1 centos-atomic-host:centos-atomic-host/7/x86_64/standard
-sed -i 's|false|true|' /etc/ostree/remotes.d/centos-atomic-host.conf
-minusone=$(ostree rev-parse centos-atomic-host/7/x86_64/standard^)
-if [ "$current" != "$minusone" ] ; then
-    sudo rpm-ostree deploy $minusone
-fi
-CENTOS
-
-$fedora24 = <<FEDORA24
-#!/bin/bash
-set -xeuo pipefail
-sudo ostree pull --commit-metadata-only --depth=1 fedora-atomic:fedora-atomic/24/x86_64/docker-host
-sudo rpm-ostree deploy $(ostree rev-parse fedora-atomic/24/x86_64/docker-host^)
-FEDORA24
-
-$fedora25 = <<FEDORA25
-#!/bin/bash
-set -xeuo pipefail
-sudo ostree pull --commit-metadata-only --depth=1 fedora-atomic:fedora-atomic/25/x86_64/docker-host
-sudo rpm-ostree deploy $(ostree rev-parse fedora-atomic/25/x86_64/docker-host^)
-FEDORA25
-
 # Define the Ansible playbook you want to run here
 # Alternately, you can set the 'PLAYBOOK_FILE' environment variable to
 # override this value
@@ -62,8 +17,6 @@ Vagrant.configure(2) do |config|
         cahc.vm.box = "centos/7/atomic/continuous"
         cahc.vm.box_url = "https://ci.centos.org/artifacts/sig-atomic/centos-continuous/images/cloud/latest/images/centos-atomic-host-7-vagrant-libvirt.box"
         cahc.vm.hostname = "cahc-dev"
-        cahc.vm.provision "shell", inline: $cahc
-        cahc.vm.provision :reload
         # Because Vagrant enforces outside-in ordering with the provisioner
         # we have to specify the same playbook in multiple places
         cahc.vm.provision "ansible" do |ansible|
@@ -74,8 +27,6 @@ Vagrant.configure(2) do |config|
     config.vm.define "centos" do |centos|
         centos.vm.box = "centos/atomic-host"
         centos.vm.hostname = "centosah-dev"
-        centos.vm.provision "shell", inline: $centos
-        centos.vm.provision :reload
         # Because Vagrant enforces outside-in ordering with the provisioner
         # we have to specify the same playbook in multiple places
         centos.vm.provision "ansible" do |ansible|
@@ -83,34 +34,13 @@ Vagrant.configure(2) do |config|
         end
     end
 
-    config.vm.define "fedora24", autostart: false do |fedora24|
-        fedora24.vm.box = "fedora/24-atomic-host"
-        fedora24.vm.hostname = "fedora24ah-dev"
-        fedora24.vm.provision "shell", inline: $fedora24
-        fedora24.vm.provision :reload
-        # Change folder sync
-        # https://pagure.io/pungi-fedora/issue/26
-        fedora24.vm.synced_folder "./", "/vagrant", disabled: 'true'
-        fedora24.vm.synced_folder "./", "/var/vagrant"
-        # Because Vagrant enforces outside-in ordering with the provisioner
-        # we have to specify the same playbook in multiple places
-        fedora24.vm.provision "ansible" do |ansible|
-            ansible.playbook = $playbook_file
-        end
-    end
 
-    config.vm.define "fedora25", autostart: false do |fedora25|
-        fedora25.vm.box = "fedora/25-atomic-host"
-        fedora25.vm.hostname = "fedora25ah-dev"
-        fedora25.vm.provision "shell", inline: $fedora25
-        fedora25.vm.provision :reload
-        # Change folder sync
-        # https://pagure.io/pungi-fedora/issue/26
-        fedora25.vm.synced_folder "./", "/vagrant", disabled: 'true'
-        fedora25.vm.synced_folder "./", "/var/vagrant"
+    config.vm.define "fedora27", autostart: false do |fedora27|
+        fedora27.vm.box = "fedora/27-atomic-host"
+        fedora27.vm.hostname = "fedora27ah-dev"
         # Because Vagrant enforces outside-in ordering with the provisioner
         # we have to specify the same playbook in multiple places
-        fedora25.vm.provision "ansible" do |ansible|
+        fedora27.vm.provision "ansible" do |ansible|
             ansible.playbook = $playbook_file
         end
     end


### PR DESCRIPTION
Originally, the `improved-sanity-test` required that the host under
test was at HEAD-1 of the stream we were testing.  Thus, the
Vagrantfile had additional scripts in place to get the box to the
proper state.

We've moved away from that methodology and now we can just `vagrant
up` a box and run our tests against that host.

This change updates the Vagrantfile to be current with the streams we
are most interested in and removes the additional provisioning steps
required to get the box to HEAD-1.

Closes #241