### PR TITLE
rpm-ostree: replace f31 with f30 tzdata package

### DIFF
--- a/tests/rpm-ostree/vars.yml
+++ b/tests/rpm-ostree/vars.yml
@@ -3,4 +3,4 @@
 g_pkg: 'wget'
 g_remove_pkg: 'bash-completion'
 g_replace_pkg: 'tzdata'
-g_replace_pkg_url: 'https://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/t/tzdata-2019c-1.fc31.noarch.rpm'
+g_replace_pkg_url: 'https://download.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/t/tzdata-2019a-1.fc30.noarch.rpm'


### PR DESCRIPTION
The rpm-ostree test was failing because the format of the rpm in
Fedora 31 was incompatible with RHEL.  Switch to the Fedora 30
tzdata package.