### PR TITLE
package-layering: explicitly fail on test results

### DIFF
--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -184,3 +184,12 @@
           local_action: copy content={{ tests | to_nice_yaml(indent=2) }} dest={{ result_file }}
           become: false
       tags: cleanup
+
+    # Handled exceptions show up as failures in Ansible but the playbook
+    # itself does not return 0, so explicitly fail the test by checking
+    # the test results
+    - name: Explicitly fail based on test results
+      when: item['result']|lower == "failed"
+      fail:
+        msg: "Failure found in test"
+      with_items: "{{ tests }}"


### PR DESCRIPTION
Ansible does not considered handled exceptions failures.  Lets
explicitly fail based on test results.