### PR TITLE
bdsf/main: use 'base-checksum' if available

### DIFF
--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Save refspec and checksum
   set_fact:
-    bdsf_saved_checksum: "{{ ros_booted['base-checksum'] if 'base-checksum' in ros_booted else ros_booted['checksum']}}"
+    bdsf_saved_checksum: "{{ ros_booted['base-checksum'] if 'base-checksum' in ros_booted else ros_booted['checksum'] }}"
     # If the host is on a local branch, we have to skip splitting the 'origin'
     # because there is no remote portion
     bdsf_saved_refspec: "{{ ros_booted['origin'].split(':')[1] if ':' in ros_booted['origin'] else ros_booted['origin'] }}"

--- a/roles/booted_deployment_set_fact/tasks/main.yml
+++ b/roles/booted_deployment_set_fact/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Save refspec and checksum
   set_fact:
-    bdsf_saved_checksum: "{{ ros_booted['checksum'] }}"
+    bdsf_saved_checksum: "{{ ros_booted['base-checksum'] if 'base-checksum' in ros_booted else ros_booted['checksum']}}"
     # If the host is on a local branch, we have to skip splitting the 'origin'
     # because there is no remote portion
     bdsf_saved_refspec: "{{ ros_booted['origin'].split(':')[1] if ':' in ros_booted['origin'] else ros_booted['origin'] }}"


### PR DESCRIPTION
In our CI tests, it was possible for the 'sanity' test to fail when
trying to rebase to the commit stored in the `g_archive_checksum`
variable.  This can happen if the 'sanity' test was run after a test
that did package layering operations and did not clean up after
itself.  This would cause the value of `checksum` in `rpm-ostree
status` to point to the current commit with the packages layered.

Since we only use `g_archive_checksum` as a way to rebase the host,
the rebase operation would fail because the commit with the package(s)
layered would not exist on the remote.

This solution is to look for the `base-checksum` key in the JSON of the
`booted` deployment and use that if it exists, otherwise fallback to
just using `checksum`.