### PR TITLE
system-containers: use FQ container name

### DIFF
--- a/tests/system-containers/vars.yml
+++ b/tests/system-containers/vars.yml
@@ -1,4 +1,4 @@
 ---
-g_hw_image: 'gscrivano/hello-world'
+g_hw_image: 'docker.io/gscrivano/hello-world'
 g_hw_name: 'hello-world'
 g_invalid_value: 'xxfoobarxx'


### PR DESCRIPTION
When a fully qualified container name is not used, skopeo will use
the default container registry and use a short shorname.  In this
case gscrivano/hello-world shows up as hello world in the atomic
images list output.  The system-container looks for the short name
that was passed in when installing the system container so the test
ends up failing.  The simple fix is to use fully qualified container
names.