### PR TITLE
atomic: explicitly fail on test results

### DIFF
--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -125,3 +125,12 @@
           local_action: copy content={{ tests | to_nice_yaml(indent=2) }} dest={{ result_file }}
           become: false
       tags: cleanup
+
+    # Handled exceptions show up as failures in Ansible but the playbook
+    # itself does not return 0, so explicitly fail the test by checking
+    # the test results
+    - name: Explicitly fail based on test results
+      when: item['result']|lower == "failed"
+      fail:
+        msg: "Failure found in test"
+      with_items: "{{ tests }}"


### PR DESCRIPTION
Ansible does not consider handled exceptions failures and will return
0.  Lets explicitly fail the playbook based on test results so Ansible
will return non-zero.