### PR TITLE
dprr: modify list of "popular" images for CentOS based streams

### DIFF
--- a/roles/docker_pull_run_remove/tasks/main.yml
+++ b/roles/docker_pull_run_remove/tasks/main.yml
@@ -3,9 +3,17 @@
 #
 # popular_images is defined in roles/docker_pull_run_remove/vars/main.yml
 #
+- when: "'CentOS' in ansible_distribution"
+  set_fact:
+    dprr_images: "{{ centos_popular_images }}"
+
+- when: "'CentOS' not in ansible_distribution"
+  set_fact:
+    dprr_images: "{{ popular_images }}"
+
 - name: Pull the popular container images
   command: "docker pull {{ item }}"
-  with_items: "{{ popular_images }}"
+  with_items: "{{ dprr_images }}"
   register: dpd
   retries: 5
   delay: 60
@@ -13,13 +21,13 @@
 
 - name: Run the popular container images
   command: "docker run --rm {{ item }} echo 'hello'"
-  with_items: "{{ popular_images }}"
+  with_items: "{{ dprr_images }}"
 
 # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1585735
 - name: Run the popular container images with cpu-shares flag
   command: "docker run --cpu-shares 2 --rm {{ item }} echo 'hello'"
-  with_items: "{{ popular_images }}"
+  with_items: "{{ dprr_images }}"
 
 - name: Remove the popular container images
   command: "docker rmi {{ item }}"
-  with_items: "{{ popular_images }}"
+  with_items: "{{ dprr_images }}"

--- a/roles/docker_pull_run_remove/vars/main.yml
+++ b/roles/docker_pull_run_remove/vars/main.yml
@@ -8,3 +8,13 @@ popular_images:
   - registry.fedoraproject.org/fedora
   - registry.centos.org/centos/centos
   - registry.access.redhat.com/rhel
+
+# Until https://github.com/CentOS/sig-atomic-buildscripts/issues/329
+# is resolved, we will use a different list of images for CentOS AH
+# streams
+centos_popular_images:
+  - docker.io/alpine
+  - docker.io/busybox
+  - docker.io/ubuntu
+  - registry.fedoraproject.org/fedora
+  - registry.centos.org/centos/centos


### PR DESCRIPTION
The i-s-t has been failing for longer than I would care to admit
because of CentOS/sig-atomic-buildscripts#329 and there's been little
movement in the direction of fixing that.  So we'll workaround the
deficincieny by using two lists of images, one that works for CentOS
derived streams and another that works for the rest.