### PR TITLE
roles: don't fail on SELinux failures; record them to files

### DIFF
--- a/roles/journal_fatal_msgs/meta/main.yml
+++ b/roles/journal_fatal_msgs/meta/main.yml
@@ -7,34 +7,34 @@
 dependencies:
   # check for SELinux denials
   - role: journal_search
-    search_string: 'avc:  denied'
-    fail_if_found: true
-    extra_args: '_TRANSPORT=audit'
+    js_search_string: 'avc:  denied'
+    js_file_prefix: 'audit_avc_denied'
+    js_extra_args: '_TRANSPORT=audit'
     tags:
       - audit_avc_denied
 
   # check for SELinux denials from kernel
   # https://bugzilla.redhat.com/show_bug.cgi?id=1536690
   - role: journal_search
-    search_string: 'avc:  denied'
-    fail_if_found: true
-    extra_args: '_TRANSPORT=kernel'
+    js_search_string: 'avc:  denied'
+    js_file_prefix: 'kernel_avc_denied'
+    js_extra_args: '_TRANSPORT=kernel'
     tags:
       - kernel_avc_denied
 
   # check for kernel Oops
   - role: journal_search
-    search_string: Oops
-    fail_if_found: true
-    extra_args: '_TRANSPORT=kernel'
+    js_search_string: Oops
+    js_file_prefix: 'oops_kernel'
+    js_extra_args: '_TRANSPORT=kernel'
     tags:
       - oops_kernel
 
   # check for unmapped SELinux contexts
   # see https://bugzilla.redhat.com/show_bug.cgi?id=1465650#c8
   - role: journal_search
-    search_string: unmapped
-    fail_if_found: true
-    extra_args: '_TRANSPORT=kernel'
+    js_search_string: unmapped
+    js_file_prefix: 'unmapped_selinux'
+    js_extra_args: '_TRANSPORT=kernel'
     tags:
       - unmapped_selinux

--- a/roles/journal_search/tasks/main.yml
+++ b/roles/journal_search/tasks/main.yml
@@ -2,35 +2,42 @@
 # vim: set ft=ansible:
 #
 # This role will search the journal from the latest boot for the string
-# supplied as an argument.  It can optionally fail if the string is found.
+# supplied as an argument.  If the string is found, the found entries
+# are written out to a file.  The intent is that a higher-order system
+# will consume these files and make any pass/fail decisions as needed.
+# (Because let's face it, we are the only ones running these playbooks
+# anyways and we know exactly how they will be used)
 #
 # Parameters:
-#   search_string (string) - string to search the journal for
-#   extra_args (string) - free form string to pass to 'journalctl' (optional)
-#   fail_if_found (bool) - cause the role to fail if the string is found (optional)
+#   js_search_string (string) - string to search the journal for
+#   js_file_prefix (string) - prefix to the filename where found entries will be
+#                             written
+#   js_extra_args (string) - free form string to pass to 'journalctl' (optional)
 #
-- name: Fail if the 'search_string' is undefined
-  when: search_string is undefined
+- name: Fail if the 'js_search_string' or 'js_file_prefix' is undefined
+  when: js_search_string is undefined or
+        js_file_prefix is undefined
   fail:
-    msg: "The variable 'search_string' is undefined"
+    msg: "The variable 'js search_string' or 'js_filename' is undefined"
 
-- name: Setup "fail_if_found" and "extra_args" variable
+- name: Setup "js_extra_args" variable
   set_fact:
-    fif: "{{ fail_if_found | default(false) | bool }}"
-    ea: "{{ extra_args | default('') }}"
+    ea: "{{ js_extra_args | default('') }}"
 
 # The command has to built up by pieces in order to handle the possibility of
 # extra args that might be passed in to the 'journalctl' command.
 - name: Build command pieces
   set_fact:
     journal_cmd: "{{ 'journalctl -b --no-pager ' + ea if ea|length > 0 else 'journalctl -b --no-pager' }}"
-    grep_cmd: "{{ 'grep ' + search_string|quote }}"
+    grep_cmd: "{{ 'grep ' + js_search_string|quote }}"
 
 # An inverse 'grep' is used to filter our some of the journal entries that
-# can be created when using Ansible
+# can be created when using Ansible.  The 'full_cmd_hint' is used by the
+# template when recording any found entries.
 - name: Build full command
   set_fact:
     full_cmd: "{{ journal_cmd + ' | ' + grep_cmd + ' | grep -v ansible-command' }}"
