### PR TITLE
dprr: Clean up language and hotfix the centos image

### DIFF
--- a/roles/docker_pull_run_remove/tasks/main.yml
+++ b/roles/docker_pull_run_remove/tasks/main.yml
@@ -3,7 +3,7 @@
 #
 # popular_images is defined in roles/docker_pull_run_remove/vars/main.yml
 #
-- name: Pull the popular images from Docker Hub
+- name: Pull the popular container images
   command: "docker pull {{ item }}"
   with_items: "{{ popular_images }}"
   register: dpd
@@ -11,15 +11,15 @@
   delay: 60
   until: dpd|success
 
-- name: Run the popular images
+- name: Run the popular container images
   command: "docker run --rm {{ item }} echo 'hello'"
   with_items: "{{ popular_images }}"
 
 # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1585735
-- name: Run the popular images with cpu-shares flag
+- name: Run the popular container images with cpu-shares flag
   command: "docker run --cpu-shares 2 --rm {{ item }} echo 'hello'"
   with_items: "{{ popular_images }}"
 
-- name: Remove the popular images
+- name: Remove the popular container images
   command: "docker rmi {{ item }}"
   with_items: "{{ popular_images }}"

--- a/roles/docker_pull_run_remove/vars/main.yml
+++ b/roles/docker_pull_run_remove/vars/main.yml
@@ -6,5 +6,5 @@ popular_images:
   - docker.io/busybox
   - docker.io/ubuntu
   - registry.fedoraproject.org/fedora
-  - registry.centos.org/centos
+  - registry.centos.org/centos/centos
   - registry.access.redhat.com/rhel


### PR DESCRIPTION
The `name` of the first task in this role wasn't accurate once we
started pulling more images from other registries.  This makes the
language a bit more generic.

Additionally, the r.c.o/centos image recently started to fail and this
was causing all the sanity tests to fail.  Switch the image to use
r.c.o/centos/centos as a hotfix.