### PR TITLE
k8-cluster:  revert to using older system containers

### DIFF
--- a/roles/kubernetes_set_facts/tasks/main.yml
+++ b/roles/kubernetes_set_facts/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: Define kube 1.5 vars
   when:
     - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] is defined
     - g_atomic_host['kubernetes-node'] | version_compare('1.6', '<')
   set_fact:
     kube_maj_ver: "1.5"
@@ -25,6 +26,7 @@
 - name: Define kube 1.6 images
   when:
     - g_atomic_host is defined
+    - g_atomic_host['kubernetes-node'] is defined
     - g_atomic_host['kubernetes-node'] | version_compare('1.6', '>=')
   set_fact:
     kube_maj_ver: "1.6"
@@ -37,14 +39,15 @@
 - name: Define kube 1.7 master nodes, worker nodes and etcd images
   when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
         (ansible_distribution == "CentOSDev") or
-        (g_atomic_host is not defined)
+        (g_atomic_host is not defined) or
+        (g_atomic_host['kubernetes-node'] is not defined)
   set_fact:
     kube_maj_ver: "1.7"
     kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"
     kube_controller_manager: "registry.fedoraproject.org/f27/kubernetes-controller-manager"
     kube_scheduler: "registry.fedoraproject.org/f27/kubernetes-scheduler"
-    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet"
-    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
+    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet:0-4.f27container"
+    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy:0-7.f27container"
     etcd: "registry.fedoraproject.org/f27/etcd"
     kube_system_containers: true
     kubectl_path: "/usr/local/bin/kubectl"

--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -11,6 +11,7 @@
     msg: |
       This role requires that the `kubernetes_set_fact` role is run
       before it can be used.
+
 - when: kube_system_containers
   block:
     - name: Pull k8s and etcd images from the registry
@@ -36,6 +37,18 @@
         - "--name kube-scheduler {{ kube_scheduler }}"
         - "--name kubelet {{ kube_kubelet }}"
         - "--name kube-proxy {{ kube_proxy }}"
+
+    # Work around https://bugzilla.redhat.com/show_bug.cgi?id=1544175
+    - name: Add the necessary line for the kubelet to start
+      lineinfile:
+        dest: /etc/tmpfiles.d/kubelet.conf
+        regexp: "^d   /var/lib/kubelet.*"
+        line: "d   /var/lib/kubelet - - - - -"
+      register: kubelet
+
+    - when: kubelet|changed
+      name: Re-create tmpfiles
+      command: systemd-tmpfiles --create /etc/tmpfiles.d/kubelet.conf
 
     # Start etcd a little early to allow it to get setup + ready
     - name: Start etcd

--- a/roles/rpm_ostree_install/tasks/main.yml
+++ b/roles/rpm_ostree_install/tasks/main.yml
@@ -2,7 +2,7 @@
 # vim: set ft=ansible:
 # role: rpm_ostree_install
 #
-# This role installs packages using rpm-ostree uninstall
+# This role installs packages using rpm-ostree install
 #
 # Parameters:
 #  roi_packages - string of one or more packages separated by a space

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -21,6 +21,39 @@
   hosts: all
   become: true
 
+# This giant mess of pre-tasks is here to workaround the problem that is fixed
+# in this PR - https://github.com/projectatomic/atomic/pull/1185
+#
+# The fallout from that missing functionality is that the 'kube-proxy' system
+# container will not start correctly unless atomic 1.22 is used to install
+# the system container with the right SELinux labels.
+#
+  pre_tasks:
+    - include_role:
+        name: rpm_version
+      vars:
+        rv_rpms: atomic
+
+    - when:
+        - ansible_distribution == 'Fedora'
+        - ansible_distribution_major_version | version_compare('26', '>')
+        - g_atomic_host is defined
+        - g_atomic_host['atomic'] | version_compare('1.22', '<=')
+      block:
+        - name: Grab the atomic 1.22 RPMs
+          get_url:
+            url: "{{ item }}"
+            dest: /root/
+          with_items:
+            - https://kojipkgs.fedoraproject.org//packages/atomic/1.22.1/1.fc27/x86_64/atomic-1.22.1-1.fc27.x86_64.rpm
+            - https://kojipkgs.fedoraproject.org//packages/atomic/1.22.1/1.fc27/x86_64/atomic-registries-1.22.1-1.fc27.x86_64.rpm
+
+        - name: Override the atomic package
+          command: rpm-ostree override replace /root/atomic-1.22.1-1.fc27.x86_64.rpm /root/atomic-registries-1.22.1-1.fc27.x86_64.rpm
+
+        - include_role:
+            name: reboot
+
   roles:
     # This playbook requires Ansible 2.2 and an Atomic Host
     - role: ansible_version_check


### PR DESCRIPTION
Two major changes here:

1)  Pin the system containers to a previous version that was working

2)  Make sure that 'atomic 1.22' is installed on the host

The new requirement on 'atomic 1.22' is to resolve the following issue
with SELinux labeling - projectatomic/atomic#1185

This is only a temporary change; once the latest versions of the
system containers are known to be working, we can revert a lot of
this.