### PR TITLE
aiv: use name when uninstalling container

### DIFF
--- a/roles/atomic_installation_verify/tasks/main.yml
+++ b/roles/atomic_installation_verify/tasks/main.yml
@@ -61,7 +61,7 @@
   command: atomic --assumeyes containers delete {{ cockpit_cid.stdout }}
 
 - name: Uninstall cockpit container
-  shell: atomic uninstall {{ cockpit_cname }}
+  shell: atomic uninstall -n cockpit {{ cockpit_cname }}
 
 - name: Check for /etc/pam.d/cockpit file
   stat:


### PR DESCRIPTION
On RHELAH, it seems that you need to pass the name of the container
when using `atomic uninstall` if `atomic install` has been used
multiple times.  (This only seems to bite me when I'm reusing a host
for multiple rounds of tests and the host is not "clean".  The
automated jobs appear to avoid this condition.)