### PR TITLE
atomic: continue to run on failure

### DIFF
--- a/tests/atomic/cleanup.yml
+++ b/tests/atomic/cleanup.yml
@@ -1,0 +1,35 @@
+---
+# set ft=ansible
+#
+
+# Run 'rpm-ostree status --json' to determine the current booted
+# deployment and setup the 'ros_booted' variable
+- import_role:
+    name: rpm_ostree_status
+
+- name: Indicate 'atomic-registries' is layered
+  when: "'atomic-registries' in ros_booted['packages']"
+  set_fact:
+    ar_is_layered: true
+
+- import_role:
+    name: docker_remove_all
+
+# If the 'atomic-registries' package was layered, we can rollback,
+# reboot, and cleanup to be back to pristine condition
+- when:
+    - ar_is_layered is defined
+    - ar_is_layered
+  block:
+    - import_role:
+        name: rpm_ostree_rollback
+
+    - import_role:
+        name: reboot
+
+    - name: Cleanup deployments
+      command: rpm-ostree cleanup -rpmb
+
+- when: ansible_distribution == 'RedHat'
+  import_role:
+    name: redhat_unsubscribe

--- a/tests/atomic/fully_qualified_container_name.yml
+++ b/tests/atomic/fully_qualified_container_name.yml
@@ -1,0 +1,92 @@
+---
+# set ft=ansible
+#
+
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_install
+  vars:
+    ai_image: "{{ cockpit_cname }}"
+    ai_options: "--name={{ cp_name }}"
+
+- import_role:
+    name: atomic_run
+  vars:
+    ar_image: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    check_mode: false
+
+- import_role:
+    name: atomic_stop
+  vars:
+    as_container: "{{ aclv_acl_jq_match['id'] }}"
+
+- import_role:
+    name: atomic_containers_delete
+  vars:
+    acd_container: "{{ aclv_acl_jq_match['id'] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_uninstall
+  vars:
+    au_image: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_images_delete
+  vars:
+    aid_image: "{{ ailv_match['id'] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_cname }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    expect_missing: true

--- a/tests/atomic/fully_qualified_name.yml
+++ b/tests/atomic/fully_qualified_name.yml
@@ -1,0 +1,85 @@
+---
+# set ft=ansible
+#
+
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_install
+  vars:
+    ai_image: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_run
+  vars:
+    ar_image: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    check_mode: false
+
+- import_role:
+    name: atomic_stop
+  vars:
+    as_container: "{{ aclv_acl_jq_match['id'] }}"
+
+- import_role:
+    name: atomic_containers_delete
+  vars:
+    acd_container: "{{ aclv_acl_jq_match['id'] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_uninstall
+  vars:
+    au_image: "{{ cockpit_cname }}"
+
+- import_role:
+    name: atomic_images_delete
+  vars:
+    aid_image: "{{ ailv_match['id'] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_cname }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_cname }}"
+    expect_missing: true

--- a/tests/atomic/images_update.yml
+++ b/tests/atomic/images_update.yml
@@ -4,8 +4,8 @@
 
 - name: Set image name
   set_fact:
-    fq_name: "docker.io/alpine"
-    local_name: "{{ ansible_docker0.ipv4.address}}:5000/alpine"
+    iu_fq_name: "docker.io/alpine"
+    iu_local_name: "{{ ansible_docker0.ipv4.address}}:5000/alpine"
 
 # Testing images update is a bit tricky since in the docker world, tags don't
 # follow any versioning--latest doesn't really mean latest.  Docker and skopeo
@@ -22,20 +22,20 @@
 - import_role:
     name: atomic_pull
   vars:
-    apl_image: "{{ fq_name }}:latest"
+    apl_image: "{{ iu_fq_name }}:latest"
 
 # Re-tag the image to local name to push it to the private registry
 - import_role:
     name: docker_tag
   vars:
-    dt_image: "{{ fq_name }}:latest"
-    dt_tag: "{{ local_name }}:latest"
+    dt_image: "{{ iu_fq_name }}:latest"
+    dt_tag: "{{ iu_local_name }}:latest"
 
 # Push the image to the private registry
 - import_role:
     name: atomic_push
   vars:
-    apsh_image: "{{ local_name }}:latest"
+    apsh_image: "{{ iu_local_name }}:latest"
     apsh_options: "--anonymous --insecure"
 
 - name: Get HOSTNAME to use to commit change
