### PR TITLE
system-containers: update hello-world image

### DIFF
--- a/tests/system-containers/vars.yml
+++ b/tests/system-containers/vars.yml
@@ -1,5 +1,5 @@
 ---
 # vim: set ft=ansible:
-g_hw_image: 'docker.io/gscrivano/hello-world'
+g_hw_image: 'docker.io/mnguyenrh/hello-world'
 g_hw_name: 'hello-world'
 g_invalid_value: 'xxfoobarxx'


### PR DESCRIPTION
The original hello-world image broke so a new image was built with
the original Dockerfile and uploaded to docker hub.  This file
should be used going forward.