### PR TITLE
use 'rpm_ostree_status' role for all the JSON output

### DIFF
--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -11,30 +11,23 @@
     bdsf_archive: "{{ archive | default('false') }}"
     bdsf_ansible_host: "{{ ansible_host }}"
 
+# This role provides the following variables:
+#  - ros: result of 'rpm-ostree status --json'
+#  - ros_json: ros.stdout piped through the from_json filter
+#  - ros_num_deployments:  number of deployments on host
+#  - ros_booted: JSON object of the booted deployment
+#  - ros_not_booted: JSON object of the not booted deployment
 - name: Get rpm-ostree status output
-  shell: >
-    rpm-ostree status --json |
-    docker run -i docker.io/miabbott/aht-tools
-    jq 'del(.deployments[]["layered-commit-meta"]["rpmostree.rpmdb.pkglist"],
-            .deployments[]["base-commit-meta"]["rpmostree.rpmdb.pkglist"])'
-  register: bdsf_ros_status
-
-- name: Set json output
-  set_fact:
-     bdsf_ros_json: "{{ bdsf_ros_status.stdout | from_json }}"
-
-- name: Discover the booted deployment
-  set_fact:
-    bdsf_ros_booted: "{{ item }}"
-  with_items: "{{ bdsf_ros_json | json_query('deployments[?booted]') }}"
+  include_role:
+    name: rpm_ostree_status
 
 - name: Save refspec and checksum
   set_fact:
-    bdsf_saved_checksum: "{{ bdsf_ros_booted['checksum'] }}"
+    bdsf_saved_checksum: "{{ ros_booted['checksum'] }}"
     # If the host is on a local branch, we have to skip splitting the 'origin'
     # because there is no remote portion
-    bdsf_saved_refspec: "{{ bdsf_ros_booted['origin'].split(':')[1] if ':' in bdsf_ros_booted['origin'] else bdsf_ros_booted['origin'] }}"
-    bdsf_saved_remote_name: "{{ bdsf_ros_booted['origin'].split(':')[0] if ':' in bdsf_ros_booted['origin'] else '' }}"
+    bdsf_saved_refspec: "{{ ros_booted['origin'].split(':')[1] if ':' in ros_booted['origin'] else ros_booted['origin'] }}"
+    bdsf_saved_remote_name: "{{ ros_booted['origin'].split(':')[0] if ':' in ros_booted['origin'] else '' }}"
 
 # If 'bdsf_archve' is true, we setup the following global variables in a YAML
 # file:

--- a/roles/local_branch_setup/tasks/main.yml
+++ b/roles/local_branch_setup/tasks/main.yml
@@ -8,25 +8,19 @@
   fail:
     msg: "branch_name is undefined"
 
+# This role provides the following variables:
+#  - ros: result of 'rpm-ostree status --json'
+#  - ros_json: ros.stdout piped through the from_json filter
+#  - ros_num_deployments:  number of deployments on host
+#  - ros_booted: JSON object of the booted deployment
+#  - ros_not_booted: JSON object of the not booted deployment
 - name: Get rpm-ostree status output
-  command: rpm-ostree status --json
-  register: ros
-
-- name: Convert rpm-ostree output to JSON
-  set_fact:
-    ros_json: "{{ ros.stdout|from_json }}"
+  include_role:
+    name: rpm_ostree_status
 
 - name: Save current booted checksum
-  when: ros_json['deployments'][0] is defined and
-        ros_json['deployments'][0]['booted']
   set_fact:
-    checksum: "{{ ros_json['deployments'][0]['checksum'] }}"
-
-- name: Save current booted checksum
-  when: ros_json['deployments'][1] is defined and
-        ros_json['deployments'][1]['booted']
-  set_fact:
-    checksum: "{{ ros_json['deployments'][1]['checksum'] }}"
+    lbs_checksum: "{{ ros_booted['checksum'] }}"
 
 - name: Create local branch
-  command: ostree refs --create {{ branch_name }} {{ checksum }}
+  command: ostree refs --create {{ branch_name }} {{ lbs_checksum }}

--- a/roles/rpm_ostree_status/tasks/main.yml
+++ b/roles/rpm_ostree_status/tasks/main.yml
@@ -5,7 +5,7 @@
 #  rpm-ostree status --json output.  If no second deployment exists,
 #  ros_not_booted will be set to false
 #
