### PR TITLE
Add basic rpm-ostree compose test 

### DIFF
--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -836,3 +836,164 @@
 
     - name: Clean up deployments
       command: rpm-ostree cleanup -rpmb
+
+
+#####################################################################################
+#
+# rpm-ostree compose
+#   - test creating custom composes
+#
+#####################################################################################
+
+- name: rpm-ostree compose
+  hosts: all
+  become: true
+
+  tags:
+    - compose
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+    # Only run this test on Fedora and CentOS Atomic Host Continuous
+    # RHEL Atomic Host and CentOS do not have compose abilities enabled
+    - when: >
+        ansible_distribution == "Fedora" or
+        ansible_distribution == "CentOSDev"
+      block:
+        - name: Set common facts
+          set_fact:
+            base_dir: '/var/srv'
+
+        - name: Set Fedora facts
+          when: ansible_distribution == "Fedora"
+          set_fact:
+            repo_url: 'https://pagure.io/fedora-atomic.git'
+            repo_name: 'fedora-atomic'
+            json_file: 'fedora-atomic-host-base.json'
+
+        - name: Set CentOS Continuous facts
+          when: ansible_distribution == "CentOSDev"
+          set_fact:
+            repo_url: 'https://github.com/CentOS/sig-atomic-buildscripts.git'
+            repo_name: 'centos'
+            base_json: 'centos-atomic-host.json'
+            json_file: 'centos-atomic-host-continuous.json'
+
+        # CentOS Atomic Host runs out of space in the root partition when
+        # creating a tree and rebasing to it so the root partition needs
+        # to be increased
+        - name: Resize partition for CentOS
+          when: ansible_distribution == "CentOSDev"
+          command: lvextend -r -L 6G atomicos/root
+
+        - name: Clone fedora 27 repo
+          when: ansible_distribution == "Fedora"
+          command: >
+            docker run -i --privileged -v {{ base_dir }}:{{ base_dir }}:z
+              docker.io/miabbott/aht-tools /bin/bash -c
+              "git clone {{ repo_url }} {{ base_dir }}/{{ repo_name }};
+               cd {{ base_dir }}/{{ repo_name }}; git checkout f27"
+
+        - name: Clone sig-atomic-buildscripts repo
+          when: ansible_distribution == "CentOSDev"
+          command: >
+            docker run -i --privileged -v {{ base_dir }}:{{ base_dir }}:z
+              docker.io/miabbott/aht-tools /bin/bash -c
+              "git clone {{ repo_url }} {{ base_dir }}/{{ repo_name }};
+               cd {{ base_dir }}/{{ repo_name }};"
+
+        - name: Create repo directory
+          file:
+            path: '{{ base_dir }}/repo'
+            state: directory
+            mode: 0755
+
+        - name: Initialize repo directory
+          command: ostree --repo=repo init --mode=archive-z2
+          args:
+            chdir: '{{ base_dir }}'
+
+        - name: Create cache directory
+          file:
+            path: '{{ base_dir }}/cache'
+            state: directory
+            mode: 0755
+
+        # base_json is required because the CAHC json file uses the centos
+        # atomic host base json which contains the package list that needs
+        # to be modified
+        - name: Modify base package json
+          when: base_json is defined
+          lineinfile:
+            dest: '{{ base_dir }}/{{ repo_name }}/{{ base_json }}'
+            state: present
+            insertafter: '"docker",$'
+            line: '         "wget",'
+
+        - name: Modify base package json
+          when: base_json is undefined
+          lineinfile:
+            dest: '{{ base_dir }}/{{ repo_name }}/{{ json_file }}'
+            state: present
+            insertafter: '"docker",$'
+            line: '         "wget",'
+
+        - name: Compose new tree
+          command: >
+            rpm-ostree compose tree
+              --cachedir={{ base_dir }}/cache
+              --repo={{ base_dir }}/repo
+              {{ base_dir }}/{{ repo_name }}/{{ json_file }}
+          register: rct_output
+
+        - name: Set refspec and commit id
+          set_fact:
+            rct_refspec: "{{ rct_output.stdout | regex_search(regexp, '\\1') }}"
+            rct_commit_id: "{{ rct_output.stdout | regex_search(regexp, '\\2') }}"
+          vars:
+            regexp: '(.*)\s=>\s(.*)'
+
+        # Fire the http server and forget about it using the async option
+        # This http server will die when the system is rebooted after rebase
+        - name: Start http server and keep it running
+          command: python -m SimpleHTTPServer 80
+          args:
+            chdir: '{{ base_dir }}'
+          async: 1000
+          poll: 0
+          tags:
+            - start
+
+        - include_role:
+            name: rpm_ostree_rebase
+          vars:
+            refspec: '{{ rct_refspec[0] }}'
+            remote_name: local
+            remote_url: http://localhost:80/repo
+
+        - include_role:
+            name: reboot
+
+        - include_role:
+            name: rpm_ostree_status
+
+        - name: Fail if booted commit is incorrect
+          when:
+            - rct_commit_id[0] != booted_checksum
+          fail:
+            msg: |
+              Expected: booted commit is {{ rct_commit_id[0] }}
+              Actual: booted commit is {{ booted_checksum }}
+          vars:
+            booted_checksum: "{{ ros_booted['checksum'] }}"
+
+        # use the rpm_ostree_install_verify to ensure wget was part of the compose
+        # but do not check that wget is layered
+        - include_role:
+            name: rpm_ostree_install_verify
+          vars:
+            roiv_package_name: 'wget'
+            roiv_binary_name: 'wget'
+            roiv_status_check: false

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -862,9 +862,15 @@
         ansible_distribution == "Fedora" or
         ansible_distribution == "CentOSDev"
       block:
