### PR TITLE
k8-cluster: use kubeconfig

### DIFF
--- a/roles/kubernetes_set_facts/tasks/main.yml
+++ b/roles/kubernetes_set_facts/tasks/main.yml
@@ -36,18 +36,19 @@
     kube_system_containers: false
     kubectl_path: "/usr/bin/kubectl"
 
-- name: Define kube 1.7 master nodes, worker nodes and etcd images
+- name: Define kube 1.9 master nodes, worker nodes and etcd images
   when: (ansible_distribution == "Fedora" and ansible_distribution_major_version > '26') or
         (ansible_distribution == "CentOSDev") or
         (g_atomic_host is not defined) or
         (g_atomic_host['kubernetes-node'] is not defined)
   set_fact:
-    kube_maj_ver: "1.7"
+    kube_maj_ver: "1.9"
     kube_apiserver: "registry.fedoraproject.org/f27/kubernetes-apiserver"
     kube_controller_manager: "registry.fedoraproject.org/f27/kubernetes-controller-manager"
     kube_scheduler: "registry.fedoraproject.org/f27/kubernetes-scheduler"
-    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet:0-4.f27container"
-    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy:0-7.f27container"
+    kube_kubelet: "registry.fedoraproject.org/f27/kubernetes-kubelet"
+    kube_proxy: "registry.fedoraproject.org/f27/kubernetes-proxy"
     etcd: "registry.fedoraproject.org/f27/etcd"
     kube_system_containers: true
+    kubeconfig_path: "/etc/kubernetes/kubelet.kubeconfig"
     kubectl_path: "/usr/local/bin/kubectl"

--- a/roles/kubernetes_setup/files/kubelet.kubeconfig
+++ b/roles/kubernetes_setup/files/kubelet.kubeconfig
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      server: http://127.0.0.1:8080/
+    name: local
+contexts:
+  - context:
+      cluster: local
+    name: local
+current-context: local

--- a/roles/kubernetes_setup/tasks/main.yml
+++ b/roles/kubernetes_setup/tasks/main.yml
@@ -70,13 +70,21 @@
         state: 'started'
         enabled: true
 
+    - name: Copy kubelet.kubeconfig file
+      copy:
+        src: roles/kubernetes_setup/files/kubelet.kubeconfig
+        dest: "{{ kubeconfig_path }}"
+        owner: root
+        group: root
+        mode: 0644
+
     - name: Add args to /etc/kubernetes/kubelet
       lineinfile:
         dest: /etc/kubernetes/kubelet
         backup: true
         backrefs: true
         regexp: '(^KUBELET_ARGS=\".*)\"\s*$'
-        line: '\1 --register-node=true"'
+        line: '\1 --kubeconfig={{ kubeconfig_path }} --register-node=true"'
 
     # Start the rest of the services
     - name: Start kubernetes services

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -27,7 +27,7 @@
 # The fallout from that missing functionality is that the 'kube-proxy' system
 # container will not start correctly unless atomic 1.22 is used to install
 # the system container with the right SELinux labels.
-#
+
   pre_tasks:
     - include_role:
         name: rpm_version


### PR DESCRIPTION
The k8-cluster test was failing in the system container use case.  The
web and db containers weren't being created because no nodes were
available.  I was able to root cause the issue to the deprecation of
the --api-servers option.  Kubernetes 1.9 uses a kubeconfig file for
the node to determine the api server.  I used a kubernetes PR [0] as
reference for the creation of the kubeconfig file and then tacked on
the --kubeconfig option to the KUBELET_ARGS.

[0] https://github.com/kubernetes/contrib/pull/2863/files