### PR TITLE
I-S-T: Add support for running against RHCOS

### DIFF
--- a/roles/docker_storage_verify/vars/redhat-3.yml
+++ b/roles/docker_storage_verify/vars/redhat-3.yml
@@ -1,0 +1,2 @@
+---
+driver: 'overlay2'

--- a/roles/rpm_ostree_rebase/tasks/main.yml
+++ b/roles/rpm_ostree_rebase/tasks/main.yml
@@ -6,13 +6,13 @@
 #
 # rpm-ostree rebase
 #   params:
-#     refspec (required) - remote refspec
-#     commit (optional) - rebase to this commit
-#     remote_name (optional) - name for remote
-#     remote_url (optional) - remote url will trigger adding of remote
+#     ror_refspec (required) - remote refspec
+#     ror_commit (optional) - rebase to this commit
+#     ror_remote_name (optional) - name for remote
+#     ror_remote_url (optional) - remote url will trigger adding of remote
 #
 - name: Fail if refspec is not defined
-  when: refspec is undefined
+  when: ror_refspec is undefined
   fail:
     msg: "ror_refspec is not defined"
 

--- a/roles/selinux_verify/vars/redhat-3.yml
+++ b/roles/selinux_verify/vars/redhat-3.yml
@@ -1,0 +1,19 @@
+---
+distro_files:
+  - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-shim', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-containerd-shim-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-ctr-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/docker-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/dockerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/dockerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/bin/container-storage-setup', value: 'system_u:object_r:bin_t:s0' }
+  - { key: '/usr/libexec/docker/docker-lvm-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-novolume-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-proxy-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+  - { key: '/usr/libexec/docker/docker-runc-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
+
+distro_procs:
+  - { key: 'docker', value: 'system_u:system_r:container_runtime_t:s0' }

--- a/tests/improved-sanity-test/README.md
+++ b/tests/improved-sanity-test/README.md
@@ -32,5 +32,8 @@ To run the test, simply invoke as any other Ansible playbook:
 $ ansible-playbook -i inventory tests/improved-sanity-test/main.yml
 ```
 
+To run against a cloud image, run with the option: `--tags cloud_image`
+To run against RHCOS, run with the option:  `--tags rhcos`
+
 *NOTE*: You are responsible for providing a host to run the test against and the
 inventory file for that host.

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -42,17 +42,20 @@
     - role: ansible_version_check
       tags:
         - ansible_version_check
+        - rhcos
 
     # Set up handler notification
     - role: handler_notify_on_failure
       handler_name: h_get_journal
       tags:
         - handler_notify_on_failure
+        - rhcos
 
     # Ensure the host(s) are indeed Atomic Host(s)
     - role: atomic_host_check
       tags:
         - atomic_host_check
+        - rhcos
 
     # Before we do anything substantial, let's check the journal to see if
     # anything blew up on boot
@@ -60,6 +63,7 @@
       tags:
         - journal_fatal_msgs_first_boot
         - journal_fatal_msgs
+        - rhcos
 
     # Check RPM signatures
     - role: rpm_signature_verify
@@ -78,6 +82,7 @@
       archive: true
       tags:
         - booted_deployment_set_fact
+        - rhcos
 
     # Setup local branch and upgrade right away so packages are layered on
     # top of the local branch.  If the local branch is created before the
@@ -87,6 +92,7 @@
       branch_name: local-branch
       tags:
         - local_branch_setup
+        - rhcos
 
     # Commit to the local branch
     - role: local_branch_commit
@@ -95,17 +101,20 @@
       version: test1
       tags:
         - local_branch_commit
+        - rhcos
 
     # Modify the origin file so we can use rpm-ostree directly
     - role: origin_file_modify
       refspec: local-branch
       tags:
         - origin_file_modify
+        - rhcos
 
     # Do the actual upgrade
     - role: rpm_ostree_upgrade
       tags:
         - rpm_ostree_upgrade_setup
+        - rhcos
 
     # Reboot the host and don't continue until expected services have started
     - role: reboot
@@ -113,11 +122,13 @@
         - docker
       tags:
         - reboot_setup
+        - rhcos
 
     # Set some facts that are used in multiple roles
     - role: osname_set_fact
       tags:
         - osname_set_fact
+        - rhcos
 
     # TEST
     # Verify that rpm-ostree can be run as non-root or sudo
@@ -127,6 +138,7 @@
       expect_failure: false
       tags:
         - command_privilege_verify
+        - rhcos
 
     # TEST
     # Verify that the output from 'atomic host status'
@@ -140,6 +152,7 @@
     - role: selinux_verify
       tags:
         - selinux_verify
+        - rhcos
 
     # TEST
     # Verify that SELinux file contexts can be modified
@@ -148,6 +161,7 @@
       test_context: "{{ g_semanage_test_context }}"
       tags:
         - semanage_fcontext_mod
+        - rhcos
 
     # Sets the selinux context of test_dir
     - name: semanage_fcontext_verify
@@ -155,23 +169,27 @@
       test_context: "{{ g_semanage_test_context }}"
       tags:
         - semanage_fcontext_verify
+        - rhcos
 
     # Sets boolean defined in vars
     - role: selinux_boolean
       tags:
         - selinux_boolean
+        - rhcos
 
     # TEST
     # Verify that 'firewalld' is correctly installed/configured
     - role: firewalld_service_verify
       tags:
         - firewalld_service_verify
+        - rhcos
 
     # TEST
     # Verify that the Docker storage defaults are correct
     - role: docker_storage_verify
       tags:
         - docker_storage_verify
+        - rhcos
 
     # TEST
     # Verify that 'docker pull' is successful. (Note: this is a different
@@ -179,6 +197,7 @@
     - role: docker_pull_run_remove
       tags:
         - docker_pull_run_remove
+        - rhcos
 
     # TEST
     # Validate 'atomic pull', 'atomic scan' works correctly.
@@ -193,6 +212,7 @@
     - role: docker_remove_all
       tags:
         - docker_remove_all
+        - rhcos
 
     # TEST
     # Validate atomic scan command
@@ -204,6 +224,7 @@
     - role: docker_remove_all
       tags:
         - docker_remove_all
+        - rhcos
 
     # Install package using package layering
     - role: rpm_ostree_install
@@ -232,18 +253,21 @@
     - role: ostree_admin_unlock_hotfix
       tags:
         - ostree_admin_unlock_hotfix
+        - rhcos
 
     # TEST
     # Verify overlayfs is present
     - role: overlayfs_verify_present
       tags:
         - overlayfs_verify_present
+        - rhcos
 
     # Install an rpm using the rpm command
     - role: rpm_install
       rpm_path: "{{ g_rpm_path }}"
       tags:
         - rpm_install
+        - rhcos
 
     # TEST
     # Verify the rpm installed successfully when unlocked
@@ -252,18 +276,21 @@
       check_binary: false
       tags:
         - package_verify_present
+        - rhcos
 
     # TEST
     # Verify that /tmp has the proper permissions
     - role: tmp_check_perms
       tags:
         - tmp_check_perms
+        - rhcos
 
     # TEST
     # Verify that the RPM database is functional
     - role: rpmdb_verify
       tags:
         - rpmdb_verify
+        - rhcos
 
     # Add users, make changes to /etc, and add things to /var before the
     # the system is upgraded
@@ -271,6 +298,7 @@
       ua_uid: "{{ g_uid1 }}"
       tags:
         - user_add
+        - rhcos
 
     # TEST
     # Verify the user created is present
@@ -278,17 +306,20 @@
       uvp_uid: "{{ g_uid1 }}"
       tags:
         - user_verify_present
+        - rhcos
 
     # Modify etc
     - role: etc_modify
       tags:
         - etc_modify
+        - rhcos
 
     # TEST
     # Verify that the changes to etc persisted
     - role: etc_verify_changes
       tags:
         - etc_verify_changes
+        - rhcos
 
     # Add files to var
     - role: var_add_files
@@ -296,6 +327,7 @@
       vaf_dirname: "{{ g_dir1 }}"
       tags:
         - var_add_files
+        - rhcos
 
     # TEST
     # Verify the files added to var persisted
@@ -304,6 +336,7 @@
       vfp_dirname: "{{ g_dir1 }}"
       tags:
         - var_files_present
+        - rhcos
 
     # Pull down docker base images, build a layered image, run it, then
     # remove the container.  But we keep the image around to run later.
@@ -312,6 +345,7 @@
     - role: docker_pull_base_image
       tags:
         - docker_pull_base_image
+        - rhcos
 
     # Build a local httpd image
     - role: docker_build
@@ -334,6 +368,7 @@
       tags:
         - atomic_stop_verify
 
+    #####
     # TEST
     # Verify we can remove the httpd container and it is no longer running
     - role: docker_rm_container
@@ -354,7 +389,7 @@
     - role: check_open_port
       cop_port: "80"
       cop_url: "http://localhost:80"
-      tag:
+      tags:
         - check_open_port
 
     # TEST
@@ -374,6 +409,7 @@
       tags:
         - container_manage_cgroup_bool
         - non_priv_systemd_httpd_container
+        - rhcos
 
     # TEST
     # Build non-priviledged systemd httpd container
@@ -423,6 +459,7 @@
       version: test2
       tags:
         - local_branch_commit
+        - rhcos
       check_mode: false
 
     # TEST
@@ -435,6 +472,7 @@
     - role: rpm_ostree_upgrade
       tags:
         - rpm_ostree_upgrade
+        - rhcos
       check_mode: false
 
     # Before we reboot, check the journal for anything that blew up
@@ -442,12 +480,14 @@
       tags:
         - journal_fatal_msgs_reboot
         - journal_fatal_msgs
+        - rhcos
 
     - role: reboot
       wait_for_services:
         - docker
       tags:
         - reboot_pre_upgrade
+        - rhcos
 
 # ---
 
@@ -468,22 +508,26 @@
     - role: ansible_version_check
       tags:
         - ansible_version_check
+        - rhcos
 
     - role: handler_notify_on_failure
       handler_name: h_get_journal
       tags:
         - handler_notify_on_failure
+        - rhcos
       check_mode: false
 
     - role: atomic_host_check
       tags:
         - atomic_host_check
+        - rhcos
 
     # Setup facts again. (Need to use the 'check_mode: false' option to ensure the
     # role runs again)
     - role: osname_set_fact
       tags:
         - osname_set_fact
+        - rhcos
       check_mode: false
 
     # Before we do any additional actions, let's check the journal to see if
@@ -492,6 +536,7 @@
       tags:
         - journal_fatal_msgs_second_boot
         - journal_fatal_msgs
+        - rhcos
 
     # We remove any subscriptions after the upgrade to verify that
     # 'rpm-ostree status' with the 'unconfigured-state' field present.
@@ -509,6 +554,7 @@
       expect_failure: false
       tags:
         - command_privilege_verify
+        - rhcos
 
     # Compare 'atomic host status' and 'rpm-ostree status' again
     - role: atomic_host_status_verify
@@ -526,6 +572,7 @@
     - role: selinux_verify
       tags:
         - selinux_verify
+        - rhcos
 
     # Verify the change to the SELinux file context persisted
     - role: semanage_fcontext_verify
@@ -533,26 +580,31 @@
       test_context: "{{ g_semanage_test_context }}"
       tags:
         - semanage_fcontext_verify
+        - rhcos
 
     # Verify the SELinux boolean changes
     - role: selinux_boolean_verify
       tags:
         - selinux_boolean_verify
+        - rhcos
 
     # TEST
     # Verify that 'firewalld' is correctly installed/configured
     - role: firewalld_service_verify
       tags:
         - firewalld_service_verify
+        - rhcos
 
     # Verify that the Docker storage defaults haven't changed
     - role: docker_storage_verify
       tags:
         - docker_storage_verify
+        - rhcos
 
     - role: docker_pull_run_remove
       tags:
         - docker_pull_run_remove
+        - rhcos
 
     # Check layered package is still installed
     - role: rpm_ostree_install_verify
@@ -651,6 +703,7 @@
     - role: overlayfs_verify_missing
       tags:
         - overlayfs_verify_missing
+        - rhcos
 
     # TEST
     # Verify admin unlocked package is removed after upgrade
@@ -658,18 +711,21 @@
       rpm_name: "{{ g_rpm_name }}"
       tags:
         - package_verify_missing
+        - rhcos
 
     # TEST
     # Check that /tmp is properly setup again
     - role: tmp_check_perms
       tags:
         - tmp_check_perms
+        - rhcos
 
     # TEST
     # Check that the RPM database is functional again
     - role: rpmdb_verify
       tags:
         - rpmdb_verify
+        - rhcos
 
     # TEST
     # Verify that the new users, /etc changes, and /var additions are still
@@ -678,22 +734,26 @@
       uvp_uid: "{{ g_uid1 }}"
       tags:
         - user_verify_present
+        - rhcos
 
     - role: etc_verify_changes
       tags:
         - etc_verify_changes
+        - rhcos
 
     - role: var_files_present
       vfp_filename: "{{ g_file1 }}"
       vfp_dirname: "{{ g_dir1 }}"
       tags:
         - var_files_present
+        - rhcos
 
     # Add more users and more files to /var ahead of the rollback
     - role: user_add
       ua_uid: "{{ g_uid2 }}"
       tags:
         - user_add
+        - rhcos
 
     # TEST
     # Ensure the user we just added is present
@@ -701,6 +761,7 @@
       uvp_uid: "{{ g_uid2 }}"
       tags:
         - user_verify_present
+        - rhcos
 
     # Add some files to var
     - role: var_add_files
@@ -708,6 +769,7 @@
       vaf_dirname: "{{ g_dir2 }}"
       tags:
         - var_add_files
+        - rhcos
 
     # TEST
     # Ensure the files we added var are present
@@ -716,6 +778,7 @@
       vfp_dirname: "{{ g_dir2 }}"
       tags:
         - var_files_present
+        - rhcos
 
     # TEST
     # Install, run and uninstall cockpit using atomic command
@@ -778,6 +841,7 @@
     - role: docker_remove_all
       tags:
         - docker_remove_all
+        - rhcos
 
     # TEST
     # Validate atomic pull works
@@ -789,6 +853,7 @@
     - role: docker_remove_all
       tags:
         - docker_remove_all
+        - rhcos
 
     # TEST
     # Validate atomic scan works
@@ -800,12 +865,14 @@
     - role: rpm_ostree_rollback
       tags:
         - rpm_ostree_rollback
+        - rhcos
 
     # Before we reboot, check the journal for anything that blew up
     - role: journal_fatal_msgs
       tags:
         - journal_fatal_msgs_second_reboot
         - journal_fatal_msgs
+        - rhcos
 
     # Reboot the host and don't continue until expected services have started
     - role: reboot
@@ -813,6 +880,7 @@
         - docker
       tags:
         - reboot_post_upgrade
+        - rhcos
 
 # ---
 
@@ -833,18 +901,21 @@
     - role: ansible_version_check
       tags:
         - ansible_version_check
+        - rhcos
 
     # Set up handler notification
     - role: handler_notify_on_failure
       handler_name: h_get_journal
       tags:
         - handler_notify_on_failure
+        - rhcos
       check_mode: false
 
     # Ensure the host(s) are indeed Atomic Host(s)
     - role: atomic_host_check
       tags:
         - atomic_host_check
+        - rhcos
 
     # Before we do any additional actions, let's check the journal to see if
     # anything blew up after reboot
@@ -852,10 +923,12 @@
       tags:
         - journal_fatal_msgs_third_boot
         - journal_fatal_msgs
+        - rhcos
 
     - role: selinux_verify
       tags:
         - selinux_verify
+        - rhcos
 
     # TEST
     # Verify that the change to the SELinux file context still exists in
@@ -865,6 +938,7 @@
       test_context: "{{ g_semanage_test_context }}"
       tags:
         - semanage_fcontext_verify
+        - rhcos
 
     # TEST
     # Check layered package is still installed
@@ -893,18 +967,21 @@
     - role: tmp_check_perms
       tags:
         - tmp_check_perms
+        - rhcos
 
     # TEST
     # Check that the RPM database is functional yet again
     - role: rpmdb_verify
       tags:
         - rpmdb_verify
+        - rhcos
 
     # TEST
     # Verify changes still exist in original tree
     - role: etc_verify_changes
       tags:
         - etc_verify_changes
+        - rhcos
 
     # TEST
     # Verify first user added is still present in original tree
@@ -912,6 +989,7 @@
       uvp_uid: "{{ g_uid1 }}"
       tags:
         - user_verify_present
+        - rhcos
 
     # TEST
     # Verify first files dropped in /var are still in original tree
@@ -920,6 +998,7 @@
       vfp_dirname: "{{ g_dir1 }}"
       tags:
         - var_files_present
+        - rhcos
 
     # TEST
     # Verify that the newest user is not present in the previous tree
@@ -927,6 +1006,7 @@
       uvm_uid: "{{ g_uid2 }}"
       tags:
         - user_verify_missing
+        - rhcos
 
     # TEST
     # Verify the most recent changes to /var are present
@@ -935,6 +1015,7 @@
       vfp_dirname: "{{ g_dir2 }}"
       tags:
         - var_files_present
+        - rhcos
 
     # TEST
     # use 'all' keyword to remove all installed pacakges
@@ -943,12 +1024,14 @@
       rou_reboot: true
       tags:
         - rpm_ostree_uninstall
+        - rhcos
 
     # load in the YAML files with archived deployment info
     - role: load_variables
       filename: "{{ playbook_dir}}/{{ ansible_host }}_bdsf_archive.yml"
       tags:
         - load_variables
+        - rhcos
 
     # rebase back to original checkout
     - role: rpm_ostree_rebase
@@ -957,6 +1040,7 @@
       ror_commit: "{{ g_archive_checksum }}"
       tags:
         - rpm_ostree_rebase
+        - rhcos
 
     # Reboot the host and don't continue until expected services have started
     - role: reboot
@@ -964,16 +1048,19 @@
         - docker
       tags:
         - reboot_cleanup
+        - rhcos
 
     # cleanup any extra deployments
     - role: rpm_ostree_cleanup_all
       tags:
         - rpm_ostree_cleanup_all
+        - rhcos
 
     # remove any docker artifacts
     - role: docker_remove_all
       tags:
         - docker_remove_all
+        - rhcos
 
     # remove users
     - role: user_del
@@ -982,6 +1069,7 @@
         - "{{ g_uid2 }}"
       tags:
         - user_del
+        - rhcos
 
     # cleanup our subscriptions because we are nice people
     - when: ansible_distribution == 'RedHat'
@@ -994,3 +1082,4 @@
       tags:
         - journal_fatal_msgs_final
         - journal_fatal_msgs
+        - rhcos


### PR DESCRIPTION
Lets add tagging to the improved-sanity-test to run against RHCOS.
There is an existing cloud_image tag to run against cloud images so
using tag `rhcos` to run against RHCOS seemed like a good idea.  The
roles without tags did not work with RHCOS so it will only test a
subset of the original improved-sanity-test.

Since RHCOS shares the same ansible_distribution as RHEL AH, I had to
use the ansible_distribution_major version to distinguish between
RHCOS and RHELAH in docker_storage_verify and selinux_verify.

Also snuck in a small fix for the rpm_ostree_rebase role.