@@ -50,20 +50,20 @@
     name: docker_commit
   vars:
     dc_commit: "{{ cmd_output.stdout }}"
-    dc_image: "{{ fq_name }}:latest"
+    dc_image: "{{ iu_fq_name }}:latest"
 
 # Remove the locally tagged image so we can pull it again from the private
 # registry
 - import_role:
     name: docker_rmi
   vars:
-    drmi_image_name: "{{ local_name }}:latest"
+    drmi_image_name: "{{ iu_local_name }}:latest"
 
 - import_role:
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ local_name }}"
+      repo: "{{ iu_local_name }}"
       tag: "latest"
     expect_missing: true
 
@@ -71,7 +71,7 @@
 - import_role:
     name: atomic_pull
   vars:
-    apl_image: "{{ local_name }}:latest"
+    apl_image: "{{ iu_local_name }}:latest"
 
 # Here is the tag manipulation.  In order to push an update to the private
 # registry, the new commited image must be tagged with the local name so it
@@ -81,35 +81,35 @@
 - import_role:
     name: docker_tag
   vars:
-    dt_image: "{{ local_name }}:latest"
-    dt_tag: "{{ local_name }}:latest-1"
+    dt_image: "{{ iu_local_name }}:latest"
+    dt_tag: "{{ iu_local_name }}:latest-1"
 
 # The new commit image  needs to be tagged with the private registry name
 #  so we can push the new layer
 - import_role:
     name: docker_tag
   vars:
-    dt_image: "{{ fq_name }}:latest"
-    dt_tag: "{{ local_name }}:latest"
+    dt_image: "{{ iu_fq_name }}:latest"
+    dt_tag: "{{ iu_local_name }}:latest"
 
 # Push the new commit to the private registry
 - import_role:
     name: atomic_push
   vars:
-    apsh_image: "{{ local_name }}:latest"
+    apsh_image: "{{ iu_local_name }}:latest"
     apsh_options: "--anonymous --insecure"
 
 # Remove the new commit image
 - import_role:
     name: docker_rmi
   vars:
-    drmi_image_name: "{{ local_name }}:latest"
+    drmi_image_name: "{{ iu_local_name }}:latest"
 
 - import_role:
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ local_name }}"
+      repo: "{{ iu_local_name }}"
       tag: "latest"
     expect_missing: true
 
@@ -120,13 +120,13 @@
 - import_role:
     name: docker_tag
   vars:
-    dt_image: "{{ local_name }}:latest-1"
-    dt_tag: "{{ local_name }}:latest"
+    dt_image: "{{ iu_local_name }}:latest-1"
+    dt_tag: "{{ iu_local_name }}:latest"
 
 # Now, the the atomic images update command checks the registry to see if
 # there is a new image and updates it
 - import_role:
     name: command
   vars:
-    cmd: atomic images update {{ local_name }}:latest
+    cmd: atomic images update {{ iu_local_name }}:latest
     output: "Writing manifest to image destination"