+    full_cmd_hint: "{{ journal_cmd + ' | ' + grep_cmd }}"
 
 # The 'full_cmd' variable is not quoted when passed to the 'shell:' module
 # because doing so causes the module to return 'No such file or directory'
@@ -44,20 +51,9 @@
   set_fact:
     found_string: "{{ j.rc == 0 }}"
 
-- name: Fail if the string was not found in the journal
+- name: Write out the found entries to a file
   when:
-    - not fif
-    - not found_string
-  fail:
-    msg: "Unable to find string '{{ search_string }}' in the journal"
-
-- name: Fail if the string was found in the journal
-  when:
-    - fif
     - found_string
-  fail:
-    msg: |
-      Found the string '{{ search_string }}' in the journal
-
-      Matching entries:
-      {{ j.stdout }}
+  local_action:
+    template src=journal_found.j2 dest="{{ playbook_dir }}/{{ js_file_prefix }}_journal_found.txt"
+  become: false

--- a/roles/journal_search/templates/journal_found.j2
+++ b/roles/journal_search/templates/journal_found.j2
@@ -1,0 +1,4 @@
+The command `{{ full_cmd_hint}}` found the following matching
+entries:
+
+{{ j.stdout }}

--- a/roles/selinux_verify/tasks/main.yml
+++ b/roles/selinux_verify/tasks/main.yml
@@ -9,6 +9,10 @@
 # Additionally, the role verifies that no files on the host have either the
 # 'unlabeled_t' or 'default_t' label.
 #
+# If any "bad" labels are found on the host, the various failures will be
+# recorded to a file named 'failed_selinux_verify.txt' where a higher-order
+# system can consume it and make any pass/fail judgements or what not.
+#
 # If there is a known problem in some of the SELinux labels on the host, you
 # can use following tags to exclude parts of the role from running (the tags
 # should be self-describing):
@@ -48,8 +52,8 @@
   fail:
     msg: "The getfattr utility is not installed"
 
-  # Rather than use the more complicated 'with_subelements' approach, it is
-  # possible to just use a list of key,value pairs and iterate over them.
+# Rather than use the more complicated 'with_subelements' approach, it is
+# possible to just use a list of key,value pairs and iterate over them.
 - name: Retrieve the common SELinux file labels
   command: getfattr -n security.selinux {{ item.key }} --absolute-names --only-values
   register: common_selinux_file_labels
@@ -57,17 +61,17 @@
   tags:
     - common_selinux_file_labels
 
-  # The verification is slightly hacky.  The state of the previous play is
-  # registered in a variable; in this case 'common_selinux_file_labels'.
-  # That variable has a key in it called 'results' which contains the details
-  # of each time the 'command' was executed.  In each of those details there
-  # is another key named 'item' which contains the 'key' and 'value' from
-  # each item in 'common_files'.  We can compare the 'value' to the stdout
-  # and see if the label was correct.  If the values don't compare correctly,
-  # we can append them to a list of failed values to be read out later.
-  #
-  # This approach can be used for all other inspections of file labels or
-  # process labels.
+# The verification is slightly hacky.  The state of the previous play is
+# registered in a variable; in this case 'common_selinux_file_labels'.
+# That variable has a key in it called 'results' which contains the details
+# of each time the 'command' was executed.  In each of those details there
+# is another key named 'item' which contains the 'key' and 'value' from
+# each item in 'common_files'.  We can compare the 'value' to the stdout
+# and see if the label was correct.  If the values don't compare correctly,
+# we can append them to a list of failed values to be read out later.
+#
+# This approach can be used for all other inspections of file labels or
+# process labels.
 
 - name: Append failed common file labels to the list
   when: item.item.value not in item.stdout
@@ -95,23 +99,6 @@
   with_items: "{{ distro_selinux_file_labels.results }}"
   tags:
     - distro_selinux_file_labels