-# Newer versions of 'rpm-ostree' include the RPM DB pacakge list in the
+# Newer versions of 'rpm-ostree' include the RPM DB package list in the
 # commit metadata.  This causes hundreds of pkg entries to be included
 # in the JSON output.  We can exclude this from the output by piping to
 # 'jq' and removing the noisy keys.

--- a/roles/rpm_ostree_uninstall/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall/tasks/main.yml
@@ -20,26 +20,17 @@
   fail:
     msg: "Reboot is not defined"
 
-- block:
-    - name: Get rpm-ostree status
-      command: rpm-ostree status --json
-      register: ros
-
-    - name: Convert to JSON
-      set_fact:
-        ros_json: "{{ ros.stdout|from_json }}"
-
-    - name: Set ros variable if deployment 0 is booted
-      when: ros_json['deployments'][0] is defined and ros_json['deployments'][0]['booted']
-      set_fact:
-        ros_booted: "{{ ros_json['deployments'][0] }}"
-        ros_not_booted: "{{ ros_json['deployments'][1] if ros_json['deployments'][1] is defined else false }}"
-
-    - name: Set ros variable if deployment 1 is booted
-      when: ros_json['deployments'][1] is defined and ros_json['deployments'][1]['booted']
-      set_fact:
-        ros_booted: "{{ ros_json['deployments'][1] }}"
-        ros_not_booted: "{{ ros_json['deployments'][0] if ros_json['deployments'][0] is defined else false }}"
+- when: rou_packages == "all"
+  block:
+    # This role provides the following variables:
+    #  - ros: result of 'rpm-ostree status --json'
+    #  - ros_json: ros.stdout piped through the from_json filter
+    #  - ros_num_deployments:  number of deployments on host
+    #  - ros_booted: JSON object of the booted deployment
+    #  - ros_not_booted: JSON object of the not booted deployment
+    - name: Get rpm-ostree status output
+      include_role:
+        name: rpm_ostree_status
 
     # If the 'packages' key has a value, we create a list of packages to
     # uninstall, otherwise skip it
@@ -47,7 +38,6 @@
       when: ros_booted['packages']|length > 0
       set_fact:
         all_installed: "{{ ros_booted['packages']|join(' ') }}"
-  when: rou_packages == "all"
 
 # Check to see if 'all_installed' was defined above, otherwise we use the
 # original value of 'packages'.  It could be 'all', which means we want to
@@ -69,8 +59,9 @@
   poll: 0
   ignore_errors: true
 
-- include_role:
+- name: Reboot if necessary
+  when: rou_reboot and rm_packages != "all"
+  include_role:
     name: reboot
   vars:
     skip_shutdown: true # shutdown was already initiated
-  when: rou_reboot and rm_packages != "all"

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -233,27 +233,19 @@
           Expected: Dry run output contains exiting because
           Actual: {{ dryrun.stdout }}
 
-    - name: Get rpm-ostree status --json output
-      command: rpm-ostree status --json
-      register: installed
+    # This role provides the following variables:
+    #  - ros: result of 'rpm-ostree status --json'
+    #  - ros_json: ros.stdout piped through the from_json filter
+    #  - ros_num_deployments:  number of deployments on host
+    #  - ros_booted: JSON object of the booted deployment
+    #  - ros_not_booted: JSON object of the not booted deployment
+    - name: Get rpm-ostree status output
+      include_role:
+        name: rpm_ostree_status
 
-    - name: Convert rpm-ostree status output to jinja2 json
+    - name: Set packages when deployment is not booted
       set_fact:
-        pending_json: "{{ installed.stdout | from_json }}"
-
-    - name: Set packages when deployment 0 is not booted
-      when:
-        - pending_json['deployments'][0] is defined
-        - not pending_json['deployments'][0]['booted']
-      set_fact:
-        pending_pkgs: "{{ pending_json['deployments'][0]['packages'] }}"
-
-    - name: Set packages when deployment 1 is not booted
-      when:
-        - pending_json['deployments'][1] is defined
-        - not pending_json['deployments'][1]['booted']
-      set_fact:
-        pending_pkgs: "{{ pending_json['deployments'][1]['packages'] }}"
+        pending_pkgs: "{{ ros_not_booted['packages'] }}"
 
     - name: Fail if {{ g_pkg2 }} is in pending packages
       when: g_pkg2 in pending_pkgs
