### PR TITLE
Add git to tools container

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,5 +6,5 @@ LABEL maintainer="Micah Abbott <miabbott@redhat.com>" \
       version="1.0"
 ENV container docker
 COPY Dockerfile /root/
-RUN microdnf install jq && \
+RUN microdnf install jq git && \
     microdnf clean all

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,6 +2,7 @@ Small tools container for use with [atomic-host-tests](https://github.com/projec
 
 As of 09-Jan-2017, the following utilities/packages are installed
   - `jq`
+  - `git`
 
 To run the container:
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 Small tools container for use with [atomic-host-tests](https://github.com/projectatomic/atomic-host-tests)
 
-As of 09-Jan-2017, the following utilities/packages are installed
+As of 09-Mar-2018, the following utilities/packages are installed
   - `jq`
   - `git`
 


### PR DESCRIPTION
For the rpm-ostree compose test, we need the ability to checkout
a git repo with the necessary files to compose a tree.  Instead of
package layering git onto the host, we can use the tools container
with git installed to clone the repo and save it to a volume mount
shared between the host and container.