### PR TITLE
roles: remove use of 'include:' statements

### DIFF
--- a/roles/atomic_host_check/meta/main.yml
+++ b/roles/atomic_host_check/meta/main.yml
@@ -1,2 +1,5 @@
 ---
 allow_duplicates: true
+
+dependencies:
+  - role: set_is_atomic

--- a/roles/atomic_host_check/tasks/main.yml
+++ b/roles/atomic_host_check/tasks/main.yml
@@ -1,16 +1,11 @@
 ---
 # vim: set ft=ansible:
 #
-# Playbook to verify that hosts under tests are actually Atomic Hosts
+# Dumb role to verify that hosts under tests are actually Atomic Hosts
 #
-# Logic borrowed from:
-# https://github.com/kubernetes/contrib/blob/master/ansible/roles/common/tasks/main.yml
+# Depends on 'set_is_atomic' role
 #
-
-- name: Determine is_atomic True/False
-  include: '../../common/set_is_atomic.yml'
-
 - name: Fail if system is not an Atomic Host
-  when: not is_atomic
+  when: not g_is_atomic
   fail:
     msg: "The system is not an Atomic Host"

--- a/roles/ostree_admin_unlock/tasks/main.yml
+++ b/roles/ostree_admin_unlock/tasks/main.yml
@@ -7,7 +7,8 @@
 - name: Unlock system
   command: ostree admin unlock
 
-- include: '../../rpm_ostree_status/tasks/main.yml'
+- include_role:
+    name: rpm_ostree_status
 
 - name: Fail if unlocked is not set to development
   when: "'development' not in ros_booted['unlocked']"

--- a/roles/ostree_admin_unlock/tasks/main.yml
+++ b/roles/ostree_admin_unlock/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Unlock system
   command: ostree admin unlock
 
-- include_role:
+- import_role:
     name: rpm_ostree_status
 
 - name: Fail if unlocked is not set to development

--- a/roles/ostree_admin_unlock_hotfix/tasks/main.yml
+++ b/roles/ostree_admin_unlock_hotfix/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Unlock system with hotfix
   command: ostree admin unlock --hotfix
 
-- include_role:
+- import_role:
     name: rpm_ostree_status
 
 - name: Fail if unlocked is not set to hotfix

--- a/roles/ostree_admin_unlock_hotfix/tasks/main.yml
+++ b/roles/ostree_admin_unlock_hotfix/tasks/main.yml
@@ -6,7 +6,8 @@
 - name: Unlock system with hotfix
   command: ostree admin unlock --hotfix
 
-- include: '../../rpm_ostree_status/tasks/main.yml'
+- include_role:
+    name: rpm_ostree_status
 
 - name: Fail if unlocked is not set to hotfix
   when: "'hotfix' not in ros_booted['unlocked']"

--- a/roles/redhat_subscription/tasks/main.yml
+++ b/roles/redhat_subscription/tasks/main.yml
@@ -21,80 +21,67 @@
 # Below we use string formatting to use a variable as the name of the file in
 # the lookup()
 # via http://stackoverflow.com/a/34239020
+- name: Get origin file
+  command: ostree admin --print-current-dir
+  register: origin_file
 
-  - name: Determine is_atomic True/False
-    include: '../../common/set_is_atomic.yml'
+- name: Get refspec from origin file
+  command: grep refspec {{ origin_file.stdout }}.origin
+  register: refspec
 
-  - block:
+- name: Fail if subscription_file is not defined
+  when: subscription_file is not defined
+  fail:
+    msg: "subscription_file is not defined!"
+  run_once: true
 
-    - name: Get origin file
-      command: ostree admin --print-current-dir
-      register: origin_file
+- name: Register with subscription-manager
+  command: >
+    subscription-manager register
+    --baseurl="{{ lookup('csvfile', 'baseurl file={} delimiter=,'.format(subscription_file)) }}"
+    --serverurl="{{ lookup('csvfile', 'serverurl file={} delimiter=,'.format(subscription_file)) }}"
+    --username="$USERNAME"
+    --password="$PASSWORD"
+    {{ lookup('csvfile', 'extra file={} default='' delimiter=,'.format(subscription_file)) }}
+  environment:
+    USERNAME: "{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
+    PASSWORD: "{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"
+  register: result
+  until: result|success
+  retries: 5
+  delay: 60
 
-    - name: Get refspec from origin file
-      command: grep refspec {{ origin_file.stdout }}.origin
-      register: refspec
+- name: disable all repos
+  command: subscription-manager repos --disable=*
+  register: result
+  until: result|success
+  retries: 5
+  delay: 60
 
-    when: is_atomic
+- name: enable server, optional, and extras repos
+  command: >
+    subscription-manager repos
+    --enable rhel-7-server-rpms
+    --enable rhel-7-server-optional-rpms
+    --enable rhel-7-server-extras-rpms
+  register: result
+  until: result|success
+  retries: 5
+  delay: 60
 
+- name: Mask and stop rhsmcertd
+  shell: >
+    systemctl mask rhsmcertd && systemctl stop rhsmcertd
 
-  - name: Fail if subscription_file is not defined
-    when: subscription_file is not defined
-    fail:
-      msg: "subscription_file is not defined!"
-    run_once: true
+- name: Revert refspec in origin after susbcription if it not the default refspec
+  when: refspec.stdout.find("refspec=rhel-atomic-host") == -1
+  replace:
+    dest: "{{ origin_file.stdout }}.origin"
+    regexp: '^refspec.*$'
+    replace: "{{ refspec.stdout }}"
 
