### PR TITLE
reboot/main: increase default timeout

### DIFF
--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -16,7 +16,7 @@
 # (otherwise ansible will target the localhost)
 - set_fact:
     real_ansible_host: "{{ ansible_host }}"
-    timeout: "{{ cli_reboot_timeout | default('120') }}"
+    timeout: "{{ cli_reboot_timeout | default('300') }}"
 
 # Have to account for both because Fedora STR uses the old version of these
 # inventory values for some reason.


### PR DESCRIPTION
In RHBZ#1572944 it is speculated that /dev/random is taking a longer
amount of time to initialize with entropy in newer Linux kernels.
The observable result of this is that boot times are increased, to the
tune of 3-4m.  Perhaps I'm being overzealous with the 300s timeout,
but we don't have much to lose at this point.

h/t to @jlebon for the probable root cause in projectatomic/papr#97