### PR TITLE
livefs: adapt test to new behavior

### DIFF
--- a/roles/rpm_ostree_reset/meta/main.yml
+++ b/roles/rpm_ostree_reset/meta/main.yml
@@ -1,0 +1,3 @@
+---
+# vim: set ft=ansible:
+allow_duplicates: true

--- a/roles/rpm_ostree_reset/tasks/main.yml
+++ b/roles/rpm_ostree_reset/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# vim: set ft=ansible:
+#
+- name: Reset all changes
+  command: rpm-ostree reset

--- a/tests/rpm-ostree/livefs.yml
+++ b/tests/rpm-ostree/livefs.yml
@@ -84,31 +84,10 @@
       live-replaced: "{{ rol_livefs_commit }}"
 
 - import_role:
-    name: rpm_ostree_status_verify
-  vars:
-    deployment: 2
-    expected:
-      booted: false
-      checksum: "{{ rol_base_commit }}"
-      packages: []
+    name: rpm_ostree_reset
 
-# Rollback twice to get to the original deployment
-- import_role:
-    name: rpm_ostree_rollback
-
-- import_role:
-    name: rpm_ostree_rollback
-
-# Reboot and verify that the system is back to the original deployment
-# without livefs or layered packages
 - import_role:
     name: reboot
-
-- import_role:
-    name: rpm_ostree_uninstall_verify
-  vars:
-    rouv_package_name: "{{ g_pkg }}"
-    rouv_status_check: false
 
 - import_role:
     name: rpm_ostree_status_verify
@@ -125,19 +104,10 @@
     deployment: 1
     expected:
       booted: false
-      checksum: "{{ rol_base_commit }}"
-      live-replaced: "{{ rol_livefs_commit }}"
-
-- import_role:
-    name: rpm_ostree_status_verify
-  vars:
-    deployment: 2
-    expected:
-      booted: false
       base-checksum: "{{ rol_base_commit }}"
       checksum: "{{ rol_livefs_commit }}"
       packages:
-       - "{{ g_pkg }}"
+        - "{{ g_pkg }}"
 
 - import_role:
     name: rpm_ostree_cleanup_all


### PR DESCRIPTION
Livefs has been reworked and the deployments after rebooting from
livefs has changed to only contain the livefs deployment and the
finalized staged deployment.  The original deployment (pre-layering
and livefs) will no longer be in the deployment list.