### PR TITLE
pkg-layering: handle allow-inactive option

### DIFF
--- a/tests/pkg-layering/install_existing_pkg.yml
+++ b/tests/pkg-layering/install_existing_pkg.yml
@@ -5,6 +5,18 @@
 
 - name: Attempt to install package that is already in the deployment
   command: rpm-ostree install {{ g_deployed_pkg }}
+  register: roi
+  failed_when:
+    - roi.rc == 1
+    - '"to explicitly require it" not in roi.stderr'
+
+# Account for newer rpm-ostree package layering behavior
+- when: '"to explicitly require it" in roi.stderr'
+  set_fact:
+    ai: true
+
+- when: ai is defined and ai
+  command: rpm-ostree install --allow-inactive {{ g_deployed_pkg }}
 
 - import_role:
     name: reboot


### PR DESCRIPTION
In newer versions of rpm-ostree package layering, the user has to
utilize the --allow-inactive option to explicitly require an existing
package.  This PR handles this behavior and older behavior for lagging
streams.