### PR TITLE
atomic: use centos registry for fq name

### DIFF
--- a/tests/atomic/vars/fedora.yml
+++ b/tests/atomic/vars/fedora.yml
@@ -1,6 +1,6 @@
 ---
 # vim: set ft=ansible:
 cockpit_short_name: "cockpit/ws"
-cockpit_fq_name: "docker.io/cockpit/ws"
+cockpit_fq_name: "registry.centos.org/cockpit/ws"
 cockpit_cname: "registry.fedoraproject.org/f27/cockpit"
 cp_name: "cockpit"


### PR DESCRIPTION
The newer version of atomic now pulls cockpit/ws from
registry.centos.org/cockpit/ws instead of docker.io/cockpit/ws