--- a/tests/atomic/images_update.yml
+++ b/tests/atomic/images_update.yml
@@ -1,0 +1,132 @@
+---
+# set ft=ansible
+#
+
+- name: Set image name
+  set_fact:
+    fq_name: "docker.io/alpine"
+    local_name: "{{ ansible_docker0.ipv4.address}}:5000/alpine"
+
+# Testing images update is a bit tricky since in the docker world, tags don't
+# follow any versioning--latest doesn't really mean latest.  Docker and skopeo
+# determine if there is an updated image based on the docker image layers.
+# In order to test images update, this test uses a private registry and tag
+# manipulation in order to commit and push new layers to the private registry
+# then update the image.
+
+# Setup the private registry
+- import_role:
+    name: docker_private_registry
+
+# Pull the latest image
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ fq_name }}:latest"
+
+# Re-tag the image to local name to push it to the private registry
+- import_role:
+    name: docker_tag
+  vars:
+    dt_image: "{{ fq_name }}:latest"
+    dt_tag: "{{ local_name }}:latest"
+
+# Push the image to the private registry
+- import_role:
+    name: atomic_push
+  vars:
+    apsh_image: "{{ local_name }}:latest"
+    apsh_options: "--anonymous --insecure"
+
+- name: Get HOSTNAME to use to commit change
+  command: >
+      docker run docker.io/alpine:latest
+      bin/sh -c 'echo hello > /test && printenv HOSTNAME'
+  register: cmd_output
+
+# Commit the changes to the image
+# Note: cmd_output comes from the command role above
+- import_role:
+    name: docker_commit
+  vars:
+    dc_commit: "{{ cmd_output.stdout }}"
+    dc_image: "{{ fq_name }}:latest"
+
+# Remove the locally tagged image so we can pull it again from the private
+# registry
+- import_role:
+    name: docker_rmi
+  vars:
+    drmi_image_name: "{{ local_name }}:latest"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ local_name }}"
+      tag: "latest"
+    expect_missing: true
+
+# Pull the image from the private registry
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ local_name }}:latest"
+
+# Here is the tag manipulation.  In order to push an update to the private
+# registry, the new commited image must be tagged with the local name so it
+# can be pushed to the private registry.  The original image needs to be
+# saved so it can be tagged back to latest and then get updated from the
+# private registry.
+- import_role:
+    name: docker_tag
+  vars:
+    dt_image: "{{ local_name }}:latest"
+    dt_tag: "{{ local_name }}:latest-1"
+
+# The new commit image  needs to be tagged with the private registry name
+#  so we can push the new layer
+- import_role:
+    name: docker_tag
+  vars:
+    dt_image: "{{ fq_name }}:latest"
+    dt_tag: "{{ local_name }}:latest"
+
+# Push the new commit to the private registry
+- import_role:
+    name: atomic_push
+  vars:
+    apsh_image: "{{ local_name }}:latest"
+    apsh_options: "--anonymous --insecure"
+
+# Remove the new commit image
+- import_role:
+    name: docker_rmi
+  vars:
+    drmi_image_name: "{{ local_name }}:latest"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ local_name }}"
+      tag: "latest"
+    expect_missing: true
+
+# Re-tag the original image back to latest.  At this point, the registry
+# contains the new layer image and the one locally is one commit behind.
+# For some reason, the arguments passed to docker_tag get swapped only on
+# this instance of the call.  It only works if we pass the vars like this.
+- import_role:
+    name: docker_tag
+  vars:
+    dt_image: "{{ local_name }}:latest-1"
+    dt_tag: "{{ local_name }}:latest"
+
+# Now, the the atomic images update command checks the registry to see if
+# there is a new image and updates it
+- import_role:
+    name: command
+  vars:
+    cmd: atomic images update {{ local_name }}:latest
+    output: "Writing manifest to image destination"

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -1,511 +1,127 @@
 ---
-# vim: set ft=ansible:
+# vim: set ft=ansible
 #
-- name: Atomic - Setup
+- name: Atomic CLI Test Suite
   hosts: all
   become: true
-
-  tags:
-    - setup
-
-  roles:
-    - role: ansible_version_check
-      tags:
-        - ansible_version_check
-
-    # Subscribe if the system is RHEL
-    - when: ansible_distribution == 'RedHat'
-      role: redhat_subscription
-      tags:
-        - redhat_subscription
-
-- name: Atomic Fully Qualified Name
-  hosts: all
-  become: true
-
-  tags:
-    - fq_name
 
   vars_files:
     - "vars/{{ ansible_distribution|lower }}.yml"
 
