### PR TITLE
system-containers: explicitly fail on results

### DIFF
--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible:
+# vim: set ft=ansible
 #
 # !!!NOTE!!! This playbook was tested using Ansible 2.2; it is recommended
 # that the same version is used.
@@ -172,5 +172,14 @@
           when: log_results
           local_action: copy content={{ tests | to_nice_yaml(indent=2) }} dest={{ result_file }}
           become: false
+
+        # Handled exceptions show up as failures in Ansible but the playbook
+        # itself does not return 0, so explicitly fail the test by checking
+        # the test results
+        - name: Explicitly fail based on test results
+          when: item['result']|lower == "failed"
+          fail:
+            msg: "Failure found in test"
+          with_items: "{{ tests }}"
       tags:
         - cleanup


### PR DESCRIPTION
Ansible doesn't seem to fail on handled exceptions so lets explicitly
fail based on the test results.