### PR TITLE
roles/selinux_verify: support RHELAH 7.7

### DIFF
--- a/roles/selinux_verify/vars/redhat-7.7.yml
+++ b/roles/selinux_verify/vars/redhat-7.7.yml
@@ -4,27 +4,18 @@ distro_files:
   - { key: '/usr/bin/docker', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-containerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd-shim', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-containerd-shim-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-containerd-shim-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-ctr-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-ctr-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/docker-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/dockerd', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/dockerd-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/dockerd-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/bin/docker-latest-storage-setup', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/bin/container-storage-setup', value: 'system_u:object_r:bin_t:s0' }
   - { key: '/usr/libexec/docker/docker-init-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/libexec/docker/docker-init-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-lvm-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-novolume-plugin', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-proxy-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/libexec/docker/docker-proxy-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
   - { key: '/usr/libexec/docker/docker-runc-current', value: 'system_u:object_r:container_runtime_exec_t:s0' }
-  - { key: '/usr/libexec/docker/docker-runc-latest', value: 'system_u:object_r:container_runtime_exec_t:s0' }
 
 distro_procs:
   - { key: 'docker', value: 'system_u:system_r:container_runtime_t:s0' }


### PR DESCRIPTION
`docker_latest` will be removed in RHELAH 7.7, so let's not go looking
for files related to it.

Also made a small change to the list of files for the RHELAH previous
to 7.7...forgot `docker-init-current` for all these years, but might
as well fix it.