### PR TITLE
admin-unlock: use package that does not require python3

### DIFF
--- a/tests/admin-unlock/vars.yml
+++ b/tests/admin-unlock/vars.yml
@@ -3,4 +3,4 @@
 g_rpm_url: 'https://raw.githubusercontent.com/projectatomic/atomic-host-tests/master/rpm/aht-dummy-1.0-1.noarch.rpm'
 g_rpm_path: 'rpm/aht-dummy-1.0-1.noarch.rpm'
 g_rpm_name: 'aht-dummy'
-g_rpm_name_2: 'fpaste'
+g_rpm_name_2: 'htop'


### PR DESCRIPTION
The `fpaste` package requires python3 now and is causing the admin
unlock test to fail.  Switch to `htop` package to avoid this error.