### PR TITLE
tree: initial changes to support Fedora STI/STR

### DIFF
--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -17,7 +17,6 @@
 - set_fact:
     real_ansible_host: "{{ ansible_host }}"
     timeout: "{{ cli_reboot_timeout | default('120') }}"
-    wf_delay: "{{ cli_wf_delay | default('30') }}"
 
 # Have to account for both because Fedora STR uses the old version of these
 # inventory values for some reason.
@@ -49,7 +48,7 @@
     wait_for host={{ real_ansible_host }}
     port={{ real_ansible_port | default('22') }}
     state=started
-    delay={{ wf_delay }}
+    delay=30
     timeout={{ timeout }}
     search_regex="OpenSSH"
   become: false

--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -17,6 +17,21 @@
 - set_fact:
     real_ansible_host: "{{ ansible_host }}"
     timeout: "{{ cli_reboot_timeout | default('120') }}"
+    wf_delay: "{{ cli_wf_delay | default('30') }}"
+
+# Have to account for both because Fedora STR uses the old version of these
+# inventory values for some reason.
+- when: ansible_port is defined
+  set_fact:
+    real_ansible_port: "{{ ansible_port }}"
+
+- when: ansible_ssh_port is defined
+  set_fact:
+    real_ansible_port: "{{ ansible_ssh_port }}"
+
+- name: Get original bootid
+  command: cat /proc/sys/kernel/random/boot_id
+  register: orig_bootid
 
 - name: restart hosts
   when: (not skip_shutdown is defined) or (not skip_shutdown)
@@ -29,17 +44,19 @@
 # that they don't use sudo, which may require a password, and is not necessary
 # anyway.
 
-- name: wait for hosts to go down
-  local_action:
-    wait_for host={{ real_ansible_host }}
-    port=22 state=absent delay=1 timeout={{ timeout }}
-  become: false
-
 - name: wait for hosts to come back up
   local_action:
     wait_for host={{ real_ansible_host }}
-    port=22 state=started delay=30 timeout={{ timeout }}
+    port={{ real_ansible_port | default('22') }} state=started delay={{ wf_delay }} timeout={{ timeout }}
   become: false
+
+# I'm not sure the retries are even necessary, but I'm keeping them in
+- name: Wait until bootid changes
+  command: cat /proc/sys/kernel/random/boot_id
+  register: new_bootid
+  until: new_bootid.stdout != orig_bootid.stdout
+  retries: 6
+  delay: 10
 
 # provide an empty iterator when a list is not provided
 # http://docs.ansible.com/ansible/playbooks_conditionals.html#loops-and-conditionals

--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -47,7 +47,11 @@
 - name: wait for hosts to come back up
   local_action:
     wait_for host={{ real_ansible_host }}
-    port={{ real_ansible_port | default('22') }} state=started delay={{ wf_delay }} timeout={{ timeout }}
+    port={{ real_ansible_port | default('22') }}
+    state=started
+    delay={{ wf_delay }}
+    timeout={{ timeout }}
+    search_regex="OpenSSH"
   become: false
 
 # I'm not sure the retries are even necessary, but I'm keeping them in

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -27,11 +27,12 @@
 # are more expansive should be handled in separate playbooks.
 #
 - name: Improved Sanity Test - Pre-Upgrade
-  hosts: all
+  hosts: "{{ subjects | default('all') }}"
   become: true
   force_handlers: true
 
   tags:
+    - atomic
     - pre_upgrade
 
   vars_files:
@@ -454,11 +455,12 @@
 # ---
 
 - name: Improved Sanity Test - Post-Upgrade
-  hosts: all
+  hosts: "{{ subjects | default('all') }}"
   become: true
   force_handlers: true
 
   tags:
+    - atomic
     - post_upgrade
 
   vars_files:
@@ -821,11 +823,12 @@
 # ---
 
 - name: Improved Sanity Test - Post-Rollback
-  hosts: all
+  hosts: "{{ subjects | default('all') }}"
   become: true
   force_handlers: true
 
   tags:
+    - atomic
     - post_rollback
 
   vars_files:


### PR DESCRIPTION
These two commits include the initial changes to try to support the [Fedora Standard Test Interface](https://fedoraproject.org/wiki/CI/Tests) and [Standard Test Roles](https://fedoraproject.org/wiki/CI/Standard_Test_Roles).

The first commit makes small changes to the `improved-sanity-test` so that it can be invoked by the Fedora STI.

The second commit changes the methodology of the `reboot` role to handle the way the STI boots up an Atomic Host as a test subject.  

There are more details in the individual commit messages and I encourage you to read them.

(I'm not 100% confident about getting these merged in, so marking it as WIP for now)