### PR TITLE
admin-unlock: always save log

### DIFF
--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -147,7 +147,7 @@
       rescue:
         - set_fact:
             tests: "{{ tests + [ { 'name':'Cleanup', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
-
+      always:
         # WRITE RESULTS TO FILE
         - name: Remove existing log files
           local_action: file path={{ result_file }} state=absent


### PR DESCRIPTION
The way it was previously written, the log file would only be written
if there was a failure during the cleanup.  We want to write the file
when the cleanup fails or passes.  Basically use the always clause.