### PR TITLE
i-s-t: remove rhcos tag from firewalld check

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -188,7 +188,6 @@
     - role: firewalld_service_verify
       tags:
         - firewalld_service_verify
-        - rhcos
 
     # TEST
     # Verify that the Docker storage defaults are correct
@@ -606,7 +605,6 @@
     - role: firewalld_service_verify
       tags:
         - firewalld_service_verify
-        - rhcos
 
     # Verify that the Docker storage defaults haven't changed
     - role: docker_storage_verify


### PR DESCRIPTION
Lets remove the rhcos tag from the firewalld role because rhcos does
not have firewalld.