-
-  # If the list of failed labels has been appended to, the variable will
-  # register as defined and thus we fail out.
-  #
-  # To get a pretty-printed message about the files with incorrect labels
-  # we can use some Jinja2 templating hacks to iterate over the list of
-  # failed files.
-- name: Fail if any SELinux file labels were incorrect
-  when: sv_failed_file_labels is defined
-  fail:
-    msg: |
-      The following files had incorrect SELinux labels:
-
-      {%- print '\n\n' %}
-      {%- for i in sv_failed_file_labels %}
-      {%- print i + '\n' %}
-      {%- endfor %}
 
 - name: Run 'rpm-ostree status' to start daemon
   command: rpm-ostree status
@@ -150,17 +137,6 @@
   tags:
     - distro_selinux_proc_labels
 
-- name: Fail if any SELinux proc labels were incorrect
-  when: sv_failed_proc_labels is defined
-  fail:
-    msg: |
-      The following procs had incorrect SELinux labels:
-
-      {%- print '\n\n' %}
-      {%- for i in sv_failed_proc_labels %}
-      {%- print i + '\n' %}
-      {%- endfor %}
-
 - name: Look for files/dirs with 'default_t' label
   command: find {{ item }} -context '*:default_t:*'
   register: find_default_t
@@ -171,19 +147,6 @@
   set_fact:
     sv_default_files: "{{ sv_default_files|default([]) + [ item.stdout ] }}"
   with_items: "{{ find_default_t.results }}"
-  tags:
-    - default_file_label
-
-- name: Fail if any files have the default_t SELinux label
-  when: sv_default_files is defined
-  fail:
-    msg: |
-      The following files had the 'default_t' label:
-
-      {%- print '\n\n' %}
-      {%- for i in sv_default_files %}
-      {%- print i + '\n' %}
-      {%- endfor %}
   tags:
     - default_file_label
 
@@ -202,15 +165,14 @@
   tags:
     - unlabeled_file_label
 
-- name: Fail if any files have the unlabeled_t SELinux label
-  when: sv_unlabeled_files is defined
-  fail:
-    msg: |
-      The following files had the 'unlabeled_t' label:
+# Rather than failing when we found an SELinux problem, we just write out the
+# problems to a file that can be read by a higher-order tool.
+- name: Write out file with any SELinux failures
+  when: sv_failed_file_labels is defined or
+        sv_failed_proc_labels is defined or
+        sv_default_files is defined or
+        sv_unlabeled_files is defined
+  local_action:
+    template src=selinux_verify.j2 dest="{{ playbook_dir }}/failed_selinux_verify.txt"
+  become: false
 
-      {%- print '\n\n' %}
-      {%- for i in sv_unlabeled_files %}
-      {%- print i + '\n' %}
-      {%- endfor %}
-  tags:
-    - unlabeled_file_label

--- a/roles/selinux_verify/templates/selinux_verify.j2
+++ b/roles/selinux_verify/templates/selinux_verify.j2
@@ -1,0 +1,38 @@
+{% if sv_failed_file_labels is defined %}
+The following files had incorrect SELinux labels:
+
+   {%- print '\n\n' %}
+   {%- for i in sv_failed_file_labels %}
+   {%- print i + '\n' %}
+   {%- endfor %}
+{% endif %}
+
+{% if sv_failed_proc_labels is defined %}
+
+The following processes had incorrect SELinux labels:
+
+   {%- print '\n\n' %}
+   {%- for i in sv_failed_proc_labels %}
+   {%- print i + '\n' %}
+   {%- endfor %}
+{% endif %}
+
+{% if sv_default_files is defined %}
+
+The following files had the 'default_t' label:
+
+   {%- print '\n\n' %}
+   {%- for i in sv_default_files %}
+   {%- print i + '\n' %}
+   {%- endfor %}
+{% endif %}
+
+{% if sv_unlabeled_files is defined %}
+
+The following files had the 'unlabeled_t' label:
+
+   {%- print '\n\n' %}
+   {%- for i in sv_unlabeled_files %}
+   {%- print i + '\n' %}
+   {%- endfor %}
+{% endif %}


### PR DESCRIPTION
A common problem when runing the 'sanity' test is that it can fail
very early because a stream has an SELinux denial immediately upon
booting the host.  While it is helpful to detect this kind of denial,
failing the whole test suite near the beginning could let other
problems slip by.

This change attempts to avoid the 'early failure' scenario by
capturing the various SELinux failures and dumping them to files on
the host where the playbook is running.  I'm open to changing how the
files are named or what not.

I've made a few assumptions about how this works because we are
basically the only ones using these roles/tests.  To everyone else,
YMMV.