### PR TITLE
treewide: add in correct vim modeline and YAML doc header

### DIFF
--- a/roles/ansible_version_check/meta/main.yml
+++ b/roles/ansible_version_check/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/ansible_version_check/vars/main.yml
+++ b/roles/ansible_version_check/vars/main.yml
@@ -1,3 +1,4 @@
 ---
+# vim: set ft=ansible:
 avc_major: '2'
 avc_minor: '4'

--- a/roles/atomic_containers_delete/meta/main.yml
+++ b/roles/atomic_containers_delete/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_containers_list/meta/main.yml
+++ b/roles/atomic_containers_list/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_host_check/meta/main.yml
+++ b/roles/atomic_host_check/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/atomic_host_status_verify/meta/main.yml
+++ b/roles/atomic_host_status_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_host_versions/defaults/main.yml
+++ b/roles/atomic_host_versions/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 ahv_rpms:
   - atomic
   - docker

--- a/roles/atomic_host_versions/meta/main.yml
+++ b/roles/atomic_host_versions/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/atomic_images_delete/meta/main.yml
+++ b/roles/atomic_images_delete/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_images_delete_all/meta/main.yml
+++ b/roles/atomic_images_delete_all/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_images_list/meta/main.yml
+++ b/roles/atomic_images_list/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_install/meta/main.yml
+++ b/roles/atomic_install/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_installation_verify/meta/main.yml
+++ b/roles/atomic_installation_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_pull/meta/main.yml
+++ b/roles/atomic_pull/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_pull_verify/meta/main.yml
+++ b/roles/atomic_pull_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_push/meta/main.yml
+++ b/roles/atomic_push/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_run/meta/main.yml
+++ b/roles/atomic_run/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_run_verify/meta/main.yml
+++ b/roles/atomic_run_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_scan/meta/main.yml
+++ b/roles/atomic_scan/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_scan_verify/meta/main.yml
+++ b/roles/atomic_scan_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_stop/meta/main.yml
+++ b/roles/atomic_stop/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_stop_verify/meta/main.yml
+++ b/roles/atomic_stop_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_system_install/meta/main.yml
+++ b/roles/atomic_system_install/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_system_install_verify/meta/main.yml
+++ b/roles/atomic_system_install_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_system_uninstall/meta/main.yml
+++ b/roles/atomic_system_uninstall/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_system_uninstall_verify/meta/main.yml
+++ b/roles/atomic_system_uninstall_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/atomic_uninstall/meta/main.yml
+++ b/roles/atomic_uninstall/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/booted_deployment_set_fact/meta/main.yml
+++ b/roles/booted_deployment_set_fact/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/command/meta/main.yml
+++ b/roles/command/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/command_privilege_verify/meta/main.yml
+++ b/roles/command_privilege_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/container_image_scanner/meta/main.yml
+++ b/roles/container_image_scanner/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 dependencies:
   - { role: atomic_pull, image: "{{ image }}" }
   - { role: atomic_scan, image: "{{ image }}" }

--- a/roles/docker_build/meta/main.yml
+++ b/roles/docker_build/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/docker_build_tag_push/meta/main.yml
+++ b/roles/docker_build_tag_push/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_build_tag_push/tasks/main.yml
+++ b/roles/docker_build_tag_push/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 #
 # This role creates the docker webserver and database images, then tags and
 # pushes the images to a private registry that is setup in another role.

--- a/roles/docker_commit/meta/main.yml
+++ b/roles/docker_commit/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_commit/tasks/main.yml
+++ b/roles/docker_commit/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 #
 #  Commit a change to an image
 #

--- a/roles/docker_images/meta/main.yml
+++ b/roles/docker_images/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_latest_setup/meta/main.yml
+++ b/roles/docker_latest_setup/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_live_restore_disable/meta/main.yml
+++ b/roles/docker_live_restore_disable/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_live_restore_disable/tasks/main.yml
+++ b/roles/docker_live_restore_disable/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 #
 #  Disables docker live-restore
 #

