### PR TITLE
docker-swarm: disable live-restore

### DIFF
--- a/roles/docker_live_restore_disable/meta/main.yml
+++ b/roles/docker_live_restore_disable/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/docker_live_restore_disable/tasks/main.yml
+++ b/roles/docker_live_restore_disable/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+#
+#  Disables docker live-restore
+#
+
+# Handle live-restore in daemon.json file
+- name: Determine if /etc/docker/daemon.json exists
+  stat:
+    path: /etc/docker/daemon.json
+  register: daemon_file
+
+- name: Turn off live restore
+  when: daemon_file.stat.exists
+  replace:
+    dest: /etc/docker/daemon.json
+    regexp: 'true'
+    replace: 'false'
+
+# Handle live-restore in /etc/sysconfig/docker file
+- name: Get contents of /etc/syconfig/docker
+  command: cat /etc/sysconfig/docker
+  register: esd
+
+- name: Remove --live-restore option if it exists
+  when: "'--live-restore' in esd.stdout"
+  replace:
+    dest: /etc/sysconfig/docker
+    regexp: '\s*--live-restore'
+    replace: ''
+
+- name: Restart docker service
+  when: daemon_file.stat.exists or
+        "'--live-restore' in esd.stdout"
+  service:
+    name: docker
+    state: restarted
+
+

--- a/tests/docker-swarm/main.yml
+++ b/tests/docker-swarm/main.yml
@@ -41,26 +41,8 @@
       tags:
         - redhat_subscription
 
-  post_tasks:
-    # docker swarm will not work with live restore enabled
-    #  and must be turned off
-    - name: Determine if /etc/docker/daemon.json exists
-      stat:
-        path: /etc/docker/daemon.json
-      register: daemon_file
-
-    - name: Turn off live restore
-      when: daemon_file.stat.exists
-      replace:
-        dest: /etc/docker/daemon.json
-        regexp: 'true'
-        replace: 'false'
-
-    - name: Restart docker service
-      when: daemon_file.stat.exists
-      service:
-        name: docker
-        state: restarted
+    # disable live-restore so docker swarm can manage container lifecycle
+    - role: docker_live_restore_disable
 
 - name: Docker Swarm - Basic Functional Test
   hosts: all


### PR DESCRIPTION
The live-restore option was enabled for fedora 28 which caused a
failure with the docker-swarm test.  The default behavior for docker
is to shutdown all running containers when the docker daemon
terminates.  The live-restore option allows containers to continue to
run when the docker daemon is unavailable; however, docker swarm
cannot run with live-restore enabled because it needs to manage the
lifecycle of the containers.

This commit disables live-restore that is enabled through
/etc/syconfig/docker.

Closes issue #370 