### PR TITLE
hnof: make handler a tiny bit more resilient

### DIFF
--- a/roles/handler_notify_on_failure/handlers/main.yml
+++ b/roles/handler_notify_on_failure/handlers/main.yml
@@ -12,9 +12,11 @@
 
 # h_get_journal handler
 - name: Get playbook name
-  shell:  echo {{ playbook_dir }} | awk -F/ '{print $NF}'
+  local_action:
+    shell echo {{ playbook_dir | quote }} | awk -F/ '{print $NF}'
   register: playbook_name
   listen: h_get_journal
+  become: false
   when: aht_result == "1"
 
 - name: Set journal name
@@ -24,7 +26,7 @@
   when: aht_result == "1"
 
 - name: Get journal
-  shell: journalctl -r -b > /tmp/{{ journal_name }}
+  shell: journalctl -r -b > /tmp/{{ journal_name | quote }}
   listen: h_get_journal
   when: aht_result == "1"
 


### PR DESCRIPTION
Previously the handler was (trying) to perform some of the tasks on
the remote host.  This particular task is just setting the name of the
journal file, so we can do that locally and unprivileged.  This should
make it slightly more resilient to network problems (but only briefly
since we try to run `journalctl` on the host almost immediately
afterwards).

Additionally, I added the `quote` filter to the variables used by the
`shell` tasks for some addtional hardening.