### PR TITLE
pkg-layering: update error message check

### DIFF
--- a/tests/pkg-layering/install_invalid_pkg.yml
+++ b/tests/pkg-layering/install_invalid_pkg.yml
@@ -9,7 +9,7 @@
   failed_when: nonexist.rc != 1
 
 - name: Fail if error not expected
-  when: "'No package' not in nonexist.stderr"
+  when: "'Packages not found' not in nonexist.stderr"
   fail:
     msg: |
       Expected: No package is contained in the rpm-ostree install output


### PR DESCRIPTION
The error message changed for installing invalid packages.  Update the
test so it doesn't fail.