### PR TITLE
dsv: update role to be more consistent across all streams

### DIFF
--- a/roles/docker_storage_verify/tasks/main.yml
+++ b/roles/docker_storage_verify/tasks/main.yml
@@ -1,33 +1,19 @@
 ---
 # vim: set ft=ansible:
 #
-- name: Include distribution vars
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution|lower }}.yml"
+- name: Set storage driver
+  set_fact:
+    storage_driver: 'overlay2'
 
-- name: Fail if required variables are not defined
-  when: driver is undefined
-  fail:
-    msg: "The required variables are not defined.  Check files under roles/docker_storage_verify/vars"
+- when: ansible_distribution == 'CentOSDev'
+  name: Set storage driver for CAHC
+  set_fact:
+    storage_driver: 'devicemapper'
 
-  # When all the streams are on docker 1.13, we should start using
-  #  docker info --format  '{{.Driver}}'
 - name: Check Docker storage driver
-  shell: "docker info | grep -oP '(?<=Storage Driver: ).*'"
-  register: storage_driver
-  failed_when: storage_driver.stdout != driver
+  command: "docker info --format {% raw %}{{.Driver}}{% endraw %}"
+  register: di
+  failed_when: "di.stdout != storage_driver"
 
-- name: Check for F26 Docker mount
-  when:
-    - ansible_distribution == 'Fedora'
-    - ansible_distribution_major_version == '26'
-  command: findmnt /var/lib/docker
-
-- name: Check for Fedora Rawhide Docker mount
-  when:
-    - ansible_distribution == 'Fedora'
-    - ansible_distribution_major_version > '26'
+- name: Check for Docker mount
   command: findmnt /var/lib/docker/containers

--- a/roles/docker_storage_verify/tasks/main.yml
+++ b/roles/docker_storage_verify/tasks/main.yml
@@ -5,8 +5,8 @@
   set_fact:
     storage_driver: 'overlay2'
 
-- when: ansible_distribution == 'CentOSDev'
-  name: Set storage driver for CAHC
+- name: Set storage driver for CAHC
+  when: ansible_distribution == 'CentOSDev'
   set_fact:
     storage_driver: 'devicemapper'
 

--- a/roles/docker_storage_verify/vars/centos-7.yml
+++ b/roles/docker_storage_verify/vars/centos-7.yml
@@ -1,1 +1,0 @@
-devicemapper.yml

--- a/roles/docker_storage_verify/vars/centos.yml
+++ b/roles/docker_storage_verify/vars/centos.yml
@@ -1,1 +1,0 @@
-devicemapper.yml

--- a/roles/docker_storage_verify/vars/centosdev-7.yml
+++ b/roles/docker_storage_verify/vars/centosdev-7.yml
@@ -1,1 +1,0 @@
-devicemapper.yml

--- a/roles/docker_storage_verify/vars/devicemapper.yml
+++ b/roles/docker_storage_verify/vars/devicemapper.yml
@@ -1,3 +1,0 @@
----
-# vim: set ft=ansible:
-driver: 'devicemapper'

--- a/roles/docker_storage_verify/vars/fedora-26.yml
+++ b/roles/docker_storage_verify/vars/fedora-26.yml
@@ -1,1 +1,0 @@
-overlay2.yml

--- a/roles/docker_storage_verify/vars/fedora-27.yml
+++ b/roles/docker_storage_verify/vars/fedora-27.yml
@@ -1,1 +1,0 @@
-overlay2.yml

--- a/roles/docker_storage_verify/vars/fedora-28.yml
+++ b/roles/docker_storage_verify/vars/fedora-28.yml
@@ -1,1 +1,0 @@
-overlay2.yml

--- a/roles/docker_storage_verify/vars/fedora-29.yml
+++ b/roles/docker_storage_verify/vars/fedora-29.yml
@@ -1,1 +1,0 @@
-overlay2.yml

--- a/roles/docker_storage_verify/vars/overlay2.yml
+++ b/roles/docker_storage_verify/vars/overlay2.yml
@@ -1,3 +1,0 @@
----
-# vim: set ft=ansible:
-driver: 'overlay2'

--- a/roles/docker_storage_verify/vars/redhat-3.yml
+++ b/roles/docker_storage_verify/vars/redhat-3.yml
@@ -1,3 +1,0 @@
----
-# vim: set ft=ansible:
-driver: 'overlay2'

--- a/roles/docker_storage_verify/vars/redhat-7.5.yml
+++ b/roles/docker_storage_verify/vars/redhat-7.5.yml
@@ -1,1 +1,0 @@
-overlay2.yml

--- a/roles/docker_storage_verify/vars/redhat-7.yml
+++ b/roles/docker_storage_verify/vars/redhat-7.yml
@@ -1,1 +1,0 @@
-devicemapper.yml

--- a/roles/docker_storage_verify/vars/redhat.yml
+++ b/roles/docker_storage_verify/vars/redhat.yml
@@ -1,1 +1,0 @@
-devicemapper.yml


### PR DESCRIPTION
Almost all of the streams are using `overlay2` as the docker storage
driver now, so we can remove a lot of the conditional workarounds we
had.

If we can get CAHC to switch to `overlay2` (see
CentOS/sig-atomic-buildscripts#341), we can simplify this role even
more.