### PR TITLE
requirements: dial in to Ansible 2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible<2.5
+ansible >2.3,<2.5
 jmespath


### PR DESCRIPTION
If there is an existing Python environment where Ansible 2.2 was
previously installed (as required previously), the `ansible<2.5`
requirement would be satisfied and would not get upgraded to Ansible
2.4 as we desire.  This updates the `requirements.txt` to require
something greater than 2.3 but less than 2.5.