### PR TITLE
handler: also save journal of previous boot

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -21,6 +21,9 @@ tests:
   # a docker-latest
   - ./.test_director -e g_docker_latest=false
 
+artifacts:
+  - tests/improved-sanity-test/improved-sanity-test-testnode-journal
+
 ---
 inherit: true
 

--- a/roles/handler_notify_on_failure/handlers/main.yml
+++ b/roles/handler_notify_on_failure/handlers/main.yml
@@ -31,6 +31,11 @@
   listen: h_get_journal
   when: aht_result == "1"
 
+- name: Get previous boot journal
+  shell: journalctl -r -b -1 >> /tmp/{{ journal_name | quote }}
+  listen: h_get_journal
+  when: aht_result == "1"
+
 - name: Retrieve journal
   synchronize:
     mode: pull


### PR DESCRIPTION
This can be help when an error in a current boot happens because of
something that happened in the *previous* boot. There doesn't seem to be
a concise way to tell `journalctl` to list both the current and previous
boots but not the ones before that, so we just append to the tmpfile in
a second invocation.