### PR TITLE
stop using workarounds for `atomic` command

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -53,8 +53,7 @@ cluster:
 context: centos/7/atomic/continuous
 
 tests:
-  # skipping 'default_t' checks until atomic 1.22 lands with (projectatomic/atomic#1185)
-  - ./.test_director --skip-tags default_file_label
+  - ./.test_director
 
 ---
 inherit: true
@@ -69,6 +68,5 @@ cluster:
 context: centos/7/atomic
 
 tests:
-  # skipping 'default_t' checks until atomic 1.22 lands with (projectatomic/atomic#1185)
-  - ./.test_director --skip-tags default_file_label
+  - ./.test_director
 

--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -60,9 +60,8 @@
 - name: Delete the cockpit container
   command: atomic --assumeyes containers delete {{ cockpit_cid.stdout }}
 
-# use -n until centos has https://github.com/projectatomic/atomic/issues/1219
 - name: Uninstall cockpit container
-  shell: atomic uninstall -n cockpit {{ cockpit_cname }}
+  shell: atomic uninstall {{ cockpit_cname }}
 
 - name: Check for /etc/pam.d/cockpit file
   stat:
@@ -108,9 +107,8 @@
 - name: Delete container
   command: atomic --assumeyes containers delete {{ cockpit_cid.stdout }}
 
-# use -n until centos has https://github.com/projectatomic/atomic/issues/1219
 - name: Uninstall cockpit container without tag
-  shell: atomic uninstall -n cockpit {{ cockpit_cname }}
+  shell: atomic uninstall {{ cockpit_cname }}
 
 - name: Check for /etc/pam.d/cockpit file
   stat:


### PR DESCRIPTION
The `atomic` command is fixed across all the streams, so we can
stop using the workarounds.