### PR TITLE
rpm-ostree: update tzdata package

### DIFF
--- a/tests/rpm-ostree/vars.yml
+++ b/tests/rpm-ostree/vars.yml
@@ -3,4 +3,4 @@
 g_pkg: 'wget'
 g_remove_pkg: 'bash-completion'
 g_replace_pkg: 'tzdata'
-g_replace_pkg_url: 'http://download.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/t/tzdata-2017b-2.fc27.noarch.rpm'
+g_replace_pkg_url: 'https://download.fedoraproject.org/pub/fedora/linux/releases/29/Everything/x86_64/os/Packages/t/tzdata-2018e-2.fc29.noarch.rpm'


### PR DESCRIPTION
The Fedora 27 tzdata package location no longer exists so use the
Fedora 29 tzdata package instead.