--- a/roles/docker_private_registry/meta/main.yml
+++ b/roles/docker_private_registry/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_pull/meta/main.yml
+++ b/roles/docker_pull/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_pull_base_image/meta/main.yml
+++ b/roles/docker_pull_base_image/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_pull_run_remove/meta/main.yml
+++ b/roles/docker_pull_run_remove/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_remove_all/meta/main.yml
+++ b/roles/docker_remove_all/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_rm_container/meta/main.yml
+++ b/roles/docker_rm_container/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_rmi/meta/main.yml
+++ b/roles/docker_rmi/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_run/meta/main.yml
+++ b/roles/docker_run/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_storage_verify/meta/main.yml
+++ b/roles/docker_storage_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_storage_verify/vars/devicemapper.yml
+++ b/roles/docker_storage_verify/vars/devicemapper.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 driver: 'devicemapper'

--- a/roles/docker_storage_verify/vars/overlay2.yml
+++ b/roles/docker_storage_verify/vars/overlay2.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 driver: 'overlay2'

--- a/roles/docker_storage_verify/vars/redhat-3.yml
+++ b/roles/docker_storage_verify/vars/redhat-3.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 driver: 'overlay2'

--- a/roles/docker_tag/meta/main.yml
+++ b/roles/docker_tag/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/docker_tag/tasks/main.yml
+++ b/roles/docker_tag/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 #
 #  Tags an image
 #

--- a/roles/docker_version_check/meta/main.yml
+++ b/roles/docker_version_check/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/epel_rpm_url/meta/main.yml
+++ b/roles/epel_rpm_url/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/etc_modify/meta/main.yml
+++ b/roles/etc_modify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/etc_verify_changes/meta/main.yml
+++ b/roles/etc_verify_changes/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/etcd_sys_container_install/meta/main.yml
+++ b/roles/etcd_sys_container_install/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/firewalld_service_verify/meta/main.yml
+++ b/roles/firewalld_service_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/handler_notify_on_failure/handlers/main.yml
+++ b/roles/handler_notify_on_failure/handlers/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 #
 # This file is a collection of generic handlers that could be used in multiple
 # playbooks.  Please use the h_get_journal handler as a template for other

--- a/roles/handler_notify_on_failure/meta/main.yml
+++ b/roles/handler_notify_on_failure/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/httpd_start/meta/main.yml
+++ b/roles/httpd_start/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/journal_search/meta/main.yml
+++ b/roles/journal_search/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/k8_cluster_services_rc_setup/files/db-rc.yml
+++ b/roles/k8_cluster_services_rc_setup/files/db-rc.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 apiVersion: v1
 kind: ReplicationController
 metadata:

--- a/roles/k8_cluster_services_rc_setup/files/db-service.yml
+++ b/roles/k8_cluster_services_rc_setup/files/db-service.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 apiVersion: v1
 kind: Service
 metadata:

--- a/roles/k8_cluster_services_rc_setup/files/webserver-rc.yml
+++ b/roles/k8_cluster_services_rc_setup/files/webserver-rc.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 kind: "ReplicationController"
 apiVersion: "v1"
 metadata:

--- a/roles/k8_cluster_services_rc_setup/files/webserver-service.yml
+++ b/roles/k8_cluster_services_rc_setup/files/webserver-service.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 apiVersion: v1
 kind: Service
 metadata:

--- a/roles/k8_cluster_services_rc_setup/meta/main.yml
+++ b/roles/k8_cluster_services_rc_setup/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/k8_cluster_services_rc_setup/tasks/main.yml
+++ b/roles/k8_cluster_services_rc_setup/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 #
 #  This role sets up the replication controller and services for the webserver
 #  and database server

--- a/roles/k8_remove_all/meta/main.yml
+++ b/roles/k8_remove_all/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/kubernetes_set_facts/meta/main.yml
+++ b/roles/kubernetes_set_facts/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/kubernetes_setup/meta/main.yml
+++ b/roles/kubernetes_setup/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/load_variables/meta/main.yml
+++ b/roles/load_variables/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/local_branch_commit/meta/main.yml
+++ b/roles/local_branch_commit/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/local_branch_setup/meta/main.yml
+++ b/roles/local_branch_setup/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/machine_id_compare/meta/main.yml
+++ b/roles/machine_id_compare/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/origin_file_modify/meta/main.yml
+++ b/roles/origin_file_modify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/osname_set_fact/meta/main.yml
+++ b/roles/osname_set_fact/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/ostree_admin_unlock/meta/main.yml
+++ b/roles/ostree_admin_unlock/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/ostree_admin_unlock_hotfix/meta/main.yml
+++ b/roles/ostree_admin_unlock_hotfix/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/overlayfs_verify_missing/meta/main.yml
+++ b/roles/overlayfs_verify_missing/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/overlayfs_verify_present/meta/main.yml
+++ b/roles/overlayfs_verify_present/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/package_verify_missing/meta/main.yml
+++ b/roles/package_verify_missing/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/package_verify_present/meta/main.yml
+++ b/roles/package_verify_present/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/reboot/meta/main.yml
+++ b/roles/reboot/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/redhat_subscription/meta/main.yml
+++ b/roles/redhat_subscription/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/redhat_subscription/vars/main.yml
+++ b/roles/redhat_subscription/vars/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 subscription_file: "subscription_data.csv"

