### PR TITLE
docker-swarm: change httpd image

### DIFF
--- a/tests/docker-swarm/vars.yml
+++ b/tests/docker-swarm/vars.yml
@@ -1,5 +1,5 @@
 ---
 # vim: set ft=ansible:
-g_image_name: 'docker.io/httpd'
+g_image_name: 'quay.io/testing-farm/httpd'
 g_ports: '80:80'
 g_service_name: 'httpd'


### PR DESCRIPTION
The docker.io/httpd image has changed and will not start automatically
anymore.  Change it to another httpd image that comes from quay.io.