@@ -382,33 +374,19 @@
     - include_role:
         name: reboot
 
-    - name: Get rpm-ostree status --json output
-      command: rpm-ostree status --json
-      register: req
+    # This role provides the following variables:
+    #  - ros: result of 'rpm-ostree status --json'
+    #  - ros_json: ros.stdout piped through the from_json filter
+    #  - ros_num_deployments:  number of deployments on host
+    #  - ros_booted: JSON object of the booted deployment
+    #  - ros_not_booted: JSON object of the not booted deployment
+    - name: Get rpm-ostree status output
+      include_role:
+        name: rpm_ostree_status
 
-    - name: Convert rpm-ostree status output to jinja2 json
+    - name: Set packages for booted deployment
       set_fact:
-        req_json: "{{ req.stdout | from_json }}"
-
-    # This is a hack for requested-packages being displayed in rpm-ostree
-    # v2017.3 that should be fixed in v2017.4.  Fix this once  all streams
-    # are at v2017.4.
-    # See https://github.com/projectatomic/rpm-ostree/pull/670
-    - name: Set packages when deployment 0 is booted
-      when: req_json['deployments'][0]['booted']
-      set_fact:
-        req_pkgs: >
-           "{{ req_json['deployments'][0]['requested-packages']
-           if req_json['deployments'][0]['requested-packages'] is defined
-           else {} }}"
-
-    - name: Set packages when deployment 1 is booted
-      when:  req_json['deployments'][1]['booted']
-      set_fact:
-        req_pkgs: >
-          "{{ req_json['deployments'][1]['requested-packages']
-          if req_json['deployments'][1]['requested-packages'] is defined
-          else {} }}"
+        req_pkgs: "{{ ros_booted['requested-packages'] }}"
 
     - name: Fail if {{ g_deployed_pkg }} is not in requested packages
       when: g_deployed_pkg not in req_pkgs

--- a/tests/pkg-layering/verify_package_deployed.yml
+++ b/tests/pkg-layering/verify_package_deployed.yml
@@ -1,32 +1,29 @@
-# vim: set ft=ansible:
 ---
+# vim: set ft=ansible:
+#
 - name: Fail when package is undefined
+  when: package is undefined
   fail:
     msg: "Package is undefined"
-  when: package is undefined
 
-- name: Get rpm-ostree status --json output
-  command: rpm-ostree status --json
-  register: installed
+# This role provides the following variables:
+#  - ros: result of 'rpm-ostree status --json'
+#  - ros_json: ros.stdout piped through the from_json filter
+#  - ros_num_deployments:  number of deployments on host
+#  - ros_booted: JSON object of the booted deployment
+#  - ros_not_booted: JSON object of the not booted deployment
+- name: Get rpm-ostree status output
+  include_role:
+    name: rpm_ostree_status
 
-- name: Convert rpm-ostree status output to jinja2 json
+- name: Set packages for booted deployment
   set_fact:
-    installed_json: "{{ installed.stdout | from_json }}"
-
-- name: Set packages when deployment 0 is booted
-  set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][0]['packages'] }}"
-  when: installed_json['deployments'][0]['packages'] is defined and installed_json['deployments'][0]['booted']
-
-- name: Set packages when deployment 1 is booted
-  set_fact:
-    installed_pkgs: "{{ installed_json['deployments'][1]['packages'] }}"
-  when: installed_json['deployments'][1]['packages'] is defined and installed_json['deployments'][1]['booted']
+    installed_pkgs: "{{ ros_booted['packages'] }}"
 
 - name: Fail if {{ package }} is not in rpm-ostree status output
+  when: package not in installed_pkgs
   fail:
     msg: "{{ package }} not in rpm-ostree status output"
-  when: package not in installed_pkgs
 
 - name: Verify {{ package }} is installed
   command: command -v {{ package }}


### PR DESCRIPTION
We had a bunch of instances in the tree where we were doing
`rpm-ostree status --json` and then going through the motions to parse
the JSON to determine things like the booted deployment, etc.
Additionally, we were littering our test logs with the 'noisy' keys
from the JSON output that were handled in #301.

This change rips out all the invocations of `rpm-ostree status --json`
and replaces them with the usage of the `rpm_ostree_status` role.  Now
we have a consistent way of dealing with the JSON output from the
`status` command and only one place where we have to make changes if
needed.