### PR TITLE
roles: add regression tests for docker/podman exec

### DIFF
--- a/roles/docker_pull_run_remove/tasks/main.yml
+++ b/roles/docker_pull_run_remove/tasks/main.yml
@@ -30,15 +30,15 @@
 
 # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1655214
 - name: Run popular images as detatched
-  command: "docker run --name test-{{ item.split('/')[1] }} -d --rm {{ item }} sleep 1000"
+  command: "docker run --name test-{{ item.split('/')[-1] }} -d --rm {{ item }} sleep 1000"
   with_items: "{{ dprr_images }}"
 
 - name: Exec into the daemon containers
-  command: "docker exec test-{{ item.split('/')[1] }} date"
+  command: "docker exec test-{{ item.split('/')[-1] }} date"
   with_items: "{{ dprr_images }}"
 
 - name: Cleanup containers
-  command: "docker rm -f test-{{ item.split('/')[1] }}"
+  command: "docker rm -f test-{{ item.split('/')[-1] }}"
   with_items: "{{ dprr_images }}"
 
 - name: Remove the popular container images

--- a/roles/docker_pull_run_remove/tasks/main.yml
+++ b/roles/docker_pull_run_remove/tasks/main.yml
@@ -28,6 +28,19 @@
   command: "docker run --cpu-shares 2 --rm {{ item }} echo 'hello'"
   with_items: "{{ dprr_images }}"
 
+# Test for https://bugzilla.redhat.com/show_bug.cgi?id=1655214
+- name: Run popular images as detatched
+  command: "docker run --name test-{{ item.split('/')[1] }} -d --rm {{ item }} sleep 1000"
+  with_items: "{{ dprr_images }}"
+
+- name: Exec into the daemon containers
+  command: "docker exec test-{{ item.split('/')[1] }} date"
+  with_items: "{{ dprr_images }}"
+
+- name: Cleanup containers
+  command: "docker rm -f test-{{ item.split('/')[1] }}"
+  with_items: "{{ dprr_images }}"
+
 - name: Remove the popular container images
   command: "docker rmi {{ item }}"
   with_items: "{{ dprr_images }}"

--- a/roles/podman_pull_run_remove/tasks/main.yml
+++ b/roles/podman_pull_run_remove/tasks/main.yml
@@ -56,15 +56,15 @@
 
     # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1650512
     - name: Run popular images as detached
-      command: "podman run --name test-{{ item.split('/')[1] }} -d {{ item }} sleep 1000"
+      command: "podman run --name test-{{ item.split('/')[-1] }} -d {{ item }} sleep 1000"
       with_items: "{{ pull_images }}"
 
     - name: Exec into the daemon containers
-      command: "podman exec test-{{ item.split('/')[1] }} date"
+      command: "podman exec test-{{ item.split('/')[-1] }} date"
       with_items: "{{ pull_images }}"
 
     - name: Cleanup containers
-      command: "podman rm -f test-{{ item.split('/')[1] }}"
+      command: "podman rm -f test-{{ item.split('/')[-1] }}"
       with_items: "{{ pull_images }}"
 
     - name: Remove the popular container images

--- a/roles/podman_pull_run_remove/tasks/main.yml
+++ b/roles/podman_pull_run_remove/tasks/main.yml
@@ -54,6 +54,19 @@
       command: "podman run --rm {{ item.key }} {{ item.value }}"
       with_dict: "{{ pull_images }}"
 
+    # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1650512
+    - name: Run popular images as detached
+      command: "podman run --name test-{{ item.split('/')[1] }} -d {{ item }} sleep 1000"
+      with_items: "{{ pull_images }}"
+
+    - name: Exec into the daemon containers
+      command: "podman exec test-{{ item.split('/')[1] }} date"
+      with_items: "{{ pull_images }}"
+
+    - name: Cleanup containers
+      command: "podman rm -f test-{{ item.split('/')[1] }}"
+      with_items: "{{ pull_images }}"
+
     - name: Remove the popular container images
       command: "podman rmi {{ item.key }}"
       with_dict: "{{ pull_images }}"


### PR DESCRIPTION
We haven't been testing the `docker/podman exec` path and missed the
following regressions in RHELAH:

https://bugzilla.redhat.com/show_bug.cgi?id=1650512
https://bugzilla.redhat.com/show_bug.cgi?id=1655214

This adds a simple test for both.