### PR TITLE
papr: skip default_t checks temporarily for CAHC

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -31,6 +31,10 @@ cluster:
 
 context: centos/7/atomic/continuous
 
+tests:
+  # skipping 'default_t' checks until atomic 1.22 lands with (projectatomic/atomic#1185)
+  - ./.test_director --skip-tags default_file_label
+
 ---
 inherit: true
 


### PR DESCRIPTION
Lets not fail the CAHC CI check because a package isn't in CAHC yet.
Since this label isn't fatal to functionality, it's pretty safe
to skip this until we get an updated version of 'container-selinux'
with the neccessary fix:

https://github.com/projectatomic/container-selinux/pull/50