### PR TITLE
docker_storage_verify: add in support for rhelah 7.5

### DIFF
--- a/roles/docker_storage_verify/tasks/main.yml
+++ b/roles/docker_storage_verify/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Include distribution vars
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml"
     - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution|lower }}.yml"
 

--- a/roles/docker_storage_verify/vars/redhat-7.5.yml
+++ b/roles/docker_storage_verify/vars/redhat-7.5.yml
@@ -1,0 +1,1 @@
+overlay2.yml


### PR DESCRIPTION
This modifies the `docker_storage_verify` role to look for the
`ansible_distribution_version` in the name of the var file.  The
RHELAH 7.5 version of said file is also added.