### PR TITLE
Resolve Ansible 2.4  import_role variable issue

### DIFF
--- a/roles/rpm_ostree_rebase/tasks/main.yml
+++ b/roles/rpm_ostree_rebase/tasks/main.yml
@@ -14,21 +14,21 @@
 - name: Fail if refspec is not defined
   when: refspec is undefined
   fail:
-    msg: "refspec is not defined"
+    msg: "ror_refspec is not defined"
 
 # Default to empty strings for everything but the refspec
 - name: Setup facts and assign defaults if needed
   set_fact:
-    ror_commit: "{{ commit | default('') }}"
-    ror_refspec: "{{ refspec }}"
-    ror_remote_name: "{{ remote_name | default('') }}"
-    ror_remote_url : "{{ remote_url | default('') }}"
+    rorl_commit: "{{ ror_commit | default('') }}"
+    rorl_refspec: "{{ ror_refspec }}"
+    rorl_remote_name: "{{ ror_remote_name | default('') }}"
+    rorl_remote_url : "{{ ror_remote_url | default('') }}"
 
 - name: Add the remote
   when:
-    - ror_remote_name != ''
-    - ror_remote_url != ''
-  command: ostree remote add --if-not-exists --no-gpg-verify {{ ror_remote_name }} {{ ror_remote_url }}
+    - rorl_remote_name != ''
+    - rorl_remote_url != ''
+  command: ostree remote add --if-not-exists --no-gpg-verify {{ rorl_remote_name }} {{ rorl_remote_url }}
 
 # Since we default to empty strings for everything but the refspec, we can
 # supply all the arguments to the 'rpm-ostree rebase' command and cover
@@ -41,7 +41,7 @@
 #  - remote not supplied & commit supplied -> 'rpm-ostree rebase :refspec commit'
 #
 - name: Rebase to new deployment
-  command: rpm-ostree rebase {{ ror_remote_name }}:{{ ror_refspec }} {{ ror_commit }}
+  command: rpm-ostree rebase {{ rorl_remote_name }}:{{ rorl_refspec }} {{ rorl_commit }}
   register: rebase
   retries: 5
   delay: 60

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -952,9 +952,9 @@
 
     # rebase back to original checkout
     - role: rpm_ostree_rebase
-      remote_name: "{{ g_archive_remote_name }}"
-      refspec: "{{ g_archive_refspec }}"
-      commit: "{{ g_archive_checksum }}"
+      ror_remote_name: "{{ g_archive_remote_name }}"
+      ror_refspec: "{{ g_archive_refspec }}"
+      ror_commit: "{{ g_archive_checksum }}"
       tags:
         - rpm_ostree_rebase
 

--- a/tests/rpm-ostree/main.yml
+++ b/tests/rpm-ostree/main.yml
@@ -48,6 +48,8 @@
     # https://bugzilla.redhat.com/show_bug.cgi?id=1571264
     - name: Run ostree admin status as a quick sanity check
       command: ostree admin status
+      tags:
+        - ostree_admin_status
 
     - import_role:
         name: rpm_ostree_status
@@ -980,9 +982,9 @@
         - import_role:
             name: rpm_ostree_rebase
           vars:
-            refspec: '{{ rct_refspec[0] }}'
-            remote_name: local
-            remote_url: http://localhost:80/repo
+            ror_refspec: '{{ rct_refspec[0] }}'
+            ror_remote_name: local
+            ror_remote_url: http://localhost:80/repo
 
         - import_role:
             name: reboot
@@ -1168,7 +1170,9 @@
           Actual:   {{ ros_booted['base-removals'] }}
 
     # check that the base package is installed again
-    - import_role:
+    # We should be able to use import_role here but for some reason the
+    # roiv_package_name is being populated by g_pkg instead of g_remove_pkg
+    - include_role:
         name: rpm_ostree_install_verify
       vars:
         roiv_package_name: '{{ g_remove_pkg }}'


### PR DESCRIPTION
There are two issues encountered after the Ansible 2.4 change.  The
first issue is the rpm_ostree_rebase role.  The refspec variable
inside the role seems to get populated with refspec somewhere up
before the rebase call and causes a failure.  This was fixed by using
a prefixed variable name (ror_refpsec) which is a best practice
anyhow.

The second issue is a little more interesting.  After calling the same
role (rpm_ostree_install_verify) multiple times in the rpm-ostree test,
the import_role doesn't seem to be respecting the variable that is
being passed in.  Instead it is using a value from somewhere up before
the same role is called.  This leads to the conclusion that prefix in
the rebase variable name above may not work in all cases.  This was
fixed by using an include_role which is a dynamic include.  We were
trying to avoid using include_role too often because there is a
recursion depth limit if used too many times.