-  - name: Register with subscription-manager
-    command: >
-      subscription-manager register
-      --baseurl="{{ lookup('csvfile', 'baseurl file={} delimiter=,'.format(subscription_file)) }}"
-      --serverurl="{{ lookup('csvfile', 'serverurl file={} delimiter=,'.format(subscription_file)) }}"
-      --username="$USERNAME"
-      --password="$PASSWORD"
-      {{ lookup('csvfile', 'extra file={} default='' delimiter=,'.format(subscription_file)) }}
-    environment:
-      USERNAME: "{{ lookup('csvfile', 'username file={} delimiter=,'.format(subscription_file)) }}"
-      PASSWORD: "{{ lookup('csvfile', 'password file={} delimiter=,'.format(subscription_file)) }}"
-    register: result
-    until: result|success
-    retries: 5
-    delay: 60
-
-  - name: disable all repos
-    command: subscription-manager repos --disable=*
-    register: result
-    until: result|success
-    retries: 5
-    delay: 60
-
-  - name: enable server, optional, and extras repos
-    command: >
-      subscription-manager repos
-      --enable rhel-7-server-rpms
-      --enable rhel-7-server-optional-rpms
-      --enable rhel-7-server-extras-rpms
-    register: result
-    until: result|success
-    retries: 5
-    delay: 60
-
-  - name: Mask and stop rhsmcertd
-    shell: >
-      systemctl mask rhsmcertd && systemctl stop rhsmcertd
-
-  - block:
-
-    - name: Revert refspec in origin after susbcription if it not the default refspec
-      when: refspec.stdout.find("refspec=rhel-atomic-host") == -1
-      replace:
-        dest: "{{ origin_file.stdout }}.origin"
-        regexp: '^refspec.*$'
-        replace: "{{ refspec.stdout }}"
-
-    - name: Remove unconfigured state in origin file
-      lineinfile:
-        dest: "{{ origin_file.stdout }}.origin"
-        regexp: '^unconfigured-state.*$'
-        state: absent
-
-    when: is_atomic
+- name: Remove unconfigured state in origin file
+  lineinfile:
+    dest: "{{ origin_file.stdout }}.origin"
+    regexp: '^unconfigured-state.*$'
+    state: absent

--- a/roles/rpm_ostree_status_verify/tasks/main.yml
+++ b/roles/rpm_ostree_status_verify/tasks/main.yml
@@ -14,12 +14,6 @@
   fail:
     msg: "deployment or expected is undefined"
 
-# We use 'include:' here instead of a 'meta' dependency because the meta
-# dependency will only be run once if this role is used multiple times in
-# a playbook.
-#- name: Pull in the 'rpm_ostree_status' role
-#  include: rpm_ostree_status.yml
-
 - name: Verify number of deployments
   when:
     - num_deployments is defined

--- a/roles/rpm_version/tasks/main.yml
+++ b/roles/rpm_version/tasks/main.yml
@@ -7,6 +7,6 @@
 # This role takes a list of rpms, retrieves the version, and stores it in a
 # dict named g_atomic_host
 #
-- include_tasks: version.yml
+- import_tasks: version.yml
   rv_rpm: "{{ item }}"
   with_items: "{{ rv_rpms }}"

--- a/roles/rpm_version/tasks/main.yml
+++ b/roles/rpm_version/tasks/main.yml
@@ -7,6 +7,6 @@
 # This role takes a list of rpms, retrieves the version, and stores it in a
 # dict named g_atomic_host
 #
-- include: version.yml
+- include_tasks: version.yml
   rv_rpm: "{{ item }}"
   with_items: "{{ rv_rpms }}"

--- a/roles/set_is_atomic/meta/main.yml
+++ b/roles/set_is_atomic/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/set_is_atomic/tasks/main.yml
+++ b/roles/set_is_atomic/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # vim: set ft=ansible:
 #
-# Common check included by various other roles, sets ``is_atomic`` True/False.
+# Common check included by various other roles, sets ``g_is_atomic`` True/False.
 #
 # Logic borrowed from:
 # https://github.com/kubernetes/contrib/blob/master/ansible/roles/common/tasks/main.yml
@@ -15,9 +15,9 @@
 
 - name: Init the is_atomic fact
   set_fact:
-    is_atomic: false
+    g_is_atomic: false
 
 - name: Set the is_atomic fact
   set_fact:
-    is_atomic: true
+    g_is_atomic: true
   when: s.stat.exists

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -275,8 +275,6 @@
           Expected: Error message should indicated the deployment is already in
                     the unlocked state: development
           Actual: {{ double_unlock.stderr }}
-      when:
-        - "'Deployment is already in unlocked state: development' not in double_unlock.stderr"
 
     - name: Run unlock hotfix (system is already locked)
       command: ostree admin unlock --hotfix
@@ -333,7 +331,7 @@
       failed_when: double_unlock.rc != 1
 
     - name: Fail when error message is incorrect
-      when: 
+      when:
         - "'Deployment is already in unlocked state: hotfix' not in double_unlock.stderr"
       fail:
         msg: |


### PR DESCRIPTION
This PR removes the use `include:` across the roles to use `include_tasks` or `include_role`

The most notable change is moving the `set_is_atomic` role from the `common` directory to the `roles` directory.

The `redhat_subscription` role looks like it changed, but it really just got re-indented.