### PR TITLE
docker_pull_run_remove: add test for cpu-shares flag

### DIFF
--- a/roles/docker_pull_run_remove/tasks/main.yml
+++ b/roles/docker_pull_run_remove/tasks/main.yml
@@ -4,7 +4,7 @@
 # popular_images is defined in roles/docker_pull_run_remove/vars/main.yml
 #
 - name: Pull the popular images from Docker Hub
-  command: "docker pull docker.io/{{ item }}"
+  command: "docker pull {{ item }}"
   with_items: "{{ popular_images }}"
   register: dpd
   retries: 5
@@ -12,9 +12,14 @@
   until: dpd|success
 
 - name: Run the popular images
-  command: "docker run --rm docker.io/{{ item }} echo 'hello'"
+  command: "docker run --rm {{ item }} echo 'hello'"
+  with_items: "{{ popular_images }}"
+
+# Test for https://bugzilla.redhat.com/show_bug.cgi?id=1585735
+- name: Run the popular images with cpu-shares flag
+  command: "docker run --cpu-shares 2 --rm {{ item }} echo 'hello'"
   with_items: "{{ popular_images }}"
 
 - name: Remove the popular images
-  command: "docker rmi docker.io/{{ item }}"
+  command: "docker rmi {{ item }}"
   with_items: "{{ popular_images }}"

--- a/roles/docker_pull_run_remove/vars/main.yml
+++ b/roles/docker_pull_run_remove/vars/main.yml
@@ -2,6 +2,9 @@
 # vim: set ft=ansible:
 #
 popular_images:
-  - alpine
-  - busybox
-  - ubuntu
+  - docker.io/alpine
+  - docker.io/busybox
+  - docker.io/ubuntu
+  - registry.fedoraproject.org/fedora
+  - registry.centos.org/centos
+  - registry.access.redhat.com/rhel


### PR DESCRIPTION
This changes the `docker_pull_run_remove` role to add a test for the
use of `--cpu-shares` flag when doing `docker run`.  This is to catch
regressions such as RHBZ#1585735.

Additionally, I expanded the list of images we are testing to include
images from registries other than docker.io.

Closes #414