-  roles:
-    - role: atomic_pull
-      apl_image: "{{ cockpit_cname }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_cname }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      expect_missing: true
-
-    - role: atomic_install
-      ai_image: "{{ cockpit_cname }}"
-
-    - role: atomic_run
-      ar_image: "{{ cockpit_cname }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      check_mode: false
-
-    - role: atomic_stop
-      as_container: "{{ aclv_acl_jq_match['id'] }}"
-
-    - role: atomic_containers_delete
-      acd_container: "{{ aclv_acl_jq_match['id'] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_cname }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      expect_missing: true
-
-    - role: atomic_uninstall
-      au_image: "{{ cockpit_cname }}"
-
-    - role: atomic_images_delete
-      aid_image: "{{ ailv_match['id'] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_cname }}"
-      expect_missing: true
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      expect_missing: true
-
-- name: Atomic Short Name
-  hosts: all
-  become: true
-
-  tags:
-    - shortname
-
-  vars_files:
-    - "vars/{{ ansible_distribution|lower }}.yml"
-
-  roles:
-    - role: atomic_pull
-      apl_image: "{{ cockpit_short_name }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_fq_name }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_short_name }}"
-      expect_missing: true
-
-    - role: atomic_install
-      ai_image: "{{ cockpit_short_name }}"
-
-    - role: atomic_run
-      ar_image: "{{ cockpit_short_name }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_fq_name }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_short_name }}"
-      check_mode: false
-
-    # aclv_acl_jq_match is the container entry that matches the image_name
-    # specified in the atomic_containers_list_verify role above.  The
-    # shortened container id is used to stop and delete the container.
-    - role: atomic_stop
-      as_container: "{{ aclv_acl_jq_match['id'][:12] }}"
-
-    - role: atomic_containers_delete
-      acd_container: "{{ aclv_acl_jq_match['id'][:12] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_fq_name }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_short_name }}"
-      expect_missing: true
-
-    - role: atomic_uninstall
-      au_image: "{{ cockpit_short_name }}"
-
-    - role: atomic_images_delete
-      aid_image: "{{ ailv_match['id'][:12] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_fq_name }}"
-      expect_missing: true
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_short_name }}"
-      expect_missing: true
-
-- name: Atomic fully qualified container name
-  hosts: all
-  become: true
-
-  tags:
-    - fq_name_name
-
-  vars_files:
-    - "vars/{{ ansible_distribution|lower }}.yml"
-
-  roles:
-    - role: atomic_pull
-      apl_image: "{{ cockpit_cname }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_cname }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      expect_missing: true
-
-    - role: atomic_install
-      ai_image: "{{ cockpit_cname }}"
-      ai_options: "--name={{ cp_name }}"
-
-    - role: atomic_run
-      ar_image: "{{ cockpit_cname }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_cname }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      check_mode: false
-
-    - role: atomic_stop
-      as_container: "{{ aclv_acl_jq_match['id'] }}"
-
-    - role: atomic_containers_delete
-      acd_container: "{{ aclv_acl_jq_match['id'] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_cname }}"
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      expect_missing: true
-
-    - role: atomic_uninstall
-      au_image: "{{ cockpit_cname }}"
-
-    - role: atomic_images_delete
-      aid_image: "{{ ailv_match['id'] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ cockpit_cname }}"
-      expect_missing: true
-
-    - role: atomic_containers_list_verify
-      expected_values:
-        image_name: "{{ cockpit_cname }}"
-      expect_missing: true
-
-- name: Atomic Pull With Tags
-  hosts: all
-  become: true
-
-  tags:
-    - pull_tags
-
-  pre_tasks:
-    - name: Set container name
-      set_fact:
-        fq_name: "docker.io/busybox"
-        short_name: "busybox"
-        tag: 1
-
-  roles:
-    - role: atomic_pull
-      apl_image: "{{ fq_name }}:{{ tag }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ fq_name }}"
-        tag: "1"
-
-    - role: atomic_images_delete
-      aid_image: "{{ ailv_match['id'] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ fq_name }}"
-      expect_missing: true
-
-    - role: atomic_pull
-      apl_image: "{{ short_name }}:{{ tag }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ fq_name }}"
-        tag: "1"
-
-    - role: atomic_images_delete
-      aid_image: "{{ ailv_match['id'] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ fq_name }}"
-      expect_missing: true
-
-- name: Atomic Pull By Digest
-  hosts: all
-  become: true
-
-  tags:
-    - pull_digest_simple
-
-  pre_tasks:
-    - name: Set image name
-      set_fact:
-        fq_name: "docker.io/busybox"
-        digest:
-          sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912
-
-  roles:
-    - name: atomic_pull
-      apl_image: "{{ fq_name }}@{{ digest }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ fq_name }}"
-        tag: "{{ digest|regex_replace('sha256:') }}"
-
-    # Delete the image to return to a clean state
-    - role: atomic_images_delete
-      aid_image: "{{ ailv_match['id'] }}"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ fq_name }}"
-      expect_missing: true
-
-- name: Atomic Pull Storage
-  hosts: all
-  become: true
-
-  tags:
-    - pull_storage
+  vars:
+    tests: []
 
   tasks:
-    - name: Set image name
+    - name: Set logging
       set_fact:
-        fq_name: "docker.io/busybox"
+        log_results: true
+        result_file: "{{ playbook_dir }}/atomic-result.log"
+      tags: setup
 
