### PR TITLE
docker-swarm: explicitly fail based on test results

### DIFF
--- a/tests/docker-swarm/main.yml
+++ b/tests/docker-swarm/main.yml
@@ -47,4 +47,13 @@
           when: log_results
           local_action: copy content={{ tests | to_nice_yaml(indent=2) }} dest={{ result_file }}
           become: false
+
+        # Handled exceptions show up as failures in Ansible but the playbook
+        # itself does not return 0, so explicitly fail the test by checking
+        # the test results
+        - name: Explicitly fail based on test results
+          when: item['result']|lower == "failed"
+          fail:
+            msg: "Failure found in test"
+          with_items: "{{ tests }}"
       tags: cleanup


### PR DESCRIPTION
I don't think Ansible considers handled exceptions as failures even
though it will display failures in the playbook summary.  Lets
explicitly fail if any of the test results have failures.