--- a/roles/redhat_unsubscribe/meta/main.yml
+++ b/roles/redhat_unsubscribe/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/resize_lv/meta/main.yml
+++ b/roles/resize_lv/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_install/meta/main.yml
+++ b/roles/rpm_install/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_nevra/meta/main.yml
+++ b/roles/rpm_nevra/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_nevra_compare/meta/main.yml
+++ b/roles/rpm_nevra_compare/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_cleanup_all/meta/main.yml
+++ b/roles/rpm_ostree_cleanup_all/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_install/meta/main.yml
+++ b/roles/rpm_ostree_install/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_install_verify/meta/main.yml
+++ b/roles/rpm_ostree_install_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_livefs/meta/main.yml
+++ b/roles/rpm_ostree_livefs/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_override/meta/main.yml
+++ b/roles/rpm_ostree_override/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_rebase/meta/main.yml
+++ b/roles/rpm_ostree_rebase/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_rollback/meta/main.yml
+++ b/roles/rpm_ostree_rollback/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_status/meta/main.yml
+++ b/roles/rpm_ostree_status/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/rpm_ostree_status_verify/meta/main.yml
+++ b/roles/rpm_ostree_status_verify/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true
 
 dependencies:

--- a/roles/rpm_ostree_uninstall/meta/main.yml
+++ b/roles/rpm_ostree_uninstall/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_uninstall_verify/meta/main.yml
+++ b/roles/rpm_ostree_uninstall_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_ostree_upgrade/meta/main.yml
+++ b/roles/rpm_ostree_upgrade/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_signature_verify/vars/centos-7.yml
+++ b/roles/rpm_signature_verify/vars/centos-7.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 rsv_gpg_key: '24c6a8a7f4a80eb5'

--- a/roles/rpm_signature_verify/vars/fedora-26.yml
+++ b/roles/rpm_signature_verify/vars/fedora-26.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 rsv_gpg_key: '812a6b4b64dab85d'

--- a/roles/rpm_signature_verify/vars/fedora-27.yml
+++ b/roles/rpm_signature_verify/vars/fedora-27.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 rsv_gpg_key: 'f55e7430f5282ee4'

--- a/roles/rpm_signature_verify/vars/fedora-28.yml
+++ b/roles/rpm_signature_verify/vars/fedora-28.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 rsv_gpg_key: 'e08e7e629db62fb1'

--- a/roles/rpm_signature_verify/vars/fedora-29.yml
+++ b/roles/rpm_signature_verify/vars/fedora-29.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 rsv_gpg_key: 'a20aa56b429476b4'

--- a/roles/rpm_signature_verify/vars/redhat-7.yml
+++ b/roles/rpm_signature_verify/vars/redhat-7.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 rsv_gpg_key: '199e2f91fd431d51'

--- a/roles/rpm_uninstall/meta/main.yml
+++ b/roles/rpm_uninstall/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpm_version/meta/main.yml
+++ b/roles/rpm_version/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/rpmdb_verify/meta/main.yml
+++ b/roles/rpmdb_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/selinux_boolean/meta/main.yml
+++ b/roles/selinux_boolean/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/selinux_boolean/tasks/main.yml
+++ b/roles/selinux_boolean/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 #
 - name: Fail if 'g_seboolean' is not defined
   when: g_seboolean is undefined

--- a/roles/selinux_boolean_verify/meta/main.yml
+++ b/roles/selinux_boolean_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/selinux_boolean_verify/tasks/main.yml
+++ b/roles/selinux_boolean_verify/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 #
 - name: Fail if 'g_seboolean' is undefined
   when: g_seboolean is undefined

--- a/roles/selinux_verify/meta/main.yml
+++ b/roles/selinux_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/selinux_verify/vars/centos-7.yml
+++ b/roles/selinux_verify/vars/centos-7.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }

--- a/roles/selinux_verify/vars/centosdev-7.yml
+++ b/roles/selinux_verify/vars/centosdev-7.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }

--- a/roles/selinux_verify/vars/common.yml
+++ b/roles/selinux_verify/vars/common.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # Until RHBZ #1428112 is fixed, we are removing the `/sysroot` entry from
 # this list.
 mountpoints:

--- a/roles/selinux_verify/vars/fedora.yml
+++ b/roles/selinux_verify/vars/fedora.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }

--- a/roles/selinux_verify/vars/redhat-3.yml
+++ b/roles/selinux_verify/vars/redhat-3.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }

--- a/roles/selinux_verify/vars/redhat-7.yml
+++ b/roles/selinux_verify/vars/redhat-7.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }

--- a/roles/semanage_fcontext_mod/meta/main.yml
+++ b/roles/semanage_fcontext_mod/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/semanage_fcontext_mod/tasks/main.yml
+++ b/roles/semanage_fcontext_mod/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 - name: Fail if variables are not defined
   when: test_dir_match is undefined or
         test_context is undefined

--- a/roles/semanage_fcontext_verify/meta/main.yml
+++ b/roles/semanage_fcontext_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/semanage_fcontext_verify/tasks/main.yml
+++ b/roles/semanage_fcontext_verify/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 - name: Fail if required variables are not defined.
   when: test_dir is undefined or
         test_context is undefined

--- a/roles/set_is_atomic/meta/main.yml
+++ b/roles/set_is_atomic/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/tmp_check_perms/meta/main.yml
+++ b/roles/tmp_check_perms/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/url_verify/meta/main.yml
+++ b/roles/url_verify/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/user_add/meta/main.yml
+++ b/roles/user_add/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/user_del/meta/main.yml
+++ b/roles/user_del/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/user_verify_missing/meta/main.yml
+++ b/roles/user_verify_missing/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/user_verify_present/meta/main.yml
+++ b/roles/user_verify_present/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/var_add_files/meta/main.yml
+++ b/roles/var_add_files/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/roles/var_files_present/meta/main.yml
+++ b/roles/var_files_present/meta/main.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 allow_duplicates: true

--- a/tests/admin-unlock/add_remove_package_non_persistence.yml
+++ b/tests/admin-unlock/add_remove_package_non_persistence.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - import_role:
     name: ostree_admin_unlock

--- a/tests/admin-unlock/add_remove_package_persistence.yml
+++ b/tests/admin-unlock/add_remove_package_persistence.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - import_role:
     name: ostree_admin_unlock_hotfix

--- a/tests/admin-unlock/cleanup.yml
+++ b/tests/admin-unlock/cleanup.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - import_role:
     name: rpm_ostree_rollback

--- a/tests/admin-unlock/hotfix_rollback.yml
+++ b/tests/admin-unlock/hotfix_rollback.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - import_role:
     name: rpm_ostree_rollback

--- a/tests/admin-unlock/main.yml
+++ b/tests/admin-unlock/main.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 #
 # Logging
 #   Running the playbook will automatically create a test result file in the

--- a/tests/admin-unlock/no_install_without_unlock.yml
+++ b/tests/admin-unlock/no_install_without_unlock.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - name: Attempt to install rpm
   command: rpm -i {{ g_rpm_url }}

--- a/tests/admin-unlock/setup.yml
+++ b/tests/admin-unlock/setup.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - name: Verify all
   when: g_rpm_url is undefined or

--- a/tests/admin-unlock/unlock_twice_error.yml
+++ b/tests/admin-unlock/unlock_twice_error.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - name: Unlock system
   command: ostree admin unlock

--- a/tests/admin-unlock/unlock_twice_hotfix_error.yml
+++ b/tests/admin-unlock/unlock_twice_hotfix_error.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 
 - name: Unlock system with hotfix
   command: ostree admin unlock --hotfix

--- a/tests/admin-unlock/vars.yml
+++ b/tests/admin-unlock/vars.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 g_rpm_url: 'https://raw.githubusercontent.com/projectatomic/atomic-host-tests/master/rpm/aht-dummy-1.0-1.noarch.rpm'
 g_rpm_path: 'rpm/aht-dummy-1.0-1.noarch.rpm'
 g_rpm_name: 'aht-dummy'

