### PR TITLE
atomic/main: cleanup after the tests are done

### DIFF
--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -468,3 +468,46 @@
     - role: command
       cmd: atomic images update {{ local_name }}:latest
       output: "Writing manifest to image destination"
+
+
+- name: Atomic- Cleanup
+  hosts: all
+  become: true
+
+  tags:
+    - cleanup
+
+  tasks:
+    - name: Check if 'atomic-registries' was layered in
+      shell: >
+        rpm-ostree status --json |
+        docker run -i docker.io/miabbott/aht-tools
+        jq '.deployments[0]["base-commit-meta"]["rpmostree.packages"]'
+      register: ros
+
+    - name: Indicate 'atomic-registries' is layered
+      when: "'atomic-registries' in ros.stdout"
+      set_fact:
+        ar_is_layered: true
+
+    - import_role:
+        name: docker_remove_all
+
+    # If the 'atomic-registries' package was layered, we can rollback,
+    # reboot, and cleanup to be back to pristine condition
+    - block:
+        - import_role:
+            name: rpm_ostree_rollback
+
+        - import_role:
+            name: reboot
+
+        - name: Cleanup deployments
+          command: rpm-ostree cleanup -rpmb
+      when:
+        - ar_is_layered is defined
+        - ar_is_layered
+
+    - when: ansible_distribution == 'RedHat'
+      import_role:
+        name: redhat_unsubscribe

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -478,15 +478,13 @@
     - cleanup
 
   tasks:
-    - name: Check if 'atomic-registries' was layered in
-      shell: >
-        rpm-ostree status --json |
-        docker run -i docker.io/miabbott/aht-tools
-        jq '.deployments[0]["base-commit-meta"]["rpmostree.packages"]'
-      register: ros
+    # Run 'rpm-ostree status --json' to determine the current booted
+    # deployment and setup the 'ros_booted' variable
+    - import_role:
+        name: rpm_ostree_status
 
     - name: Indicate 'atomic-registries' is layered
-      when: "'atomic-registries' in ros.stdout"
+      when: "'atomic-registries' in ros_booted['base-commit-meta']['rpmostree.packages']"
       set_fact:
         ar_is_layered: true
 
@@ -495,7 +493,10 @@
 
     # If the 'atomic-registries' package was layered, we can rollback,
     # reboot, and cleanup to be back to pristine condition
-    - block:
+    - when:
+        - ar_is_layered is defined
+        - ar_is_layered
+      block:
         - import_role:
             name: rpm_ostree_rollback
 
@@ -504,9 +505,6 @@
 
         - name: Cleanup deployments
           command: rpm-ostree cleanup -rpmb
-      when:
-        - ar_is_layered is defined
-        - ar_is_layered
 
     - when: ansible_distribution == 'RedHat'
       import_role:

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -484,7 +484,7 @@
         name: rpm_ostree_status
 
     - name: Indicate 'atomic-registries' is layered
-      when: "'atomic-registries' in ros_booted['layered-commit-meta']['rpmostree.packages']"
+      when: "'atomic-registries' in ros_booted['packages']"
       set_fact:
         ar_is_layered: true
 

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -484,7 +484,7 @@
         name: rpm_ostree_status
 
     - name: Indicate 'atomic-registries' is layered
-      when: "'atomic-registries' in ros_booted['base-commit-meta']['rpmostree.packages']"
+      when: "'atomic-registries' in ros_booted['layered-commit-meta']['rpmostree.packages']"
       set_fact:
         ar_is_layered: true
 


### PR DESCRIPTION
The test was sloppy about cleaning up after itself, in that it did no
cleanup at all really.  This adds a final playbook that will cleanup
the containers/images and rollback any layering of 'atomic-registries'
package that might have occurred.