### PR TITLE
i-s-t: set container_manage_cgroup for all streams

### DIFF
--- a/tests/improved-sanity-test/main.yml
+++ b/tests/improved-sanity-test/main.yml
@@ -408,9 +408,8 @@
     # Configure container_manage_cgroup boolean
     # See - https://bugzilla.redhat.com/show_bug.cgi?id=1510139
     #     - https://bugzilla.redhat.com/show_bug.cgi?id=1554881
-    - when: ansible_distribution == "RedHat" or
-            ansible_distribution == "Fedora"
-      role: selinux_boolean
+    #     - https://bugzilla.redhat.com/show_bug.cgi?id=1553803
+    - role: selinux_boolean
       g_seboolean: "container_manage_cgroup"
       tags:
         - container_manage_cgroup_bool


### PR DESCRIPTION
CentOS Atomic Host and CAHC inherited the systemd container cgroups
issue and now needs the container_manage_cgroup seboolean.