### PR TITLE
podman needs seccomp=unconfined for newer images

### DIFF
--- a/roles/podman_pull_run_remove/tasks/main.yml
+++ b/roles/podman_pull_run_remove/tasks/main.yml
@@ -51,7 +51,7 @@
     # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1592932
     #          https://bugzilla.redhat.com/show_bug.cgi?id=1593419
     - name: Run the popular container images testing for network access
-      command: "podman run --rm {{ item.key }} {{ item.value }}"
+      command: "podman run --rm --security-opt seccomp=unconfined {{ item.key }} {{ item.value }}"
       with_dict: "{{ pull_images }}"
 
     # Test for https://bugzilla.redhat.com/show_bug.cgi?id=1650512


### PR DESCRIPTION
"Couldn't resolve host name" error is showing up while installing
packages via dnf in Fedora 35 container images.

There is a clone3 incompatibility and podman needs to run with
seccomp=unconfined

See https://bugzilla.redhat.com/show_bug.cgi?id=1985499