### PR TITLE
roles/user_verify*: change grep pattern for home dir change

### DIFF
--- a/roles/user_verify_missing/tasks/main.yml
+++ b/roles/user_verify_missing/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Set regex pattern
   set_fact:
-    regex_pattern: "^atomic-user-{{ g_uid1 }}:x:{{ g_uid1 }}:{{ g_uid1 }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ g_uid1 }}:/bin/bash"
+    regex_pattern: "^atomic-user-{{ uvm_uid }}:x:{{ uvm_uid }}:{{ uvm_uid }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ uvm_uid }}:/bin/bash"
 
 - name: Check to see if the user is in /etc/passwd
   command: "grep -e {{ regex_pattern }} /etc/passwd"

--- a/roles/user_verify_missing/tasks/main.yml
+++ b/roles/user_verify_missing/tasks/main.yml
@@ -6,7 +6,11 @@
   fail:
     msg: "uvm_uid is undefined"
 
+- name: Set regex pattern
+  set_fact:
+    regex_pattern: "^atomic-user-{{ g_uid1 }}:x:{{ g_uid1 }}:{{ g_uid1 }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ g_uid1 }}:/bin/bash"
+
 - name: Check to see if the user is in /etc/passwd
-  command: "grep atomic-user-{{ uvm_uid }}:x:{{ uvm_uid }}:{{ uvm_uid }}::/home/atomic-user-{{ uvm_uid }}:/bin/bash /etc/passwd"
+  command: "grep -e {{ regex_pattern }} /etc/passwd"
   register: grep_user
   failed_when: grep_user.rc != 1

--- a/roles/user_verify_present/tasks/main.yml
+++ b/roles/user_verify_present/tasks/main.yml
@@ -6,8 +6,12 @@
   fail:
     msg: "uvp_uid variable is undefined"
 
+- name: Set regex pattern
+  set_fact:
+    regex_pattern: "^atomic-user-{{ g_uid1 }}:x:{{ g_uid1 }}:{{ g_uid1 }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ g_uid1 }}:/bin/bash"
+
 - name: Verify users in /etc/passwd
-  command: "grep atomic-user-{{ uvp_uid }}:x:{{ uvp_uid }}:{{ uvp_uid }}::/home/atomic-user-{{ uvp_uid }}:/bin/bash /etc/passwd"
+  command: "grep -e {{ regex_pattern }} /etc/passwd"
 
 - name: Verify password is a SHA-512 hash
   command: "grep '^atomic-user-{{ uvp_uid }}:$6$.*' /etc/shadow"

--- a/roles/user_verify_present/tasks/main.yml
+++ b/roles/user_verify_present/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Set regex pattern
   set_fact:
-    regex_pattern: "^atomic-user-{{ uvp_uid }}:x:{{ upv_uid }}:{{ upv_uid }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ uvp_uid }}:/bin/bash"
+    regex_pattern: "^atomic-user-{{ uvp_uid }}:x:{{ uvp_uid }}:{{ uvp_uid }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ uvp_uid }}:/bin/bash"
 
 - name: Verify users in /etc/passwd
   command: "grep -e {{ regex_pattern }} /etc/passwd"

--- a/roles/user_verify_present/tasks/main.yml
+++ b/roles/user_verify_present/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Set regex pattern
   set_fact:
-    regex_pattern: "^atomic-user-{{ g_uid1 }}:x:{{ g_uid1 }}:{{ g_uid1 }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ g_uid1 }}:/bin/bash"
+    regex_pattern: "^atomic-user-{{ uvp_uid }}:x:{{ upv_uid }}:{{ upv_uid }}::{{ '\\(/var\\)\\?' | regex_escape() }}/home/atomic-user-{{ uvp_uid }}:/bin/bash"
 
 - name: Verify users in /etc/passwd
   command: "grep -e {{ regex_pattern }} /etc/passwd"


### PR DESCRIPTION
It looks like projectatomic/rpm-ostree#1726 changed how `useradd`
operates on `ostree` hosts, so we have to look for `/var/home/<user>`
now.  Except that not all the `ostree` hosts will have this change, so
make it an optional part of the regex pattern.