-    - name: Delete all images
-      import_role:
-        name: atomic_images_delete_all
-
-    - name: Pull {{ fq_name }} using ostree
-      import_role:
-        name: atomic_pull
-      vars:
-        apl_image: "{{ fq_name }}"
-        apl_options: "--storage=ostree"
-
-    # The TYPE field doesn't show up in the json output (see
-    # https://github.com/projectatomic/atomic/issues/1129) so
-    # we must check for ostree in the output of the command
-    - name: Fail if ostree storage not in atomic list output
-      command: atomic images list
-      register: ail_output
-      failed_when: >
-        fq_name not in ail_output.stdout and
-        "ostree" not in ail_output.stdout
-
-    - name: Delete all images
-      import_role:
-        name: atomic_images_delete_all
-
-    - import_role:
-        name: atomic_pull
-      vars:
-        apl_image: "{{ fq_name }}"
-        apl_options: "--storage=docker"
-
-    # The TYPE field doesn't show up in the json output (see
-    # https://github.com/projectatomic/atomic/issues/1129) so
-    # we must check for ostree in the output of the command
-    - name: Fail if ostree storage not in atomic list output
-      command: atomic images list
-      register: ail_output
-      failed_when: >
-        fq_name not in ail_output.stdout and
-        "docker" not in ail_output.stdout
-
-- name: Atomic Images Update
-  hosts: all
-  become: true
-
-  tags:
-    - images_update
-
-  pre_tasks:
-    - name: Set image name
-      set_fact:
-        fq_name: "docker.io/alpine"
-        local_name: "{{ ansible_docker0.ipv4.address}}:5000/alpine"
-
-  # Testing images update is a bit tricky since in the docker world, tags don't
-  # follow any versioning--latest doesn't really mean latest.  Docker and skopeo
-  # determine if there is an updated image based on the docker image layers.
-  # In order to test images update, this test uses a private registry and tag
-  # manipulation in order to commit and push new layers to the private registry
-  # then update the image.
-
-  roles:
-    # Setup the private registry
-    - role: docker_private_registry
-
-    # Pull the latest image
-    - role: atomic_pull
-      apl_image: "{{ fq_name }}:latest"
-
-    # Re-tag the image to local name to push it to the private registry
-    - role: docker_tag
-      dt_image: "{{ fq_name }}:latest"
-      dt_tag: "{{ local_name }}:latest"
-
-    # Push the image to the private registry
-    - role: atomic_push
-      apsh_image: "{{ local_name }}:latest"
-      apsh_options: "--anonymous --insecure"
-
-    # Make a change to the original image and get the HOSTNAME to use to
-    # commit the change
-    - role: command
-      cmd: >
-        docker run docker.io/alpine:latest
-        bin/sh -c 'echo hello > /test && printenv HOSTNAME'
-
-    # Commit the changes to the image
-    # Note: cmd_output comes from the command role above
-    - role: docker_commit
-      dc_commit: "{{ cmd_output.stdout }}"
-      dc_image: "{{ fq_name }}:latest"
-
-    # Remove the locally tagged image so we can pull it again from the private
-    # registry
-    - role: docker_rmi
-      drmi_image_name: "{{ local_name }}:latest"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ local_name }}"
-        tag: "latest"
-      expect_missing: true
-
-    # Pull the image from the private registry
-    - role: atomic_pull
-      apl_image: "{{ local_name }}:latest"
-
-    # Here is the tag manipulation.  In order to push an update to the private
-    # registry, the new commited image must be tagged with the local name so it
-    # can be pushed to the private registry.  The original image needs to be
-    # saved so it can be tagged back to latest and then get updated from the
-    # private registry.
-    - role: docker_tag
-      dt_image: "{{ local_name }}:latest"
-      dt_tag: "{{ local_name }}:latest-1"
-
-    # The new commit image  needs to be tagged with the private registry name
-    #  so we can push the new layer
-    - role: docker_tag
-      dt_image: "{{ fq_name }}:latest"
-      dt_tag: "{{ local_name }}:latest"
-
-    # Push the new commit to the private registry
-    - role: atomic_push
-      apsh_image: "{{ local_name }}:latest"
-      apsh_options: "--anonymous --insecure"
-
-    # Remove the new commit image
-    - role: docker_rmi
-      drmi_image_name: "{{ local_name }}:latest"
-
-    - role: atomic_images_list_verify
-      expected_values:
-        repo: "{{ local_name }}"
-        tag: "latest"
-      expect_missing: true
-
-    # Re-tag the original image back to latest.  At this point, the registry
-    # contains the new layer image and the one locally is one commit behind.
-    # For some reason, the arguments passed to docker_tag get swapped only on
-    # this instance of the call.  It only works if we pass the vars like this.
-    - role: docker_tag
-      vars:
-        dt_image: "{{ local_name }}:latest-1"
-        dt_tag: "{{ local_name }}:latest"
-
-    # Now, the the atomic images update command checks the registry to see if
-    # there is a new image and updates it
-    - role: command
-      cmd: atomic images update {{ local_name }}:latest
-      output: "Writing manifest to image destination"
+    - include_tasks: 'setup.yml'
+      tags: setup
 
 
-- name: Atomic- Cleanup
-  hosts: all
-  become: true
+    # TEST
+    # Pull, install, run, uninstall, delete by fully qualified name
+    - block:
+        - include_tasks: 'fully_qualified_name.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull, install, run, uninstall, delete by fqn', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull, install, run, uninstall, delete by fqn', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      tags: fully_qualified_name
 
