### PR TITLE
rpm-ostree: workaround ansible variable issue

### DIFF
--- a/roles/rpm_ostree_uninstall_verify/tasks/main.yml
+++ b/roles/rpm_ostree_uninstall_verify/tasks/main.yml
@@ -30,6 +30,7 @@
   set_fact:
     rouv_binary_name: "{{ rouv_binary_name if rouv_binary_name is defined else rouv_package_name }}"
     rouv_status_check: "{{ rouv_status_check | default(true) }}"
+    rouv_binary_check: "{{ rouv_binary_check | default(true) }}"
 
 - import_role:
     name: rpm_ostree_status
@@ -44,6 +45,7 @@
       Actual: Booted deployment packages: {{ ros_booted['packages'] }}
 
 - name: Fail if binary for {{ rouv_binary_name }} is installed
+  when: rouv_binary_check
   command: command -v {{ rouv_binary_name }}
   register: binary
   failed_when: binary.rc != 1

--- a/tests/rpm-ostree/override_remove_reset.yml
+++ b/tests/rpm-ostree/override_remove_reset.yml
@@ -25,11 +25,15 @@
         base-removals:
           {{ ros_booted['base-removals'] }}
 
+# Had to use include_role instead of import_role here because the variables
+# were not being overwritten properly (previous values were being used)
+# This might be https://github.com/ansible/ansible/issues/37787
 # verify the package has been removed by checking the rpm output
-- import_role:
+- include_role:
     name: rpm_ostree_uninstall_verify
   vars:
     rouv_package_name: '{{ g_remove_pkg }}'
+    rouv_binary_check: false
 
 # cleanup by resetting package
 - import_role:


### PR DESCRIPTION
We have been sporadically hitting an issue with Ansible where the
arguments passed in are not overwriting the previous values for those
variables.  This may be an Ansible bug [0].

The only way we have been able to mitigate this is by using
include_role instead of import role.  So why not use include_role
everywhere?  Ansible has a recursion depth limit that is hit when
include_role is used often.

Another change that was needed was to make the binary check optional
since some RPMs don't exactly have a binary that can be checked with
command -v.

[0] https://github.com/ansible/ansible/issues/37787