### PR TITLE
Install rpms for rpm-ostree install gpg test

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,5 +6,5 @@ LABEL maintainer="Micah Abbott <miabbott@redhat.com>" \
       version="1.0"
 ENV container docker
 COPY Dockerfile /root/
-RUN microdnf install jq git && \
+RUN microdnf install jq git python createrepo_c && \
     microdnf clean all

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,8 +1,10 @@
 Small tools container for use with [atomic-host-tests](https://github.com/projectatomic/atomic-host-tests)
 
-As of 09-Mar-2018, the following utilities/packages are installed
-  - `jq`
-  - `git`
+As of 22-Mar-2018, the following utilities/packages are installed
+  - `jq`  added to remove package list from rpm-ostree json output
+  - `git` added to clone repo for rpm-ostree compose test
+  - `python` added to start http server to serve local repo for rpm-ostree install gpg test
+  - `createrepo_c` added to create a local repo for rpm-ostree install gpg test
 
 To run the container:
 


### PR DESCRIPTION
Install createrepo_c and python on the aht-tools container so it we
can create a local repo and serve it through python's
SimpleHTTPServer.

Also added notes in the README to explain why the packages were added.
This might help in the future to determine if a package is still
needed in the tools container.