### PR TITLE
papr:  update for release of F28

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -1,11 +1,11 @@
 cluster:
   hosts:
     - name: testnode
-      distro: fedora/27/atomic
+      distro: fedora/28/atomic
   container:
     image: registry.fedoraproject.org/fedora:27
 
-context: fedora/27/atomic
+context: fedora/28/atomic
 
 packages:
   - python-virtualenv
@@ -15,6 +15,25 @@ packages:
   - redhat-rpm-config
   - libselinux-python
   - rsync
+
+tests:
+  # permanently set g_docker_latest=false, since Fedora doesn't have
+  # a docker-latest
+  - ./.test_director -e g_docker_latest=false
+
+---
+inherit: true
+
+cluster:
+  hosts:
+    - name: testnode
+      distro: fedora/27/atomic
+      ostree:
+        branch: fedora/27/x86_64/updates/atomic-host
+  container:
+      image: registry.fedoraproject.org/fedora:27
+
+context: fedora/27/atomic
 
 tests:
   # permanently set g_docker_latest=false, since Fedora doesn't have

--- a/.papr.yml
+++ b/.papr.yml
@@ -69,8 +69,6 @@ cluster:
 context: centos/7/atomic
 
 tests:
-  # skipping kernel_avc_denied due to https://bugzilla.redhat.com/show_bug.cgi?id=1536991
-  #  - should be fixed in CentOS 7.5
   # skipping 'default_t' checks until atomic 1.22 lands with (projectatomic/atomic#1185)
-  - ./.test_director --skip-tags kernel_avc_denied,default_file_label
+  - ./.test_director --skip-tags default_file_label
 


### PR DESCRIPTION
Let's start testing the tests against F28 and switch to using the
'updates' stream on Fedora 27 AH.