### PR TITLE
rpm-ostree: user older tzdata package

### DIFF
--- a/tests/rpm-ostree/vars.yml
+++ b/tests/rpm-ostree/vars.yml
@@ -3,4 +3,4 @@
 g_pkg: 'wget'
 g_remove_pkg: 'bash-completion'
 g_replace_pkg: 'tzdata'
-g_replace_pkg_url: 'https://download.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/t/tzdata-2019c-3.fc32.noarch.rpm'
+g_replace_pkg_url: 'https://kojipkgs.fedoraproject.org//vol/fedora_koji_archive04/packages/tzdata/2020a/1.fc30/noarch/tzdata-2020a-1.fc30.noarch.rpm'


### PR DESCRIPTION
rpm-ostree version on RHEL Atomic Host is too old to support the ztsd
compression used in the newer Fedora tzdata packages causing the test to
fail with "Unrecognized archive format".