### PR TITLE
k8-cluster: fix missing double quotes on regex

### DIFF
--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -11,6 +11,7 @@
     msg: |
       This role requires that the `kubernetes_set_fact` role is run
       before it can be used.
+
 - when: kube_system_containers
   block:
     - name: Pull k8s and etcd images from the registry
@@ -48,7 +49,7 @@
       replace:
         dest: "/etc/kubernetes/apiserver"
         regexp: "^KUBE_ADMISSION_CONTROL=.*$"
-        replace: 'KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ResourceQuota'
+        replace: 'KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ResourceQuota"'
 
     # Start apiserver to get it primed
     - name: Start apiserver
@@ -63,7 +64,7 @@
         backup: true
         backrefs: true
         regexp: '(^KUBELET_ARGS=\".*)\"\s*$'
-        line: '\1 --register-node=true'
+        line: '\1 --register-node=true"'
 
     # Start the rest of the services
     - name: Start kubernetes services


### PR DESCRIPTION
I'm not sure how this test was working but there are two regex
groups that were missing double quotes based on how the statements
were structured.

The first regex was a replace which ends in .*$ which will match
anything including the end quote but the replacement string did
not include the end double quote.

The second regex was a regex group capture that does not include
the end double quote so the line replacement needs to have the
double quote included.