-  tags:
-    - cleanup
 
-  tasks:
-    # Run 'rpm-ostree status --json' to determine the current booted
-    # deployment and setup the 'ros_booted' variable
-    - import_role:
-        name: rpm_ostree_status
+    # TEST
+    # Pull, install, run, uninstall, delete by short name
+    - block:
+        - include_tasks: 'short_name.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull, install, run, uninstall, delete by short name', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull, install, run, uninstall, delete by short name', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      tags: short_name
 
-    - name: Indicate 'atomic-registries' is layered
-      when: "'atomic-registries' in ros_booted['packages']"
-      set_fact:
-        ar_is_layered: true
 
-    - import_role:
-        name: docker_remove_all
+    # TEST
+    # Pull, install, run, uninstall, delete by fully qualified container name
+    - block:
+        - include_tasks: 'fully_qualified_container_name.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull, install, run, uninstall, delete by fully qualified container name ', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull, install, run, uninstall, delete by fully qualified container name ', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      tags: fq_name_name
 
-    # If the 'atomic-registries' package was layered, we can rollback,
-    # reboot, and cleanup to be back to pristine condition
-    - when:
-        - ar_is_layered is defined
-        - ar_is_layered
-      block:
-        - import_role:
-            name: rpm_ostree_rollback
 
-        - import_role:
-            name: reboot
+    # TEST
+    # Pull with tags
+    - block:
+        - include_tasks: 'pull_tags.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull with tags', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull with tags', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      tags: pull_tags
 
-        - name: Cleanup deployments
-          command: rpm-ostree cleanup -rpmb
 
-    - when: ansible_distribution == 'RedHat'
-      import_role:
-        name: redhat_unsubscribe
+    # TEST
+    # Pull with digest
+    - block:
+        - include_tasks: 'pull_digest.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull with digest', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull with digest', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      tags: pull_digest
+
+
+    # TEST
+    # Pull with storage
+    - block:
+        - include_tasks: 'pull_storage.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull with storage', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Pull with storage', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      tags: pull_storage
+
+
+    # TEST
+    # Images update
+    - block:
+        - include_tasks: 'images_update.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Images update', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Images update', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      tags: images_update
+
+
+    # CLEANUP
+    - block:
+        - include_tasks: 'cleanup.yml'
+        - set_fact:
+            tests: "{{ tests + [ { 'name': 'Cleanup', 'result':'Passed', 'result_details': '' } ] }}"
+      rescue:
+        - set_fact:
+            tests: "{{ tests + [ { 'name':'Cleanup', 'result':'Failed', 'result_details': ansible_failed_result } ] }}"
+      always:
+        # WRITE RESULTS TO FILE
+        - name: Remove existing log files
+          local_action: file path={{ result_file }} state=absent
+          become: false
+
+        - name: Save result to file
+          when: log_results
+          local_action: copy content={{ tests | to_nice_yaml(indent=2) }} dest={{ result_file }}
+          become: false
+      tags: cleanup

--- a/tests/atomic/pull_digest.yml
+++ b/tests/atomic/pull_digest.yml
@@ -4,21 +4,21 @@
 
 - name: Set image name
   set_fact:
-    fq_name: "docker.io/busybox"
-    digest:
+    pd_fq_name: "docker.io/busybox"
+    pd_digest:
       sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912
 
 - import_role:
     name: atomic_pull
   vars:
