### PR TITLE
roles/rpm_ostree_status: remove tools container on exit

### DIFF
--- a/roles/rpm_ostree_status/tasks/main.yml
+++ b/roles/rpm_ostree_status/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Get rpm-ostree status output
   shell: >
     rpm-ostree status --json |
-    docker run -i docker.io/miabbott/aht-tools
+    docker run --rm -i docker.io/miabbott/aht-tools
     jq 'del(.deployments[]["layered-commit-meta"]["rpmostree.rpmdb.pkglist"],
             .deployments[]["base-commit-meta"]["rpmostree.rpmdb.pkglist"])'
   register: ros


### PR DESCRIPTION
When reusing a test system to validate some other changes, I noticed
that there were a pile of `aht-tools` containers on the host.  This
looks like an oversight when I first started using the tools container
to filter out JSON keys; should make things a little more tidy.