### PR TITLE
introduce podman sanity checks

### DIFF
--- a/roles/podman_pull_run_remove/meta/main.yml
+++ b/roles/podman_pull_run_remove/meta/main.yml
@@ -1,0 +1,3 @@
+---
+# vim: set ft=ansible:
+allow_duplicates: true

--- a/roles/podman_pull_run_remove/tasks/main.yml
+++ b/roles/podman_pull_run_remove/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+# vim: set ft=ansible:
+#
+# This is a copy of the `docker_pull_run_remove` role which has been adapted
+# to use `podman`.  There are some minor changes that expand on the original
+# role to make this more comprehensive.
+#
+# `popular_images` is defined in roles/podman_pull_run_remove/vars/main.yml
+# It is a dict using image names as a key and the value is a command that
+# can be run.
+#
+
+# Check to see if the host has podman, but don't fail if it is not installed
+- name: Check if podman is installed
+  command: rpm -q podman
+  register: podman
+  ignore_errors: true
+
+- when: podman.rc == 0
+  block:
+    - name: Disable the docker daemon
+      service:
+        name: docker
+        state: stopped
+
+    - name: Pull the popular container images
+      command: "podman pull {{ item.key }}"
+      with_dict: "{{ popular_images }}"
+      register: podman_pull
+      retries: 5
+      delay: 60
+      until: podman_pull is success
+
+    - name: Run the popular container images
+      command: "podman run --rm {{ item.key }} echo 'hello'"
+      with_dict: "{{ popular_images }}"
+
+    # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1585735
+    - name: Run the popular container images with cpu-shares flag
+      command: "podman run --cpu-shares 2 --rm {{ item.key }} echo 'hello'"
+      with_dict: "{{ popular_images }}"
+
+    # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1592932
+    #          https://bugzilla.redhat.com/show_bug.cgi?id=1593419
+    - name: Run the popular container images testing for network access
+      command: "podman run --rm {{ item.key }} {{ item.value }}"
+      with_dict: "{{ popular_images }}"
+
+    - name: Remove the popular container images
+      command: "podman rmi {{ item.key }}"
+      with_dict: "{{ popular_images }}"
+
+    - name: Re-enable docker
+      service:
+        name: docker
+        state: started

--- a/roles/podman_pull_run_remove/tasks/main.yml
+++ b/roles/podman_pull_run_remove/tasks/main.yml
@@ -16,6 +16,14 @@
   register: podman
   ignore_errors: true
 
+- when: "'CentOS' not in ansible_distribution"
+  set_fact:
+    pull_images: "{{ popular_images | combine(rhel_images) }}"
+
+- when: "'CentOS' in ansible_distribution"
+  set_fact:
+    pull_images: "{{ popular_images }}"
+
 - when: podman.rc == 0
   block:
     - name: Disable the docker daemon
@@ -25,7 +33,7 @@
 
     - name: Pull the popular container images
       command: "podman pull {{ item.key }}"
-      with_dict: "{{ popular_images }}"
+      with_dict: "{{ pull_images }}"
       register: podman_pull
       retries: 5
       delay: 60
@@ -33,22 +41,22 @@
 
     - name: Run the popular container images
       command: "podman run --rm {{ item.key }} echo 'hello'"
-      with_dict: "{{ popular_images }}"
+      with_dict: "{{ pull_images }}"
 
     # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1585735
     - name: Run the popular container images with cpu-shares flag
       command: "podman run --cpu-shares 2 --rm {{ item.key }} echo 'hello'"
-      with_dict: "{{ popular_images }}"
+      with_dict: "{{ pull_images }}"
 
     # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1592932
     #          https://bugzilla.redhat.com/show_bug.cgi?id=1593419
     - name: Run the popular container images testing for network access
       command: "podman run --rm {{ item.key }} {{ item.value }}"
-      with_dict: "{{ popular_images }}"
+      with_dict: "{{ pull_images }}"
 
     - name: Remove the popular container images
       command: "podman rmi {{ item.key }}"
-      with_dict: "{{ popular_images }}"
+      with_dict: "{{ pull_images }}"
 
     - name: Re-enable docker
       service:

--- a/roles/podman_pull_run_remove/vars/main.yml
+++ b/roles/podman_pull_run_remove/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# vim: set ft=ansible:
+#
+popular_images:
+  docker.io/alpine: 'ping -c 3 1.1.1.1'
+  docker.io/busybox: 'ping -c 3 1.1.1.1'
+  docker.io/ubuntu: 'bash -c "apt-get update && apt-get -y install iputils-ping && ping -c 3 1.1.1.1"'
+  registry.fedoraproject.org/fedora: 'bash -c "dnf -y install iputils && ping -c 3 1.1.1.1"'
+  registry.centos.org/centos/centos/centos: 'ping -c 3 1.1.1.1'
+  registry.access.redhat.com/rhel: 'curl --fail -o /dev/null -I https://1.1.1.1'

--- a/roles/podman_pull_run_remove/vars/main.yml
+++ b/roles/podman_pull_run_remove/vars/main.yml
@@ -6,5 +6,5 @@ popular_images:
   docker.io/busybox: 'ping -c 3 1.1.1.1'
   docker.io/ubuntu: 'bash -c "apt-get update && apt-get -y install iputils-ping && ping -c 3 1.1.1.1"'
   registry.fedoraproject.org/fedora: 'bash -c "dnf -y install iputils && ping -c 3 1.1.1.1"'
-  registry.centos.org/centos/centos/centos: 'ping -c 3 1.1.1.1'
+  registry.centos.org/centos/centos: 'ping -c 3 1.1.1.1'
   registry.access.redhat.com/rhel: 'curl --fail -o /dev/null -I https://1.1.1.1'

--- a/roles/podman_pull_run_remove/vars/main.yml
+++ b/roles/podman_pull_run_remove/vars/main.yml
@@ -7,4 +7,6 @@ popular_images:
   docker.io/ubuntu: 'bash -c "apt-get update && apt-get -y install iputils-ping && ping -c 3 1.1.1.1"'
   registry.fedoraproject.org/fedora: 'bash -c "dnf -y install iputils && ping -c 3 1.1.1.1"'
   registry.centos.org/centos/centos: 'ping -c 3 1.1.1.1'
+
+rhel_images:
   registry.access.redhat.com/rhel: 'curl --fail -o /dev/null -I https://1.1.1.1'

--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -205,6 +205,13 @@
         - rhcos
 
     # TEST
+    # Verify that basic `podman` operations are successful.
+    - role: podman_pull_run_remove
+      tags:
+        - podman_pull_run_remove
+        - rhcos
+
+    # TEST
     # Validate 'atomic pull', 'atomic scan' works correctly.
     # Remove images after test of each command.
     # Do this ahead of 'ostree admin unlock' because of overlay + SELinux
@@ -614,6 +621,11 @@
     - role: docker_pull_run_remove
       tags:
         - docker_pull_run_remove
+        - rhcos
+
+    - role: podman_pull_run_remove
+      tags:
+        - podman_pull_run_remove
         - rhcos
 
     # Check layered package is still installed


### PR DESCRIPTION
`podman` is included in most (all?) of the AH streams that we are testing, so let's start making sure it works on Atomic Host.

This is a re-implementation of the `docker_pull_run_remove` role that uses `podman`.  It's slightly more comprehensive than the original role, but still very bare bones.

Closes #378 