-        - name: Set common facts
+        - name: Set base dir
           set_fact:
             base_dir: '/var/srv'
+
+        - name: Set common facts
+          set_fact:
+            compose_pkg: 'wget'
+            cache_dir: '{{ base_dir }}/cache'
+            repo_dir: '{{ base_dir }}/repo'
 
         - name: Set Fedora facts
           when: ansible_distribution == "Fedora"
@@ -906,7 +912,7 @@
 
         - name: Create repo directory
           file:
-            path: '{{ base_dir }}/repo'
+            path: '{{ repo_dir }}'
             state: directory
             mode: 0755
 
@@ -917,7 +923,7 @@
 
         - name: Create cache directory
           file:
-            path: '{{ base_dir }}/cache'
+            path: '{{ cache_dir }}'
             state: directory
             mode: 0755
 
@@ -930,7 +936,7 @@
             dest: '{{ base_dir }}/{{ repo_name }}/{{ base_json }}'
             state: present
             insertafter: '"docker",$'
-            line: '         "wget",'
+            line: '         "{{ compose_pkg }}",'
 
         - name: Modify base package json
           when: base_json is undefined
@@ -938,13 +944,13 @@
             dest: '{{ base_dir }}/{{ repo_name }}/{{ json_file }}'
             state: present
             insertafter: '"docker",$'
-            line: '         "wget",'
+            line: '         "{{ compose_pkg }}",'
 
         - name: Compose new tree
           command: >
             rpm-ostree compose tree
-              --cachedir={{ base_dir }}/cache
-              --repo={{ base_dir }}/repo
+              --cachedir={{ cache_dir }}
+              --repo={{ repo_dir }}
               {{ base_dir }}/{{ repo_name }}/{{ json_file }}
           register: rct_output
 
@@ -987,13 +993,13 @@
               Expected: booted commit is {{ rct_commit_id[0] }}
               Actual: booted commit is {{ booted_checksum }}
           vars:
-            booted_checksum: "{{ ros_booted['checksum'] }}"
+            booted_checksum: '{{ ros_booted["checksum"] }}'
 
-        # use the rpm_ostree_install_verify to ensure wget was part of the compose
-        # but do not check that wget is layered
+        # use the rpm_ostree_install_verify to ensure compose_pkg  was part
+        # of the compose but do not check that it is layered
         - include_role:
             name: rpm_ostree_install_verify
           vars:
-            roiv_package_name: 'wget'
-            roiv_binary_name: 'wget'
+            roiv_package_name: '{{ compose_pkg }}'
+            roiv_binary_name: '{{ compose_pkg }}'
             roiv_status_check: false

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -1008,10 +1008,6 @@
             roiv_binary_name: '{{ compose_pkg }}'
             roiv_status_check: false
 
-        - name: debug3
-          debug:
-            msg: "test"
-
         - include_role:
             name: rpm_ostree_rollback
 

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -892,12 +892,16 @@
         # to be increased
         - name: Resize partition for CentOS
           when: ansible_distribution == "CentOSDev"
-          command: lvextend -r -L 6G atomicos/root
+          include_role:
+            name: resize_lv
+          vars:
+            rl_lvname: 'root'
+            rl_lvsize: '6'
 
         - name: Clone fedora 27 repo
           when: ansible_distribution == "Fedora"
           command: >
-            docker run -i --privileged -v {{ base_dir }}:{{ base_dir }}:z
+            docker run -v {{ base_dir }}:{{ base_dir }}:z
               docker.io/miabbott/aht-tools /bin/bash -c
               "git clone {{ repo_url }} {{ base_dir }}/{{ repo_name }};
                cd {{ base_dir }}/{{ repo_name }}; git checkout f27"
@@ -905,7 +909,7 @@
         - name: Clone sig-atomic-buildscripts repo
           when: ansible_distribution == "CentOSDev"
           command: >
-            docker run -i --privileged -v {{ base_dir }}:{{ base_dir }}:z
+            docker run -v {{ base_dir }}:{{ base_dir }}:z
               docker.io/miabbott/aht-tools /bin/bash -c
               "git clone {{ repo_url }} {{ base_dir }}/{{ repo_name }};
                cd {{ base_dir }}/{{ repo_name }};"
@@ -930,7 +934,7 @@
         # base_json is required because the CAHC json file uses the centos
         # atomic host base json which contains the package list that needs
         # to be modified
-        - name: Modify base package json
+        - name: Modify base package json for CAHC
           when: base_json is defined
           lineinfile:
             dest: '{{ base_dir }}/{{ repo_name }}/{{ base_json }}'
@@ -938,7 +942,7 @@
             insertafter: '"docker",$'
             line: '         "{{ compose_pkg }}",'
 
-        - name: Modify base package json
+        - name: Modify base package json for Fedora
           when: base_json is undefined
           lineinfile:
             dest: '{{ base_dir }}/{{ repo_name }}/{{ json_file }}'
@@ -1003,3 +1007,17 @@
             roiv_package_name: '{{ compose_pkg }}'
             roiv_binary_name: '{{ compose_pkg }}'
             roiv_status_check: false
+
+        - name: debug3
+          debug:
+            msg: "test"
+
+        - include_role:
+            name: rpm_ostree_rollback
+
+        - include_role:
+            name: reboot
+
+        - name: Clean up deployments
+          command: rpm-ostree cleanup -rpmb
+


### PR DESCRIPTION
Since the ability to create composes exists for Fedora and Centos
Atomic Host Continuous streams, we should have a test for it.

This change only includes a basic test for rpm-ostree compose.
There should be more tests to cover additional rpm-ostree compose
subcommands and options.
