### PR TITLE
initramfs: update test for BootLoaderSpec change

### DIFF
--- a/tests/rpm-ostree/initramfs.yml
+++ b/tests/rpm-ostree/initramfs.yml
@@ -54,7 +54,7 @@
     osname: "{{ ros_booted['osname'] }}"
 
 - name: Get boot entry file
-  shell: ls -1 /boot/loader/entries/ | grep -E "ostree-[2-]*fedora-atomic[-0]*.conf"
+  shell: ls -1 /boot/loader/entries/ | grep -E "ostree-[2-]*{{ osname }}[-0]*.conf"
   register: boot_file
 
 - name: Get initrd file

--- a/tests/rpm-ostree/initramfs.yml
+++ b/tests/rpm-ostree/initramfs.yml
@@ -53,9 +53,13 @@
   set_fact:
     osname: "{{ ros_booted['osname'] }}"
 
-- name: Get bootloader entry
+- name: Get boot entry file
+  shell: ls -1 /boot/loader/entries/ | grep -E "ostree-[2-]*fedora-atomic[-0]*.conf"
+  register: boot_file
+
+- name: Get initrd file
   shell: >
-    grep ^initrd /boot/loader/entries/ostree-{{ osname }}-0.conf |
+    grep ^initrd /boot/loader/entries/{{ boot_file.stdout }} |
     sed -e 's,initrd ,/boot/,'
   register: initrd
 
@@ -79,9 +83,9 @@
 - import_role:
     name: reboot
 
-- name: Get bootloader entry
+- name: Get boot entry file
   shell: >
-    grep ^initrd /boot/loader/entries/ostree-{{ osname }}-0.conf |
+    grep ^initrd /boot/loader/entries/{{ boot_file.stdout }} |
     sed -e 's,initrd ,/boot/,'
   register: initrd_disabled
 


### PR DESCRIPTION
The BootLoaderSpec filename change in ostree [0] is causing failures
in streams containing the change.  This commit will handle pre and
post BLS filename changes using a simple regex.

[0] https://github.com/ostreedev/ostree/pull/1654