-    apl_image: "{{ fq_name }}@{{ digest }}"
+    apl_image: "{{ pd_fq_name }}@{{ pd_digest }}"
 
 - import_role:
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ fq_name }}"
-      tag: "{{ digest|regex_replace('sha256:') }}"
+      repo: "{{ pd_fq_name }}"
+      tag: "{{ pd_digest|regex_replace('sha256:') }}"
 
 # Delete the image to return to a clean state
 - import_role:
@@ -30,5 +30,5 @@
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ fq_name }}"
+      repo: "{{ pd_fq_name }}"
     expect_missing: true

--- a/tests/atomic/pull_digest.yml
+++ b/tests/atomic/pull_digest.yml
@@ -1,0 +1,34 @@
+---
+# set ft=ansible
+#
+
+- name: Set image name
+  set_fact:
+    fq_name: "docker.io/busybox"
+    digest:
+      sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912
+
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ fq_name }}@{{ digest }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ fq_name }}"
+      tag: "{{ digest|regex_replace('sha256:') }}"
+
+# Delete the image to return to a clean state
+- import_role:
+    name: atomic_images_delete
+  vars:
+    aid_image: "{{ ailv_match['id'] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ fq_name }}"
+    expect_missing: true

--- a/tests/atomic/pull_storage.yml
+++ b/tests/atomic/pull_storage.yml
@@ -4,17 +4,17 @@
 
 - name: Set image name
   set_fact:
-    fq_name: "docker.io/busybox"
+    ps_fq_name: "docker.io/busybox"
 
 - name: Delete all images
   import_role:
     name: atomic_images_delete_all
 
-- name: Pull {{ fq_name }} using ostree
+- name: Pull {{ ps_fq_name }} using ostree
   import_role:
     name: atomic_pull
   vars:
-    apl_image: "{{ fq_name }}"
+    apl_image: "{{ ps_fq_name }}"
     apl_options: "--storage=ostree"
 
 # The TYPE field doesn't show up in the json output (see
@@ -24,7 +24,7 @@
   command: atomic images list
   register: ail_output
   failed_when: >
-    fq_name not in ail_output.stdout and
+    ps_fq_name not in ail_output.stdout and
     "ostree" not in ail_output.stdout
 
 - name: Delete all images
@@ -34,7 +34,7 @@
 - import_role:
     name: atomic_pull
   vars:
-    apl_image: "{{ fq_name }}"
+    apl_image: "{{ ps_fq_name }}"
     apl_options: "--storage=docker"
 
 # The TYPE field doesn't show up in the json output (see
@@ -44,6 +44,6 @@
   command: atomic images list
   register: ail_output
   failed_when: >
-    fq_name not in ail_output.stdout and
+    ps_fq_name not in ail_output.stdout and
     "docker" not in ail_output.stdout
 

--- a/tests/atomic/pull_storage.yml
+++ b/tests/atomic/pull_storage.yml
@@ -1,0 +1,49 @@
+---
+# set ft=ansible
+#
+
+- name: Set image name
+  set_fact:
+    fq_name: "docker.io/busybox"
+
+- name: Delete all images
+  import_role:
+    name: atomic_images_delete_all
+
+- name: Pull {{ fq_name }} using ostree
+  import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ fq_name }}"
+    apl_options: "--storage=ostree"
+
+# The TYPE field doesn't show up in the json output (see
+# https://github.com/projectatomic/atomic/issues/1129) so
+# we must check for ostree in the output of the command
+- name: Fail if ostree storage not in atomic list output
+  command: atomic images list
+  register: ail_output
+  failed_when: >
+    fq_name not in ail_output.stdout and
+    "ostree" not in ail_output.stdout
+
+- name: Delete all images
+  import_role:
+    name: atomic_images_delete_all
+
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ fq_name }}"
+    apl_options: "--storage=docker"
+
+# The TYPE field doesn't show up in the json output (see
+# https://github.com/projectatomic/atomic/issues/1129) so
+# we must check for ostree in the output of the command
+- name: Fail if ostree storage not in atomic list output
+  command: atomic images list
+  register: ail_output
+  failed_when: >
+    fq_name not in ail_output.stdout and
+    "docker" not in ail_output.stdout
+

--- a/tests/atomic/pull_tags.yml
+++ b/tests/atomic/pull_tags.yml
@@ -4,20 +4,20 @@
 
 - name: Set container name
   set_fact:
