### PR TITLE
ist: only run OpenSCAP test on RHEL

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -196,7 +196,8 @@
 
     # TEST
     # Validate atomic scan command
-    - role: atomic_scan_verify
+    - when: ansible_distribution == 'RedHat'
+      role: atomic_scan_verify
       tags:
         - atomic_scan_verify
 
@@ -792,7 +793,8 @@
 
     # TEST
     # Validate atomic scan works
-    - role: atomic_scan_verify
+    - when: ansible_distribution == 'RedHat'
+      role: atomic_scan_verify
       tags:
         - atomic_scan_verify
 


### PR DESCRIPTION
Otherwise we don't have access to the registry anyway.