### PR TITLE
docker-build-httpd: set non-interactive timezone

### DIFF
--- a/tests/docker-build-httpd/files/ubuntu_httpd/Dockerfile
+++ b/tests/docker-build-httpd/files/ubuntu_httpd/Dockerfile
@@ -8,6 +8,9 @@ ENV container docker
 
 COPY Dockerfile /root/
 
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/New_York
+
 RUN apt-get update && \
     apt-get -y install apache2 && \
     apt-get clean


### PR DESCRIPTION
The docker-build-httpd test was stuck at a prompt during the building of
the Dockerfile because tzdata (a dependent package) was prompting to set
the timezone.