--- a/tests/atomic/cleanup.yml
+++ b/tests/atomic/cleanup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/fully_qualified_container_name.yml
+++ b/tests/atomic/fully_qualified_container_name.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/fully_qualified_name.yml
+++ b/tests/atomic/fully_qualified_name.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/images_update.yml
+++ b/tests/atomic/images_update.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/main.yml
+++ b/tests/atomic/main.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 #
 - name: Atomic CLI Test Suite
   hosts: all

--- a/tests/atomic/pull_digest.yml
+++ b/tests/atomic/pull_digest.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/pull_storage.yml
+++ b/tests/atomic/pull_storage.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/pull_tags.yml
+++ b/tests/atomic/pull_tags.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/setup.yml
+++ b/tests/atomic/setup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/short_name.yml
+++ b/tests/atomic/short_name.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/atomic/vars.yml
+++ b/tests/atomic/vars.yml
@@ -1,3 +1,4 @@
 ---
+# vim: set ft=ansible:
 g_container_name: etcd
 g_container_fq_name: registry.access.redhat.com/rhel7/etcd

--- a/tests/atomic/vars/centos.yml
+++ b/tests/atomic/vars/centos.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 cockpit_short_name: "cockpit/ws"
 cockpit_fq_name: "docker.io/cockpit/ws"
 cockpit_cname: "registry.fedoraproject.org/f27/cockpit"

--- a/tests/atomic/vars/centosdev.yml
+++ b/tests/atomic/vars/centosdev.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 cockpit_short_name: "cockpit/ws"
 cockpit_fq_name: "docker.io/cockpit/ws"
 cockpit_cname: "registry.fedoraproject.org/f27/cockpit"

--- a/tests/atomic/vars/fedora.yml
+++ b/tests/atomic/vars/fedora.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 cockpit_short_name: "cockpit/ws"
 cockpit_fq_name: "docker.io/cockpit/ws"
 cockpit_cname: "registry.fedoraproject.org/f27/cockpit"

--- a/tests/atomic/vars/redhat.yml
+++ b/tests/atomic/vars/redhat.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 cockpit_short_name: "rhel7/cockpit-ws"
 cockpit_fq_name: "registry.access.redhat.com/rhel7/cockpit-ws"
 cockpit_cname: "registry.access.redhat.com/rhel7/cockpit-ws"

--- a/tests/docker-build-httpd/cleanup.yml
+++ b/tests/docker-build-httpd/cleanup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker-build-httpd/docker-build-httpd.yml
+++ b/tests/docker-build-httpd/docker-build-httpd.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker-build-httpd/main.yml
+++ b/tests/docker-build-httpd/main.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 - name: Docker Build HTTPD - Test Suite
   hosts: all
   become: true

--- a/tests/docker-build-httpd/setup.yml
+++ b/tests/docker-build-httpd/setup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker-build-httpd/vars.yml
+++ b/tests/docker-build-httpd/vars.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 base_images:
   - docker.io/alpine
   - docker.io/busybox

--- a/tests/docker-swarm/cleanup.yml
+++ b/tests/docker-swarm/cleanup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker-swarm/functional.yml
+++ b/tests/docker-swarm/functional.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker-swarm/main.yml
+++ b/tests/docker-swarm/main.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 - name: Docker Swarm - Test Suite
   hosts: all
   become: true

--- a/tests/docker-swarm/setup.yml
+++ b/tests/docker-swarm/setup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker-swarm/vars.yml
+++ b/tests/docker-swarm/vars.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 g_image_name: 'docker.io/httpd'
 g_ports: '80:80'
 g_service_name: 'httpd'

--- a/tests/docker/cleanup.yml
+++ b/tests/docker/cleanup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker/functional.yml
+++ b/tests/docker/functional.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker/main.yml
+++ b/tests/docker/main.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 - name: Docker - Test Suite
   hosts: all
   become: true

--- a/tests/docker/setup.yml
+++ b/tests/docker/setup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/docker/vars.yml
+++ b/tests/docker/vars.yml
@@ -1,2 +1,3 @@
 ---
+# vim: set ft=ansible:
 g_docker_latest: true

--- a/tests/images_cve_scanner/vars.yml
+++ b/tests/images_cve_scanner/vars.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 registry: registry.access.redhat.com
 
 image_name_list:

