### PR TITLE
rpm-ostree: update tz data package location

### DIFF
--- a/tests/rpm-ostree/vars.yml
+++ b/tests/rpm-ostree/vars.yml
@@ -3,4 +3,4 @@
 g_pkg: 'wget'
 g_remove_pkg: 'bash-completion'
 g_replace_pkg: 'tzdata'
-g_replace_pkg_url: 'https://download.fedoraproject.org/pub/fedora/linux/releases/29/Everything/x86_64/os/Packages/t/tzdata-2018e-2.fc29.noarch.rpm'
+g_replace_pkg_url: 'https://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/t/tzdata-2019c-1.fc31.noarch.rpm'


### PR DESCRIPTION
Update to the new location of the tzdata package because the old
one is no longer there.