-    fq_name: "docker.io/busybox"
-    short_name: "busybox"
-    tag: 1
+    pt_fq_name: "docker.io/busybox"
+    pt_short_name: "busybox"
+    pt_tag: 1
 
 - import_role:
     name: atomic_pull
   vars:
-    apl_image: "{{ fq_name }}:{{ tag }}"
+    apl_image: "{{ pt_fq_name }}:{{ pt_tag }}"
 
 - import_role:
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ fq_name }}"
+      repo: "{{ pt_fq_name }}"
       tag: "1"
 
 - import_role:
@@ -29,19 +29,19 @@
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ fq_name }}"
+      repo: "{{ pt_fq_name }}"
     expect_missing: true
 
 - import_role:
     name: atomic_pull
   vars:
-    apl_image: "{{ short_name }}:{{ tag }}"
+    apl_image: "{{ pt_short_name }}:{{ pt_tag }}"
 
 - import_role:
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ fq_name }}"
+      repo: "{{ pt_fq_name }}"
       tag: "1"
 
 - import_role:
@@ -53,5 +53,5 @@
     name: atomic_images_list_verify
   vars:
     expected_values:
-      repo: "{{ fq_name }}"
+      repo: "{{ pt_fq_name }}"
     expect_missing: true

--- a/tests/atomic/pull_tags.yml
+++ b/tests/atomic/pull_tags.yml
@@ -1,0 +1,57 @@
+---
+# set ft=ansible
+#
+
+- name: Set container name
+  set_fact:
+    fq_name: "docker.io/busybox"
+    short_name: "busybox"
+    tag: 1
+
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ fq_name }}:{{ tag }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ fq_name }}"
+      tag: "1"
+
+- import_role:
+    name: atomic_images_delete
+  vars:
+    aid_image: "{{ ailv_match['id'] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ fq_name }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ short_name }}:{{ tag }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ fq_name }}"
+      tag: "1"
+
+- import_role:
+    name: atomic_images_delete
+  vars:
+    aid_image: "{{ ailv_match['id'] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ fq_name }}"
+    expect_missing: true

--- a/tests/atomic/setup.yml
+++ b/tests/atomic/setup.yml
@@ -1,0 +1,16 @@
+---
+# set ft=ansible
+#
+
+- import_role:
+    name: ansible_version_check
+  tags:
+    - ansible_version_check
+
+# Subscribe if the system is RHEL
+- when: ansible_distribution == 'RedHat'
+  import_role:
+    name: redhat_subscription
+  tags:
+    - redhat_subscription
+

--- a/tests/atomic/short_name.yml
+++ b/tests/atomic/short_name.yml
@@ -1,0 +1,94 @@
+---
+# set ft=ansible
+#
+
+- import_role:
+    name: atomic_pull
+  vars:
+    apl_image: "{{ cockpit_short_name }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_fq_name }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_short_name }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_install
+  vars:
+    ai_image: "{{ cockpit_short_name }}"
+
+- import_role:
+    name: atomic_run
+  vars:
+    ar_image: "{{ cockpit_short_name }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_fq_name }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_short_name }}"
+    check_mode: false
+
+# aclv_acl_jq_match is the container entry that matches the image_name
+# specified in the atomic_containers_list_verify role above.  The
+# shortened container id is used to stop and delete the container.
+- import_role:
+    name: atomic_stop
+  vars:
+    as_container: "{{ aclv_acl_jq_match['id'][:12] }}"
+
+- import_role:
+    name: atomic_containers_delete
+  vars:
+    acd_container: "{{ aclv_acl_jq_match['id'][:12] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_fq_name }}"
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_short_name }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_uninstall
+  vars:
+    au_image: "{{ cockpit_short_name }}"
+
+- import_role:
+    name: atomic_images_delete
+  vars:
+    aid_image: "{{ ailv_match['id'][:12] }}"
+
+- import_role:
+    name: atomic_images_list_verify
+  vars:
+    expected_values:
+      repo: "{{ cockpit_fq_name }}"
+    expect_missing: true
+
+- import_role:
+    name: atomic_containers_list_verify
+  vars:
+    expected_values:
+      image_name: "{{ cockpit_short_name }}"
+    expect_missing: true


### PR DESCRIPTION
This is a follow-on to #391 for the atomic test suite.  The changes
allow the tests to continue to run on failure using Ansible's
block/rescue/always.