--- a/tests/improved-sanity-test/vars/centos.yml
+++ b/tests/improved-sanity-test/vars/centos.yml
@@ -1,3 +1,4 @@
 ---
+# vim: set ft=ansible:
 g_ros_install_pkg: 'ntp'
 g_ros_install_bin: 'ntpd'

--- a/tests/improved-sanity-test/vars/common.yml
+++ b/tests/improved-sanity-test/vars/common.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 g_uid1: '2001'
 g_file1: 'commit1'
 g_dir1: 'qe1'

--- a/tests/improved-sanity-test/vars/os_defaults.yml
+++ b/tests/improved-sanity-test/vars/os_defaults.yml
@@ -1,3 +1,4 @@
 ---
+# vim: set ft=ansible:
 g_ros_install_pkg: 'httpd'
 g_ros_install_bin: 'httpd'

--- a/tests/k8-cluster/cleanup.yml
+++ b/tests/k8-cluster/cleanup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/k8-cluster/main.yml
+++ b/tests/k8-cluster/main.yml
@@ -1,3 +1,5 @@
+---
+# vim: set ft=ansible:
 - name: Kubernetes Cluster - Test Suite
   hosts: all
   become: true

--- a/tests/k8-cluster/setup.yml
+++ b/tests/k8-cluster/setup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/k8-cluster/single_node_cluster.yml
+++ b/tests/k8-cluster/single_node_cluster.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/alternate_repo_install.yml
+++ b/tests/pkg-layering/alternate_repo_install.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/cleanup.yml
+++ b/tests/pkg-layering/cleanup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/dry_run.yml
+++ b/tests/pkg-layering/dry_run.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/dry_run_interaction.yml
+++ b/tests/pkg-layering/dry_run_interaction.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/gpg.yml
+++ b/tests/pkg-layering/gpg.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/install_existing_pkg.yml
+++ b/tests/pkg-layering/install_existing_pkg.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/install_invalid_pkg.yml
+++ b/tests/pkg-layering/install_invalid_pkg.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/install_nonroot_pkg.yml
+++ b/tests/pkg-layering/install_nonroot_pkg.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/install_previously_layered.yml
+++ b/tests/pkg-layering/install_previously_layered.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/install_unprivileged.yml
+++ b/tests/pkg-layering/install_unprivileged.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/main.yml
+++ b/tests/pkg-layering/main.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/multi_pkg_install_uninstall.yml
+++ b/tests/pkg-layering/multi_pkg_install_uninstall.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/reboot_flag.yml
+++ b/tests/pkg-layering/reboot_flag.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 - set_fact:

--- a/tests/pkg-layering/setup.yml
+++ b/tests/pkg-layering/setup.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/single_pkg_install_uninstall.yml
+++ b/tests/pkg-layering/single_pkg_install_uninstall.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/uninstall_invalid_pkg.yml
+++ b/tests/pkg-layering/uninstall_invalid_pkg.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 # set ft=ansible
 #
 

--- a/tests/pkg-layering/vars.yml
+++ b/tests/pkg-layering/vars.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 g_pkg1: 'wget'
 g_pkg2: 'ltrace'
 g_invalid_pkg: 'foobar'

--- a/tests/rpm-ostree/vars.yml
+++ b/tests/rpm-ostree/vars.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 g_pkg: 'wget'
 g_remove_pkg: 'bash-completion'
 g_replace_pkg: 'tzdata'

--- a/tests/system-containers/main.yml
+++ b/tests/system-containers/main.yml
@@ -1,5 +1,5 @@
 ---
-# vim: set ft=ansible
+# vim: set ft=ansible:
 #
 # !!!NOTE!!! This playbook was tested using Ansible 2.2; it is recommended
 # that the same version is used.

--- a/tests/system-containers/vars.yml
+++ b/tests/system-containers/vars.yml
@@ -1,4 +1,5 @@
 ---
+# vim: set ft=ansible:
 g_hw_image: 'docker.io/gscrivano/hello-world'
 g_hw_name: 'hello-world'
 g_invalid_value: 'xxfoobarxx'


### PR DESCRIPTION
The OCD took over and I updated all of the YAML files to start with
the `---` document separator[0] and have a proper `vim` modeline[1]

[0] http://yaml.org/spec/1.0/#id2561718
[1] http://vimdoc.sourceforge.net/htmldoc/options.html#modeline